### PR TITLE
Add parameters to confidence mode

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/Options.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Options.java
@@ -59,6 +59,7 @@ public class Options {
     private final Integer nnsCount;
     private final Integer mrCount;
 	private final Integer controlCoverageCutoff;
+	private final Integer controlCoverageCutoffForSomatic;
 	private final Integer testCoverageCutoff;
 	private final Float mrPercentage;
 	
@@ -131,6 +132,7 @@ public class Options {
         nnsCount = ((Integer) options.valueOf("nnsCounts"));
         mrCount = ((Integer) options.valueOf("mrCounts"));
         controlCoverageCutoff = ((Integer) options.valueOf("controlCoverageCutoff"));
+        controlCoverageCutoffForSomatic = ((Integer) options.valueOf("controlCoverageCutoffForSomatic"));
         testCoverageCutoff = ((Integer) options.valueOf("testCoverageCutoff"));
         mrPercentage = ((Float) options.valueOf("mrPercentage"));
         filtersToIgnore = (List<String>) options.valuesOf("filtersToIgnore");
@@ -180,6 +182,8 @@ public class Options {
 		.describedAs("minPercentage");
 		parser.accepts("controlCoverageCutoff", "Minimum coverage (DP format field) value to gain a PASS for control samples").withRequiredArg().ofType(Integer.class)
 		.describedAs("controlCoverageCutoff");
+		parser.accepts("controlCoverageCutoffForSomatic", "Minimum coverage (DP format field) value to gain a PASS for control samples when the call is a SOMATIC one").withRequiredArg().ofType(Integer.class)
+		.describedAs("controlCoverageCutoffForSomatic");
 		parser.accepts("testCoverageCutoff", "Minimum coverage (DP format field) value to gain a PASS for test samples").withRequiredArg().ofType(Integer.class)
 		.describedAs("testCoverageCutoff");
 		parser.accepts("mrPercentage", "Number of mutant reads (MR) required to be High Confidence as a percentage").withRequiredArg().ofType(Float.class)
@@ -378,6 +382,9 @@ public class Options {
 
 	public Optional<Integer> getControlCutoff() {
 		return Optional.ofNullable(controlCoverageCutoff);
+	}
+	public Optional<Integer> getControlCutoffForSomatic() {
+		return Optional.ofNullable(controlCoverageCutoffForSomatic);
 	}
 	public Optional<Integer> getTestCutoff() {
 		return Optional.ofNullable(testCoverageCutoff);

--- a/qannotate/src/au/edu/qimr/qannotate/Options.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Options.java
@@ -53,8 +53,11 @@ public class Options {
     private  final int bufferSize; //trf
     private  final int gap ; //cadd
 	
-   private final Integer nnsCount;
-   private final Integer mrCount;
+    private final Integer miunCutoff;
+    private final Integer minCutoff;
+    private final Float minPercentage;
+    private final Integer nnsCount;
+    private final Integer mrCount;
 	private final Integer controlCoverageCutoff;
 	private final Integer testCoverageCutoff;
 	private final Float mrPercentage;
@@ -122,6 +125,9 @@ public class Options {
         bufferSize = (options.has("buffer"))? (Integer) options.valueOf("buffer") : 0; //TRF default is 0
         
         
+        miunCutoff = ((Integer) options.valueOf("miunCutoff"));
+        minCutoff = ((Integer) options.valueOf("minCutoff"));
+        minPercentage = ((Float) options.valueOf("minPercentage"));
         nnsCount = ((Integer) options.valueOf("nnsCounts"));
         mrCount = ((Integer) options.valueOf("mrCounts"));
         controlCoverageCutoff = ((Integer) options.valueOf("controlCoverageCutoff"));
@@ -166,6 +172,12 @@ public class Options {
 			.describedAs("numberOfNovelStarts");
 		parser.accepts("mrCounts", "Number of mutant reads (MR) required to be High Confidence").withRequiredArg().ofType(Integer.class)
 		.describedAs("numberOfMutantReads");
+		parser.accepts("miunCutoff", "Number of failed filter reads (FF) containing the alt, that will result in a MIUN (Mutation In Unfiltered Normal) in the filter field").withRequiredArg().ofType(Integer.class)
+		.describedAs("miunCutoff");
+		parser.accepts("minCutoff", "Minimum number of reads containing the alt, that will result in a MIN (Mutation In Normal) in the filter field. Used in conjunction with minPercentage").withRequiredArg().ofType(Integer.class)
+		.describedAs("minCutoff");
+		parser.accepts("minPercentage", "Percentage of reads containing the alt, that will result in a MIN (Mutation In Normal) in the filter field. Used in conjunction with minCutoff").withRequiredArg().ofType(Float.class)
+		.describedAs("minPercentage");
 		parser.accepts("controlCoverageCutoff", "Minimum coverage (DP format field) value to gain a PASS for control samples").withRequiredArg().ofType(Integer.class)
 		.describedAs("controlCoverageCutoff");
 		parser.accepts("testCoverageCutoff", "Minimum coverage (DP format field) value to gain a PASS for test samples").withRequiredArg().ofType(Integer.class)
@@ -369,6 +381,15 @@ public class Options {
 	}
 	public Optional<Integer> getTestCutoff() {
 		return Optional.ofNullable(testCoverageCutoff);
+	}
+	public Optional<Integer> getMIUNCutoff() {
+		return Optional.ofNullable(miunCutoff);
+	}
+	public Optional<Integer> getMINCutoff() {
+		return Optional.ofNullable(minCutoff);
+	}
+	public Optional<Float> getMINPercentage() {
+		return Optional.ofNullable(minPercentage);
 	}
 
 }

--- a/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
@@ -184,28 +184,11 @@ public class HomoplymersMode extends AbstractMode{
 			throw new IllegalArgumentException("motif supplied to findHomopolymer is invalid: " + motif);
 		}
 		
-		if (indelType.isSnpOrCS) {
-			/*
-			 * for single base, check to see if the updown ref starts with the same base 
-			 */
-			if (motif.length() == 1 || motif.chars().distinct().count() == 1) {
-				char mChar = motif.charAt(0);
-				if (updownReference[1][0] != mChar && updownReference[0][updownReference[0].length-1] != mChar) {
-					return 0;
-				}
-			} else {
-				/*
-				 * should only be here for compound snps that are not the same base - return 0
-				 */
-				return 0;
-			}
-		}
-			
 		int upBaseCount = 1;
 		int downBaseCount = 1;
  		//upstream - start from end since this is the side adjacent to the indel
 		//decide if it is contiguous		
-		int finalUpIndex = updownReference[0].length-1;	
+		final int finalUpIndex = updownReference[0].length-1;	
 		
 		//count upstream homopolymer bases
 		char nearBase = (char) updownReference[0][finalUpIndex];
@@ -216,7 +199,7 @@ public class HomoplymersMode extends AbstractMode{
 				break;
 			}
 		}
-			
+		
 		//count downstream homopolymer
 		nearBase = (char) updownReference[1][0];
 		for (int i=1; i< updownReference[1].length; i++) {
@@ -229,13 +212,21 @@ public class HomoplymersMode extends AbstractMode{
 		
 		int max;
 		//reset up or down stream for deletion and SNPs reference base
-		if(indelType.equals(SVTYPE.DEL)){			
-			byte[] mByte = motif.getBytes(); 	
+		if(indelType.equals(SVTYPE.DEL) || indelType.equals(SVTYPE.SNP) || indelType.equals(SVTYPE.DNP)  
+				|| indelType.equals(SVTYPE.ONP) || indelType.equals(SVTYPE.TNP) ){
+			byte[] mByte = motif.getBytes();
 			
 			int left = 0;
-			nearBase = (char) updownReference[0][finalUpIndex];			
-			for(int i = 0; i < mByte.length; i ++ ) {
-				if (nearBase == mByte[i])  {
+			nearBase = (char) updownReference[0][finalUpIndex];
+//			for (byte b : mByte) {
+//				if (nearBase == b) {
+//					left ++;
+//				} else {
+//					break;				 
+//				}
+//			}
+			for(int i = 0; i < mByte.length; i ++ ) { 
+				if (nearBase == mByte[i]) {
 					left ++;
 				} else {
 					break;				 
@@ -248,7 +239,7 @@ public class HomoplymersMode extends AbstractMode{
 			for(int i = mByte.length -1; i >=0; i--) { 
 				if (nearBase == mByte[i]) {
 					right++;
-				} else {
+				} else  {
 					break;
 				}
 			}
@@ -257,39 +248,7 @@ public class HomoplymersMode extends AbstractMode{
 			max = (left == right && left == mByte.length)? 
 					(downBaseCount + upBaseCount - mByte.length) : Math.max(downBaseCount, upBaseCount);
 						 			
-		} else if (indelType.isSnpOrCS) {
-			byte[] mByte = motif.getBytes();
-			if (mByte[0] != updownReference[0][finalUpIndex]) {
-				return downBaseCount + mByte.length;
-			} else if (mByte[0] != updownReference[1][0]) {
-				return upBaseCount + mByte.length;
-			}
-			
-			int left = 0;
-			nearBase = (char) updownReference[0][finalUpIndex];
-			for (byte b : mByte) {
-				if (nearBase == b)  {
-					left ++;
-				} else {
-					break;				 
-				}
-			}
-			upBaseCount += left; 
-						
-			int right = 0;
-			nearBase = (char) updownReference[1][0];
-			for (byte b : mByte) {
-				if (nearBase == b) {
-					right++;
-				} else {
-					break;
-				}
-			}
-			downBaseCount += right; 
-			
-			max = (left == right && left == mByte.length)? 
-					(downBaseCount + upBaseCount - mByte.length) : Math.max(downBaseCount, upBaseCount);
-		} else{
+		} else {
 		    //INS don't have reference base
 			max = (updownReference[0][finalUpIndex] == updownReference[1][0] )? 
 					(downBaseCount + upBaseCount) : Math.max(downBaseCount, upBaseCount);

--- a/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
@@ -70,12 +70,14 @@ public class HomoplymersMode extends AbstractMode{
 		try (VCFFileReader reader = new VCFFileReader(input) ;
 	            VCFFileWriter writer = new VCFFileWriter(new File(output))  ) {
 			header.addInfo(VcfHeaderUtils.INFO_HOM,  "2", "String",VcfHeaderUtils.INFO_HOM_DESC); 			
-		    for(final VcfHeaderRecord record: header)	writer.addHeader(record.toString());
+		    for(final VcfHeaderRecord record: header) {
+		    		writer.addHeader(record.toString());
+		    }
 		    
 		    int sum = 0;
 			for (final VcfRecord re : reader) {	
 				String chr = IndelUtils.getFullChromosome(re.getChromosome());
-				byte[]  base =  referenceBase.get(chr);								 
+				byte[]  base =  referenceBase.get(chr);
 				writer.add( annotate(re,  base));
 				sum ++;
 			}

--- a/qannotate/test/au/edu/qimr/qannotate/modes/CCMModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/CCMModeTest.java
@@ -248,5 +248,13 @@ public class CCMModeTest {
 		h.addOrReplace(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE_INCLUDING_FORMAT + "ABC_1\tDEF_1\tABC_2\tDEF_2");
 		return h;
 	}
+	public static VcfHeader createSingleSampleTwoCallerVcf() {
+		VcfHeader h = new VcfHeader();
+		h.addOrReplace("##fileformat=VCFv4.0");
+		h.addOrReplace("##1:qTestBamUUID=DEF");
+		h.addOrReplace("##2:qTestBamUUID=DEF");
+		h.addOrReplace(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE_INCLUDING_FORMAT + "DEF_1\tDEF_2");
+		return h;
+	}
 	
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -99,6 +99,68 @@ public class ConfidenceModeTest {
 		 assertEquals("", sb.toString());
 		 ConfidenceMode.checkMIN(new String [] {"A"}, 2000,  alleleDist,  sb, 20, 5f);
 		 assertEquals("MIN", sb.toString());
+		 
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIN(new String [] {"C"}, 2000,  alleleDist,  sb, 20, 5f);
+		 assertEquals("", sb.toString());
+	 }
+	 
+	 @Test
+	 public void checkMIUN() {
+		 StringBuilder sb = null;
+		 ConfidenceMode.checkMIUN(null,   null,  sb, -1);
+		 assertEquals(null, sb);
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, "", sb, -1);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, "C1", sb, 1);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, "C1:G2:T3", sb, 1);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIUN(new String [] {"A","C"}, "C1:G2:T3", sb, 2);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, "C1:G2:T3", sb, 2);
+		 assertEquals("MIUN", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, "C1:G2:T3", sb, 3);
+		 assertEquals("MIUN", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"C"}, "C1:G2:T3", sb, 1);
+		 assertEquals("MIUN", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"G"}, "C1:G2:T3", sb, 2);
+		 assertEquals("MIUN", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1:G2:T3", sb, 3);
+		 assertEquals("MIUN", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1:G2:T3", sb, 4);
+		 assertEquals("", sb.toString());
+	 }
+	 
+	 @Test
+	 public void testHOM() {
+		 StringBuilder sb = null;
+		 ConfidenceMode.checkHOM(sb, -1, -1);
+		 assertEquals(null, sb);
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkHOM(sb, -1, -1);
+		 assertEquals("", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkHOM(sb, 1, 0);
+		 assertEquals("HOM", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkHOM(sb, 1, 1);
+		 assertEquals("HOM", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkHOM(sb, 1, 2);
+		 assertEquals("", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkHOM(sb, 2, 2);
+		 assertEquals("HOM", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkHOM(sb, 3, 2);
+		 assertEquals("HOM", sb.toString());
 	 }
 	 
 	 @Test

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -842,23 +842,22 @@ public class ConfidenceModeTest {
 	 @Test
 	 public void applyMRFilter() {
 		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(null, null, -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("", "", -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(".", ".", -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/0", ".", -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/0", "0", -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/0", "10", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("0/1", "10,0", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("0/1", "10,4", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/1", "10,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/1", "4,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("1/1", "10,5", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("1/1", "10,4", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("1/1", "10,4,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("2/2", "10,4,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("1/2", "10,5,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("1/2", "0,5,5", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("1/2", "10,5,4", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("2/2", "10,5,6", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{}, "", -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,0}, ".", -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,0}, "0", -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,0}, "10", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "10,0", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "10,4", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "10,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "4,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{1,1}, "10,5", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{1,1}, "10,4", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{1,1}, "10,4,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{1,2}, "10,5,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{1,2}, "0,5,5", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{1,2}, "10,5,4", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{2,2}, "10,5,6", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{2,2}, "10,4,5", 5));
 	 }
 	 
 	 @Test

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -29,6 +29,9 @@ import org.qcmg.vcf.VCFFileReader;
 
 public class ConfidenceModeTest {
 	
+	 public static final VcfFileMeta TWO_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
+	 public static final VcfFileMeta SINGLE_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createSingleSampleTwoCallerVcf());
+	
 	 @AfterClass
 	 public static void deleteIO(){
 		 new File(DbsnpModeTest.inputName).delete();
@@ -196,8 +199,7 @@ public class ConfidenceModeTest {
 		  * chr1	792590	.	C	A	.	.	FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT;EFF=downstream_gene_variant(MODIFIER||4458|||LINC01128|retained_intron|NON_CODING|ENST00000425657||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000416570||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000448975||1),downstream_gene_variant(MODIFIER||3584|||LINC01128|lincRNA|NON_CODING|ENST00000449005||1),non_coding_exon_variant(MODIFIER|||n.4370C>A||LINC01128|lincRNA|NON_CODING|ENST00000445118|5|1)	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:46,1:47:.:A3;C8:PASS:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.	0/1:61,7:68:C1[]2[]:A9;C3:PASS:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:62,11:73:.:.:PASS:99:SOMATIC:.:.:89.77
 		  */
 		 VcfRecord r = new VcfRecord(new String[]{"chr1","792590",".","C","A",".",".","FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT","GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL","0/0:46,1:47:.:A3;C8:.:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.","0/1:61,7:68:C1[]2[]:A9;C3:.:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.","./.:.:.:.:.:.:.:NCIG:.:.:.","0/1:62,11:73:.:.:.:99:SOMATIC:.:.:89.77"});
-		 VcfFileMeta meta = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
-		 ConfidenceMode cm =new ConfidenceMode(meta);
+		 ConfidenceMode cm =new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
 		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
 		 cm.addAnnotation();
 		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
@@ -213,8 +215,7 @@ public class ConfidenceModeTest {
 		  * chr1	14248	.	T	G	.	.	FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:24,1:25:T1[]0[]:G8;T42:PASS:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.	0/1:20,6:26:T2[]1[]:G11;T94:PASS:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:19,6:25:.:.:PASS:86:SOMATIC:.:.:57.77
 		  */
 		 VcfRecord r = new VcfRecord(new String[]{"chr1","14248",".","T","G",".",".","FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT","GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL","0/0:24,1:25:T1[]0[]:G8;T42:.:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.","0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.","./.:.:.:.:.:.:.:NCIG:.:.:.","0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"});
-		 VcfFileMeta meta = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
-		 ConfidenceMode cm =new ConfidenceMode(meta);
+		 ConfidenceMode cm =new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
 		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
 		 cm.addAnnotation();
 		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
@@ -520,7 +521,7 @@ public class ConfidenceModeTest {
 		 VcfRecord r = new VcfRecord(new String[]{"chr1","2245570","rs2843152","C","G",".",".","FLANK=GATGCGAGGAG;DP=4;FS=0.000;MQ=60.00;MQ0=0;QD=17.76;SOR=0.693;IN=1,2;DB;VLD;VAF=0.6276;EFF=downstream_gene_variant(MODIFIER||4012||728|SKI|protein_coding|CODING|ENST00000378536||1),intergenic_region(MODIFIER||||||||||1)"
 				 ,"GT:AD:DP:FT:GQ:INF:MR:NNS:OABS"
 				 ,".:.:.:.:.:.:.:.:."
-				 ,"1/1:.:4:5BP=1;COVT:.:SOMATIC;GERM=53,185:4:4:G2[35]2[35]"
+				 ,"1/1:0,4:4:5BP=1;COVT:.:SOMATIC;GERM=53,185:4:4:G2[35]2[35]"
 				 ,".:.:.:.:.:.:.:.:."
 				 ,"1/1:0,4:4:5BP=1;COVT:12:SOMATIC;GERM=53,185:4:4:G2[35]2[35]"});
 		 
@@ -531,8 +532,8 @@ public class ConfidenceModeTest {
 		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
 		 assertEquals(true, r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_INFO).contains( "SOMATIC"));
 		 assertEquals(true, r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_INFO).contains( "GERM=53,185"));
-		 assertEquals("5BP=1;COVT", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("5BP=1;COVT", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV;MR", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV;MR", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
 	 }
 	 
 	 
@@ -569,9 +570,9 @@ public class ConfidenceModeTest {
 	 public void confidenceRealLifeSingle() {
 		 //chr8	12306635	rs28428895	C	T	.	PASS	FLANK=ACACATACATA;DB;CONF=HIGH;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)	GT:GD:AC:MR:NNS	0/1:C/T:C10[39],3[30],G1[11],0[0],T7[41.29],1[42]:8:8	0/0:C/C:C19[36.11],20[38.45],T1[42],0[0]:1:1
 		 VcfRecord vcf1 = new VcfRecord(new String[]{"chr8","12306635","rs28428895","C","T",".",".","FLANK=ACACATACATA;DB;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)","GT:AC:AD:DP:NNS:FT","0/1:C10[39],3[30],G1[11],0[0],T7[41.29],1[42]:13,8:22:8:.","0/0:C19[36.11],20[38.45],T1[42],0[0]:39,1:40:1:."});
-		 VcfRecord vcf2 = new VcfRecord(new String[]{"chr8","12306635","rs28428895","C","T","57.77",".","SOMATIC;DB;GERM=30,185;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)","GT:AD:DP:GQ:PL:GD:AC:MR:NNS:FT",".:.:.:.:.:C/C:C14[38.79],3[30],G1[11],0[0],T11[39.27],4[25.25]:15:15:MIN","0/1:4,3:7:86:86,0,133:C/T:C22[36.23],22[36.91],T2[26.5],1[42]:3:2:MR;NNS"});
+		 VcfRecord vcf2 = new VcfRecord(new String[]{"chr8","12306635","rs28428895","C","T","57.77",".","SOMATIC;DB;GERM=30,185;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)","GT:AD:DP:GQ:PL:GD:AC:MR:NNS:FT","0/1:17,15,1:33:.:.:C/C:C14[38.79],3[30],G1[11],0[0],T11[39.27],4[25.25]:15:15:MIN","0/1:4,3:7:86:86,0,133:C/T:C22[36.23],22[36.91],T2[26.5],1[42]:3:2:MR;NNS"});
 		 
-		 ConfidenceMode cm =new ConfidenceMode();
+		 ConfidenceMode cm =new ConfidenceMode(SINGLE_SAMPLE_TWO_CALLER_META);
 		 cm.positionRecordMap.put(vcf1.getChrPosition(), java.util.Arrays.asList(vcf1, vcf2));
 		 cm.addAnnotation();
 		 
@@ -579,8 +580,31 @@ public class ConfidenceModeTest {
 		 vcf2 = cm.positionRecordMap.get(vcf2.getChrPosition()).get(1);
 		 assertEquals("PASS", vcf1.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
 		 assertEquals("PASS", vcf1.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("MIN", vcf2.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("MR;NNS", vcf2.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", vcf2.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV;MR", vcf2.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+	 }
+	 
+	 @Test
+	 public void multipleADValues() {
+		 /*
+		  *chr1	63982013	rs12130694	C	G,T	.	.	FLANK=GGAAGGGGAGC;BaseQRankSum=1.437;ClippingRankSum=0.000;DP=21;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=29.74;ReadPosRankSum=-0.087;SOR=4.615;IN=1,2;DB;VAF=[.,0.359];GERM=T:32:48:80:0;HOM=4,GGAAGGGAAGgGGAGCGGGGG	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	2/2:1,0,21:22:T0[]1[]:G4;T6:MR:.:.:18:C1[12]0[0];T18[30.39]3[35]:.	1/2:0,3,8:12:T1[]0[]:A1;G9;T13:SBIASALT;NNS;MR:.:SOMATIC:3,7:A1[12]0[0];G3[12]0[0];T7[19.14]1[32]:.2/2:1,19:20:.:.:PASS:48:.:.:.:594.77	2/2:0,8:8:.:.:PASS:22:.:.:.:119.79 
+		  */
+		 VcfRecord vcf = new VcfRecord(new String[]{"chr1	","63982013","rs12130694","C","G,T",".",".","FLANK=GGAAGGGGAGC;BaseQRankSum=1.437;ClippingRankSum=0.000;DP=21;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=29.74;ReadPosRankSum=-0.087;SOR=4.615;IN=1,2;DB;VAF=[.,0.359];GERM=T:32:48:80:0;HOM=4,GGAAGGGAAGgGGAGCGGGGG"
+				 ,"GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL"
+				 ,"2/2:1,0,21:22:T0[]1[]:G4;T6:MR:.:.:18:C1[12]0[0];T18[30.39]3[35]:."
+				 ,"1/2:0,3,8:12:T1[]0[]:A1;G9;T13:SBIASALT;NNS;MR:.:SOMATIC:3,7:A1[12]0[0];G3[12]0[0];T7[19.14]1[32]:."
+				 ,"2/2:1,19:20:.:.:PASS:48:.:.:.:594.77"
+				 ,"2/2:0,8:8:.:.:PASS:22:.:.:.:119.79"});
+		 
+		 ConfidenceMode cm =new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+		 cm.positionRecordMap.put(vcf.getChrPosition(), Arrays.asList(vcf));
+		 cm.addAnnotation();
+		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
+		 
+		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("SBIASALT;NNS;MR", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
 	 }
 	 
 	 @Test
@@ -813,6 +837,28 @@ public class ConfidenceModeTest {
 		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
 		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
 		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+	 }
+	 
+	 @Test
+	 public void applyMRFilter() {
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(null, null, -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("", "", -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(".", ".", -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/0", ".", -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/0", "0", -1));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/0", "10", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("0/1", "10,0", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("0/1", "10,4", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/1", "10,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("0/1", "4,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("1/1", "10,5", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("1/1", "10,4", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("1/1", "10,4,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("2/2", "10,4,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("1/2", "10,5,5", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("1/2", "0,5,5", 5));
+		 assertEquals(true, ConfidenceMode.applyMutantReadFilter("1/2", "10,5,4", 5));
+		 assertEquals(false, ConfidenceMode.applyMutantReadFilter("2/2", "10,5,6", 5));
 	 }
 	 
 	 @Test

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.qcmg.common.model.MafConfidence;
 import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Constants;
+import org.qcmg.common.vcf.VcfFileMeta;
 import org.qcmg.common.vcf.VcfFormatFieldRecord;
 import org.qcmg.common.vcf.VcfInfoFieldRecord;
 import org.qcmg.common.vcf.VcfRecord;
@@ -115,27 +116,30 @@ public class ConfidenceModeTest {
 		 assertEquals("", sb.toString());
 		 ConfidenceMode.checkMIUN(new String [] {"A"}, "C1", sb, 1);
 		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, "C1:G2:T3", sb, 1);
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, "C1;G2;T3", sb, 1);
 		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C"}, "C1:G2:T3", sb, 2);
+		 ConfidenceMode.checkMIUN(new String [] {"A","C"}, "C1;G2;T3", sb, 2);
 		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, "C1:G2:T3", sb, 2);
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, "C1;G2;T3", sb, 2);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, "C1:G2:T3", sb, 3);
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, "C1;G2;T3", sb, 3);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"C"}, "C1:G2:T3", sb, 1);
+		 ConfidenceMode.checkMIUN(new String [] {"C"}, "C1;G2;T3", sb, 1);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"G"}, "C1:G2:T3", sb, 2);
+		 ConfidenceMode.checkMIUN(new String [] {"G"}, "C1;G2;T3", sb, 2);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1:G2:T3", sb, 3);
+		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1;G2;T3", sb, 3);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1:G2:T3", sb, 4);
+		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1;G2;T3", sb, 4);
 		 assertEquals("", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, "A3;C8", sb, 2);
+		 assertEquals("MIUN", sb.toString());
 	 }
 	 
 	 @Test
@@ -163,6 +167,7 @@ public class ConfidenceModeTest {
 		 assertEquals("HOM", sb.toString());
 	 }
 	 
+	 
 	 @Test
 	 public void endOfReads() {
 		 /*
@@ -183,9 +188,42 @@ public class ConfidenceModeTest {
 		 assertEquals("5BP=2", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
 		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
 		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
 	 }
-	 
+
+	 @Test
+	 public void realLifeMIUN() {
+		 /*
+		  * chr1	792590	.	C	A	.	.	FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT;EFF=downstream_gene_variant(MODIFIER||4458|||LINC01128|retained_intron|NON_CODING|ENST00000425657||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000416570||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000448975||1),downstream_gene_variant(MODIFIER||3584|||LINC01128|lincRNA|NON_CODING|ENST00000449005||1),non_coding_exon_variant(MODIFIER|||n.4370C>A||LINC01128|lincRNA|NON_CODING|ENST00000445118|5|1)	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:46,1:47:.:A3;C8:PASS:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.	0/1:61,7:68:C1[]2[]:A9;C3:PASS:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:62,11:73:.:.:PASS:99:SOMATIC:.:.:89.77
+		  */
+		 VcfRecord r = new VcfRecord(new String[]{"chr1","792590",".","C","A",".",".","FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT","GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL","0/0:46,1:47:.:A3;C8:.:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.","0/1:61,7:68:C1[]2[]:A9;C3:.:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.","./.:.:.:.:.:.:.:NCIG:.:.:.","0/1:62,11:73:.:.:.:99:SOMATIC:.:.:89.77"});
+		 VcfFileMeta meta = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
+		 ConfidenceMode cm =new ConfidenceMode(meta);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("MIUN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+	 }
+	 @Test
+	 public void realLifeMIN() {
+		 /*
+		  * chr1	14248	.	T	G	.	.	FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:24,1:25:T1[]0[]:G8;T42:PASS:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.	0/1:20,6:26:T2[]1[]:G11;T94:PASS:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:19,6:25:.:.:PASS:86:SOMATIC:.:.:57.77
+		  */
+		 VcfRecord r = new VcfRecord(new String[]{"chr1","14248",".","T","G",".",".","FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT","GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL","0/0:24,1:25:T1[]0[]:G8;T42:.:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.","0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.","./.:.:.:.:.:.:.:NCIG:.:.:.","0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"});
+		 VcfFileMeta meta = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
+		 ConfidenceMode cm =new ConfidenceMode(meta);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("MIN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+	 }
 	 
 	 @Test
 	 public void newCoverageCutoffs() {

--- a/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
@@ -72,18 +72,41 @@ public class HomoplymersModeTest {
 		VcfRecord re = new VcfRecord(new String[] {  "chr1", "21", null, "TCC", "AGG" });		
 		HomoplymersMode  homo = new HomoplymersMode(3,4);	
 		re = homo.annotate(re, getReference());
-		assertEquals("0,CCCaggCCC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		assertEquals("0,CCCtccCCC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+//		assertEquals("0,CCCaggCCC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 		
 		//SNP
 		re = new VcfRecord(new String[] {  "chr1", "16", null, "G", "A" });		
 		homo = new HomoplymersMode(10,5);	
 		re = homo.annotate(re, getReference());
-		assertEquals("2,GATCGaACCCT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+//		assertEquals("2,GATCGaACCCT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		assertEquals("2,GATCGgACCCT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 		
 		//SNP in non homoplyers region
 		re = new VcfRecord(new String[] {  "chr1", "13", null, "T", "A" });	
 		re = homo.annotate(re, getReference());	 
-		assertEquals("2,TTGGAaCGGAC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		assertEquals("0,TTGGAtCGGAC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+//		assertEquals("2,TTGGAaCGGAC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		
+		re = new VcfRecord(new String[] {  "chr1", "10", null, "T", "A" });	
+		re = homo.annotate(re, "TTTTTTTTTTGCTGCTAGCTA".getBytes());	 
+		assertEquals("10,TTTTTtGCTGC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		
+		re = new VcfRecord(new String[] {  "chr1", "10", null, "G", "A" });	
+		re = homo.annotate(re, "TTTTTTTTTTGCTGCTAGCTA".getBytes());	 
+		assertEquals("2,TTTTTgGCTGC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		
+		re = new VcfRecord(new String[] {  "chr1", "10", null, "G", "A" });	
+		re = homo.annotate(re, "TTTTTTTTTTTTTTTTTTTT".getBytes());	 
+		assertEquals("0,TTTTTgTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		
+		re = new VcfRecord(new String[] {  "chr1", "10", null, "A", "C" });	
+		re = homo.annotate(re, "TTTTTTTTTTTTTTTTTTTT".getBytes());	 
+		assertEquals("0,TTTTTaTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		
+		re = new VcfRecord(new String[] {  "chr1", "10", null, "T", "C" });	
+		re = homo.annotate(re, "TTTTTTTTTTTTTTTTTTTT".getBytes());	 
+		assertEquals("20,TTTTTtTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 	}
 	
 	@Test

--- a/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
@@ -72,7 +72,7 @@ public class HomoplymersModeTest {
 		VcfRecord re = new VcfRecord(new String[] {  "chr1", "21", null, "TCC", "AGG" });		
 		HomoplymersMode  homo = new HomoplymersMode(3,4);	
 		re = homo.annotate(re, getReference());
-		assertEquals("0,CCCtccCCC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		assertEquals("5,CCCtccCCC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 //		assertEquals("0,CCCaggCCC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 		
 		//SNP
@@ -94,15 +94,18 @@ public class HomoplymersModeTest {
 		
 		re = new VcfRecord(new String[] {  "chr1", "10", null, "G", "A" });	
 		re = homo.annotate(re, "TTTTTTTTTTGCTGCTAGCTA".getBytes());	 
-		assertEquals("2,TTTTTgGCTGC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		assertEquals("9,TTTTTgGCTGC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+//		assertEquals("2,TTTTTgGCTGC", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 		
 		re = new VcfRecord(new String[] {  "chr1", "10", null, "G", "A" });	
 		re = homo.annotate(re, "TTTTTTTTTTTTTTTTTTTT".getBytes());	 
-		assertEquals("0,TTTTTgTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		assertEquals("10,TTTTTgTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+//		assertEquals("0,TTTTTgTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 		
 		re = new VcfRecord(new String[] {  "chr1", "10", null, "A", "C" });	
 		re = homo.annotate(re, "TTTTTTTTTTTTTTTTTTTT".getBytes());	 
-		assertEquals("0,TTTTTaTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		assertEquals("10,TTTTTaTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+//		assertEquals("0,TTTTTaTTTTT", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
 		
 		re = new VcfRecord(new String[] {  "chr1", "10", null, "T", "C" });	
 		re = homo.annotate(re, "TTTTTTTTTTTTTTTTTTTT".getBytes());	 
@@ -115,10 +118,14 @@ public class HomoplymersModeTest {
 		b[0] = "AAAAA".getBytes();
 		b[1] = "AAAAA".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(5, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
 		assertEquals(11, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+		assertEquals(5, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+		assertEquals(5, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(11, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -127,10 +134,14 @@ public class HomoplymersModeTest {
 		b[0] = "CTTTTCCC".getBytes();
 		b[1] = "CCTTGGTT".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
 		assertEquals(6, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(6, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -139,10 +150,14 @@ public class HomoplymersModeTest {
 		b[0] = "TTGACTCC".getBytes();
 		b[1] = "TTTTTTAT".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(3, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(6, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(6, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+		assertEquals(6, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
 		assertEquals(7, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(3, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(7, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -151,10 +166,14 @@ public class HomoplymersModeTest {
 		b[0] = "GGTTT".getBytes();
 		b[1] = "TTGTT".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
 		assertEquals(6, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(6, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -163,10 +182,14 @@ public class HomoplymersModeTest {
 		b[0] = "CATAAATTTT".getBytes();
 		b[1] = "TTTTTTTAAA".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(7, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(7, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+		assertEquals(7, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
 		assertEquals(12, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(12, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -175,10 +198,14 @@ public class HomoplymersModeTest {
 		b[0] = "TTGTTTTTTT".getBytes();
 		b[1] = "AATTTCCAAA".getBytes();
 		
-		assertEquals(3, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(7, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(7, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+		assertEquals(7, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
 		assertEquals(8, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(3, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(8, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -187,13 +214,20 @@ public class HomoplymersModeTest {
 		b[0] = "GGTTT".getBytes();
 		b[1] = "TTGTT".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "AA", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "CC", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "GG", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "AA", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "CC", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "GG", SVTYPE.SNP));
 		assertEquals(7, HomoplymersMode.findHomopolymer(b, "TT", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "TA", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "ATA", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "AT", SVTYPE.SNP));
+		assertEquals(4, HomoplymersMode.findHomopolymer(b, "TA", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "ATA", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "AT", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "AA", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "CC", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "GG", SVTYPE.SNP));
+//		assertEquals(7, HomoplymersMode.findHomopolymer(b, "TT", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "TA", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "ATA", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "AT", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -208,9 +242,10 @@ public class HomoplymersModeTest {
 		} catch (IllegalArgumentException iae){}
 		
 		assertEquals("6,GGTTTtTTGTT", HomoplymersMode.getHomopolymerData("A,T", b, SVTYPE.SNP));
-		assertEquals("0,GGTTTaTTGTT", HomoplymersMode.getHomopolymerData("A,C", b, SVTYPE.SNP));
+		assertEquals("3,GGTTTaTTGTT", HomoplymersMode.getHomopolymerData("A,C", b, SVTYPE.SNP));
+//		assertEquals("0,GGTTTaTTGTT", HomoplymersMode.getHomopolymerData("A,C", b, SVTYPE.SNP));
 		assertEquals("6,GGTTTtTTGTT", HomoplymersMode.getHomopolymerData("A,C,T", b, SVTYPE.SNP));
-		assertEquals("0,GGTTTcTTGTT", HomoplymersMode.getHomopolymerData("C,G", b, SVTYPE.SNP));
+		assertEquals("3,GGTTTcTTGTT", HomoplymersMode.getHomopolymerData("C,G", b, SVTYPE.SNP));
 	}
 	
 	
@@ -220,10 +255,14 @@ public class HomoplymersModeTest {
 		b[0] = "CTTGACCACATCCTATTTTATCAGCAGGGTCTTTATGACCTGTATCTCATGATATCAATCCTGCAGACCTCATCTATCTTTTTTTTTTTTTTTTTTTTTT".getBytes();
 		b[1] = "AGACAAAGTCTCACTTTGTCACCCAGGCTGGAGTGCAATGACACCATCTCAGCTCACTGCAACTTCTGCCTCCCAGGTTCAAGCAATTCTCCTGCCTTAG".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
-		assertEquals(2, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+		assertEquals(22, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(22, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(22, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
 		assertEquals(23, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(2, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(23, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	
 	@Test
@@ -232,10 +271,14 @@ public class HomoplymersModeTest {
 		b[0] = "AAGAAAATAAAGCATATACAATCCTGGACTCCATAGATATAAAACTGTGATGTAATATCTGTATTGGTATCAAGTGATAAAACAACATTAAACTTTTCCC".getBytes();
 		b[1] = "CCTTGGTTTTGGCTCTAAGATAGCAACTCTATCATTGACTTAGTTTTCAAACTATAGGTCACACACTCATTTTTTCACTCATGGGTCTTCATGAAAAGAT".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
 		assertEquals(6, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(6, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
 	}
 	@Test
 	public void findHomopolymer3() {
@@ -243,10 +286,100 @@ public class HomoplymersModeTest {
 		b[0] = "AGGATGACAGCCTCCAGCTGCATCTCTGTTGGAGAGTCAAATTACCTACAGTACCATCTAAATACTTGGAATCTGTCATTCCTGGAGCTGTGTTGACTCC".getBytes();
 		b[1] = "TTTTTTATTCATTTTGTAATTCGGAACATTTTCTTTTATTTTTAAGGGAGTTTGGGTTAGCTTTCTATCAATCGTAAACAAAGGAAACCAGTCGAAAGTA".getBytes();
 		
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
-		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
-		assertEquals(3, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+		assertEquals(6, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+		assertEquals(6, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+		assertEquals(6, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
 		assertEquals(7, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "A", SVTYPE.SNP));
+//		assertEquals(0, HomoplymersMode.findHomopolymer(b, "G", SVTYPE.SNP));
+//		assertEquals(3, HomoplymersMode.findHomopolymer(b, "C", SVTYPE.SNP));
+//		assertEquals(7, HomoplymersMode.findHomopolymer(b, "T", SVTYPE.SNP));
+	}
+	
+	@Test
+	public void findHom() {
+		byte[][] refs = new byte[2][];
+		refs[0] = "TCAAGAGTTT".getBytes();
+		refs[1] = "CTTTATTTTT".getBytes();
+		
+		assertEquals(3, findHomopolymer(refs, "C", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(refs, "C", SVTYPE.SNP));
+		
+	}
+	
+	static int findHomopolymer(byte[][] updownReference, String motif, SVTYPE indelType){
+		
+		int upBaseCount = 1;
+		int downBaseCount = 1;
+ 		//upstream - start from end since this is the side adjacent to the indel
+		//decide if it is contiguous		
+		int finalUpIndex = updownReference[0].length-1;	
+		
+		//count upstream homopolymer bases
+		char nearBase = (char) updownReference[0][finalUpIndex];
+		for (int i=finalUpIndex-1; i>=0; i--) {
+			if (nearBase == updownReference[0][i]) {
+				upBaseCount++;
+			} else {
+				break;
+			}
+		}
+		
+		//count downstream homopolymer
+		nearBase = (char) updownReference[1][0];
+		for (int i=1; i< updownReference[1].length; i++) {
+			if (nearBase == updownReference[1][i]) {
+				downBaseCount++;
+			} else {
+				break;
+			}
+		}
+		
+		int max;
+		//reset up or down stream for deletion and SNPs reference base
+		if(indelType.equals(SVTYPE.DEL) || indelType.equals(SVTYPE.SNP) || indelType.equals(SVTYPE.DNP)  
+				|| indelType.equals(SVTYPE.ONP) || indelType.equals(SVTYPE.TNP) ){
+			byte[] mByte = motif.getBytes();
+			
+			int left = 0;
+			nearBase = (char) updownReference[0][finalUpIndex];
+			for (byte b : mByte) {
+				if (nearBase == b) {
+					left ++;
+				} else {
+					break;				 
+				}
+			}
+//			for(int i = 0; i < mByte.length; i ++ ) { 
+//				if (nearBase == mByte[i]) {
+//					left ++;
+//				} else {
+//					break;				 
+//				}
+//			}
+			upBaseCount += left; 
+						
+			int right = 0;
+			nearBase = (char) updownReference[1][0];
+			for(int i = mByte.length -1; i >=0; i--) { 
+				if (nearBase == mByte[i]) {
+					right++;
+				} else  {
+					break;
+				}
+			}
+			downBaseCount += right; 
+			
+			max = (left == right && left == mByte.length)? 
+					(downBaseCount + upBaseCount - mByte.length) : Math.max(downBaseCount, upBaseCount);
+						 			
+		} else {
+		    //INS don't have reference base
+			max = (updownReference[0][finalUpIndex] == updownReference[1][0] )? 
+					(downBaseCount + upBaseCount) : Math.max(downBaseCount, upBaseCount);
+		}
+					
+		return (max == 1)? 0 : max;
 	}
 	
 //	public byte[] getRef() throws IOException {

--- a/qcommon/src/org/qcmg/common/util/IndelUtils.java
+++ b/qcommon/src/org/qcmg/common/util/IndelUtils.java
@@ -263,7 +263,8 @@ public class IndelUtils {
 		if(type.equals(SVTYPE.UNKNOWN))
 			return null; 
 		
-		return alt;  //return alt for snp, mnp 		
+		return ref;  //return ref for snp, mnp 		THIS IS THE OLD (CURRENT PRODUCTION) WAY OF DOING IT
+//		return alt;  //return alt for snp, mnp 		THIS IS THE NEW (ASPIRATIONAL) WAY OF DOING IT
 	}
 	
 	/**

--- a/qcommon/src/org/qcmg/common/util/TabTokenizer.java
+++ b/qcommon/src/org/qcmg/common/util/TabTokenizer.java
@@ -25,10 +25,10 @@ public class TabTokenizer {
 	
 	public static String[] tokenize(final String data, final char delim) {
 		int nextIndex = data.indexOf(delim);
-		if (nextIndex < 0) throw new IllegalArgumentException("no delimiters '" + delim + "' found in string: " + data);
+		if (nextIndex < 0) return new String[]{data};//throw new IllegalArgumentException("no delimiters '" + delim + "' found in string: " + data);
 		
 		int currentIndex = 0;
-		final List<String> resultList = new ArrayList<String>();
+		final List<String> resultList = new ArrayList<>();
 		
 		resultList.add(data.substring(currentIndex, nextIndex));
 		currentIndex = nextIndex + 1;

--- a/qcommon/src/org/qcmg/common/vcf/VcfRecord.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfRecord.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
@@ -279,6 +280,10 @@ public class VcfRecord implements Comparable<VcfRecord> {
 	
 	public int getFormatColumnCount() {
 		return formatRecords.size();
+	}
+	
+	public Map<String, String[]> getFormatFieldsAsMap() {
+		return VcfUtils.getFormatFieldsAsMap(formatRecords);
 	}
 	
 	public String getFormatFieldStrings(){ 

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -1451,7 +1451,7 @@ public class VcfUtils {
 	 * @param minCoverage
 	 * @return
 	 */
-	public static boolean mutationInNorma(int altCount, int totalReadCount, int percentage, int maxCoverage) {
+	public static boolean mutationInNorma(int altCount, int totalReadCount, float percentage, int maxCoverage) {
 		if (altCount == 0) {
 			return false;
 		}
@@ -1467,5 +1467,7 @@ public class VcfUtils {
 		float passingCount = totalReadCount > 0 ? (((float)totalReadCount / 100) * percentage) : 0;
 		return altCount >= passingCount;
 	}
- 
+	public static boolean mutationInNorma(int altCount, int totalReadCount, int percentage, int maxCoverage) {
+		return mutationInNorma(altCount, totalReadCount, (float) percentage, maxCoverage);
+	}
 }

--- a/qcommon/test/org/qcmg/common/util/IndelUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/IndelUtilsTest.java
@@ -90,10 +90,10 @@ public class IndelUtilsTest {
 	}
 	
 	@Test
-	public void getMoti() {
-		assertEquals("A", IndelUtils.getMotif("C", "A", SVTYPE.SNP));
-		assertEquals("DEF", IndelUtils.getMotif("ABC", "DEF", SVTYPE.SNP));
-		assertEquals("DEF", IndelUtils.getMotif("ABC", "DEF", SVTYPE.DNP));
+	public void getMotif() {
+		assertEquals("C", IndelUtils.getMotif("C", "A", SVTYPE.SNP));
+		assertEquals("ABC", IndelUtils.getMotif("ABC", "DEF", SVTYPE.SNP));
+		assertEquals("ABC", IndelUtils.getMotif("ABC", "DEF", SVTYPE.DNP));
 		assertEquals("B", IndelUtils.getMotif("AB", "A", SVTYPE.DEL));
 		assertEquals("C", IndelUtils.getMotif("BC", "B", SVTYPE.DEL));
 		assertEquals("CDEF", IndelUtils.getMotif("B", "BCDEF", SVTYPE.INS));

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -1240,6 +1240,32 @@ public class VcfUtilsTest {
 	}
 	
 	@Test
+	public void getFFAsMapSpeedTest() {
+		List<String> ffs = Arrays.asList("GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL","0/1:27,19:46:C1[]2[];T1[]0[]:C6;T5:PASS:.:.:18:C10[40.2]9[35.33];T12[38.75]15[38]:.","0/1:9,39:48:C3[]2[]:C4;T1:PASS:.:.:37:C19[38]20[36.9];T5[39.2]4[37.75]:.","0/1:31,24:55:.:.:PASS:99:.:.:.:746.77","0/1:10,41:51:.:.:PASS:99:.:.:.:1468.77");
+		int counter = 1000000;
+		long start = System.currentTimeMillis();
+		for (int i = 0 ; i < counter ; i++) {
+			Map<String, String[]> ffMap = VcfUtils.getFormatFieldsAsMap(ffs);
+			assertEquals(11, ffMap.size());
+		}
+		System.out.println("Time taken old: " + (System.currentTimeMillis() - start));
+		
+		start = System.currentTimeMillis();
+		for (int i = 0 ; i < counter ; i++) {
+			Map<String, String[]> ffMap = VcfUtils.getFormatFieldsAsMap(ffs);
+			assertEquals(11, ffMap.size());
+		}
+		System.out.println("Time taken new: " + (System.currentTimeMillis() - start));
+		
+		start = System.currentTimeMillis();
+		for (int i = 0 ; i < counter ; i++) {
+			Map<String, String[]> ffMap = VcfUtils.getFormatFieldsAsMap(ffs);
+			assertEquals(11, ffMap.size());
+		}
+		System.out.println("Time taken old: " + (System.currentTimeMillis() - start));
+	}
+	
+	@Test
 	public void min() {
 		assertEquals(false, VcfUtils.mutationInNorma(0, 0, 0, 0));
 		assertEquals(false, VcfUtils.mutationInNorma(0, 10, 1, 2));

--- a/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
+++ b/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
@@ -249,15 +249,9 @@ public class SignatureUtilTest {
 			SignatureUtil.decipherCoverageStringBespoke("");
 			Assert.fail("Should have thrown an IAE");
 		} catch (IllegalArgumentException iae) {}
-		try {
-			SignatureUtil.decipherCoverageStringBespoke("1");
-			Assert.fail("Should have thrown an IAE");
-		} catch (IllegalArgumentException iae) {}
-		try {
-			SignatureUtil.decipherCoverageStringBespoke("1,2,3,4");
-			Assert.fail("Should have thrown an IAE");
-		} catch (IllegalArgumentException iae) {}
 		
+		Assert.assertEquals(Optional.empty(), SignatureUtil.decipherCoverageStringBespoke("1"));
+		Assert.assertEquals(Optional.empty(), SignatureUtil.decipherCoverageStringBespoke("1,2,3,4"));
 		Assert.assertEquals(Optional.empty(), SignatureUtil.decipherCoverageStringBespoke("1-2-3,4"));
 		Assert.assertEquals(Optional.empty(), SignatureUtil.decipherCoverageStringBespoke("1-2-3-4-"));
 		Assert.assertEquals(Optional.empty(), SignatureUtil.decipherCoverageStringBespoke("1---3-4-"));


### PR DESCRIPTION
Changes to the annotation process to more align the process to what the current production pipeline does.
Have paramaterised the values that have been changed so that we can move back to those values without (java) code changes should that ever be desirable (will need to update wdl to take advantage of this).