### PR TITLE
Fix issues around the AD format field

### DIFF
--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -951,6 +951,49 @@ public class VcfUtils {
 		}
 	}
 	
+	public static String fillAD(String oldAD, String newGt, String oldGt) {
+		if (newGt.equals(oldGt)) {
+			return oldAD;
+		}
+		String [] adArray = TabTokenizer.tokenize(oldAD, Constants.COMMA);
+		int newgt1 = Integer.valueOf(""+newGt.charAt(0));
+		int newgt2 = Integer.valueOf(""+newGt.charAt(2));
+		int oldgt1 = Integer.valueOf(""+oldGt.charAt(0));
+		int oldgt2 = Integer.valueOf(""+oldGt.charAt(2));
+		
+		if (Math.max(oldgt1, oldgt2) >= Math.max(newgt1, newgt2)) {
+			return oldAD;
+		}
+		
+		String [] newADArray = new String[Math.max(newgt1,  newgt2) + 1];
+		
+		int i = 0;
+		for (String s : adArray) {
+				
+			if (i == oldgt1) {
+				newADArray[oldgt1 != newgt1 ? newgt1 : i] = s;
+			} else if ( i == oldgt2) {
+				newADArray[oldgt2 != newgt2 ? newgt2 : i] = s;
+			} else {
+				newADArray[i] = s;	
+			}
+				
+			i++;
+		}
+		
+		/*
+		 * loop through and set any null elements to .
+		 * ACTUALLY, set this to 0 rather than missing data
+		 */
+		for (int j = 0 ; j < newADArray.length ; j++) {
+			if (null == newADArray[j]) {
+				newADArray[j] = "0";
+			}
+		}
+		
+		return Arrays.stream(newADArray).collect(Collectors.joining(Constants.COMMA_STRING));
+	}
+	
 	
 	/**
 	 * Will return a Optional<VcfRecord> that represents the smooshing together of the supplied control and test VCfRecords that are assumed to be GATK generated.
@@ -1034,9 +1077,17 @@ public class VcfUtils {
 				if (secondGT > 0) {
 					secondGT += noOfControlAlts;
 				}
-				tFF = tFF.replace(tGT, firstGT + Constants.SLASH_STRING + secondGT);
+				String newGT = firstGT + Constants.SLASH_STRING + secondGT;
+				tFF = tFF.replace(tGT, newGT);
 				tFFs.remove(1);
 				tFFs.add(tFF);
+				Map<String, String [] > ffMap = getFormatFieldsAsMap(tFFs);
+				String [] adArray = ffMap.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS);
+				if (null != adArray || adArray.length > 0) {
+					String newAD = fillAD(adArray[0] , newGT, tGT);
+					adArray[0] = newAD;
+					tFFs = convertFFMapToList(ffMap);
+				}
 				
 				addAdditionalSampleToFormatField(m, tFFs);
 			}

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -951,7 +951,7 @@ public class VcfUtils {
 		}
 	}
 	
-	public static String fillAD(String oldAD, String newGt, String oldGt) {
+	public static String calculateAD(String oldAD, String newGt, String oldGt) {
 		if (newGt.equals(oldGt)) {
 			return oldAD;
 		}
@@ -1084,7 +1084,7 @@ public class VcfUtils {
 				Map<String, String [] > ffMap = getFormatFieldsAsMap(tFFs);
 				String [] adArray = ffMap.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS);
 				if (null != adArray || adArray.length > 0) {
-					String newAD = fillAD(adArray[0] , newGT, tGT);
+					String newAD = calculateAD(adArray[0] , newGT, tGT);
 					adArray[0] = newAD;
 					tFFs = convertFFMapToList(ffMap);
 				}

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -14,6 +14,7 @@ import java.util.TreeSet;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.qcmg.common.model.ChrPointPosition;
 import org.qcmg.common.model.ChrRangePosition;
@@ -170,6 +171,22 @@ public class VcfUtilsTest {
 	}
 	
 	@Test
+	public void mergeGATKRealLife() {
+		String s1 = "chr4	49123053	.	G	A	800.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-0.287;ClippingRankSum=0.000;DP=147;ExcessHet=3.0103;FS=13.746;MLEAC=1;MLEAF=0.500;MQ=49.35;MQRankSum=1.081;QD=5.89;ReadPosRankSum=0.743;SOR=3.371	GT:AD:DP:GQ:PL	0/1:108,28:136:99:829,0,4491";
+		String s2 = "chr4	49123053	.	G	T	544.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=1.033;ClippingRankSum=0.000;DP=72;ExcessHet=3.0103;FS=13.528;MLEAC=1;MLEAF=0.500;MQ=47.67;MQRankSum=1.416;QD=11.35;ReadPosRankSum=0.807;SOR=3.456	GT:AD:DP:GQ:PL	0/1:33,15:48:99:573,0,2744";
+		VcfRecord  vcf1  = new VcfRecord(s1.split("\t"));
+		VcfRecord  vcf2  = new VcfRecord(s2.split("\t"));
+		Optional<VcfRecord> oMergedVcf = VcfUtils.mergeGATKVcfRecs(vcf1, vcf2);
+		assertEquals(true, oMergedVcf.isPresent());
+		VcfRecord mergedVcf = oMergedVcf.get();
+		assertEquals(3, mergedVcf.getFormatFields().size());
+		assertEquals("A,T", mergedVcf.getAlt());
+		assertEquals("GT:AD:DP:GQ:QL", mergedVcf.getFormatFields().get(0));
+		assertEquals("0/1:108,28:136:99:800.77", mergedVcf.getFormatFields().get(1));
+		assertEquals("0/2:33,0,15:48:99:544.77", mergedVcf.getFormatFields().get(2));
+	}
+	
+	@Test
 	public void mergeGATKTestOnly() {
 		String s = "chr1\t13550\t.\tG\tA\t367.77\t.\tAC=1;AF=0.500;AN=2;BaseQRankSum=1.943;ClippingRankSum=0.411;DP=25;FS=36.217;MLEAC=1;MLEAF=0.500;MQ=27.62;MQRankSum=3.312;QD=14.71;ReadPosRankSum=1.670;SOR=3.894\tGT:AD:DP:GQ:PL\t0/1:11,14:25:99:396,0,223";
 		VcfRecord  vcf  = new VcfRecord(s.split("\t"));
@@ -213,7 +230,7 @@ public class VcfUtilsTest {
 		assertEquals(Constants.MISSING_DATA_STRING, mergedVcf.getInfo());
 		assertEquals(3, mergedVcf.getFormatFields().size());
 		assertEquals("0/1:10,3:13:78:49.77", mergedVcf.getFormatFields().get(1));
-		assertEquals("0/2:8,5:13:99:157.77", mergedVcf.getFormatFields().get(2));
+		assertEquals("0/2:8,0,5:13:99:157.77", mergedVcf.getFormatFields().get(2));
 	}
 	
 	@Test
@@ -1239,7 +1256,7 @@ public class VcfUtilsTest {
 		assertArrayEquals(new String[]{".","5348.77"}, ffMap.get(VcfHeaderUtils.FORMAT_QL));
 	}
 	
-	@Test
+	@Ignore
 	public void getFFAsMapSpeedTest() {
 		List<String> ffs = Arrays.asList("GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL","0/1:27,19:46:C1[]2[];T1[]0[]:C6;T5:PASS:.:.:18:C10[40.2]9[35.33];T12[38.75]15[38]:.","0/1:9,39:48:C3[]2[]:C4;T1:PASS:.:.:37:C19[38]20[36.9];T5[39.2]4[37.75]:.","0/1:31,24:55:.:.:PASS:99:.:.:.:746.77","0/1:10,41:51:.:.:PASS:99:.:.:.:1468.77");
 		int counter = 1000000;

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -171,7 +171,7 @@ public class VcfUtilsTest {
 	}
 	
 	@Test
-	public void calculateAD() {
+	public void calculateAD () {
 		assertEquals("0,1", VcfUtils.calculateAD("0,1", "1/1", "1/1"));
 		assertEquals("0,0,1", VcfUtils.calculateAD("0,1", "2/2", "1/1"));
 		assertEquals("0,0,1", VcfUtils.calculateAD("0,1", "0/2", "0/1"));

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -171,6 +171,17 @@ public class VcfUtilsTest {
 	}
 	
 	@Test
+	public void calculateAD() {
+		assertEquals("0,1", VcfUtils.calculateAD("0,1", "1/1", "1/1"));
+		assertEquals("0,0,1", VcfUtils.calculateAD("0,1", "2/2", "1/1"));
+		assertEquals("0,0,1", VcfUtils.calculateAD("0,1", "0/2", "0/1"));
+		assertEquals("0,100,50", VcfUtils.calculateAD("0,100,50", "1/2", "1/2"));
+		assertEquals("0,0,100", VcfUtils.calculateAD("0,100", "2/2", "1/1"));
+		assertEquals("0,0,100,50", VcfUtils.calculateAD("0,100,50", "2/3", "1/2"));
+		assertEquals("0,100,0,50", VcfUtils.calculateAD("0,100,50", "3/3", "2/2"));
+	}
+	
+	@Test
 	public void mergeGATKRealLife() {
 		String s1 = "chr4	49123053	.	G	A	800.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-0.287;ClippingRankSum=0.000;DP=147;ExcessHet=3.0103;FS=13.746;MLEAC=1;MLEAF=0.500;MQ=49.35;MQRankSum=1.081;QD=5.89;ReadPosRankSum=0.743;SOR=3.371	GT:AD:DP:GQ:PL	0/1:108,28:136:99:829,0,4491";
 		String s2 = "chr4	49123053	.	G	T	544.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=1.033;ClippingRankSum=0.000;DP=72;ExcessHet=3.0103;FS=13.528;MLEAC=1;MLEAF=0.500;MQ=47.67;MQRankSum=1.416;QD=11.35;ReadPosRankSum=0.807;SOR=3.456	GT:AD:DP:GQ:PL	0/1:33,15:48:99:573,0,2744";


### PR DESCRIPTION
2 parts to this one; `qsnp` vcf mode was not properly handling the `AD` format field when multiple alts were present for a vcf record, and `q3vcftools` merge was also not appropriately handling the `AD` format field when merging snps from standard and vcf modes.

The `q3vcftools` change is available from internal svn revision `11019` onwards.

fixes #7 


