### PR TITLE
Add constructor to QCMGAtomicArray that allows user to set the max capacity of the internal AtomicLongArray

### DIFF
--- a/qcommon/src/org/qcmg/common/model/QCMGAtomicLongArray.java
+++ b/qcommon/src/org/qcmg/common/model/QCMGAtomicLongArray.java
@@ -18,10 +18,16 @@ public class QCMGAtomicLongArray {
 	
 	private AtomicLongArray array;
 	private volatile int capacity;
+	private int maxCapacity = MAX_CAPACITY;
 	
 	public  QCMGAtomicLongArray(final int initialCapacity) {
+		this(initialCapacity, MAX_CAPACITY);
+	}
+	
+	public  QCMGAtomicLongArray(final int initialCapacity, final int maxCapacity) {
+		this.maxCapacity = maxCapacity;
 		// double capacity 
-		capacity = Math.min(initialCapacity * 2, MAX_CAPACITY);
+		capacity = Math.min(initialCapacity * 2, maxCapacity);
 		array = new AtomicLongArray(capacity);
 	}
 	
@@ -61,7 +67,7 @@ public class QCMGAtomicLongArray {
 				System.out.println("resizing...");
 			
 				// double the required capacity
-				capacity = Math.min(arrayPosition * 2, MAX_CAPACITY);
+				capacity = Math.min(arrayPosition * 2, maxCapacity);
 				
 				AtomicLongArray newArray = new AtomicLongArray(capacity);
 				for (int i = 0, length = array.length() ; i < length ; i++) {

--- a/qprofiler/src/org/qcmg/qprofiler/bam/BamSummaryReport.java
+++ b/qprofiler/src/org/qcmg/qprofiler/bam/BamSummaryReport.java
@@ -133,7 +133,7 @@ public class BamSummaryReport extends SummaryReport {
 		rgSummaries.put( SummaryReportUtils.All_READGROUP, new ReadGroupSummary( SummaryReportUtils.All_READGROUP) ); 
 	}
 			
-	private final KmersSummary kmersSummary = new KmersSummary( KmersSummary.maxKmers ); //default use biggest mers length
+	private final KmersSummary kmersSummary = new KmersSummary( KmersSummary.MAX_KMERS ); //default use biggest mers length
  	
 	private final static SAMTagUtil STU = SAMTagUtil.getSingleton();
 	private final short CS = STU.CS;
@@ -287,7 +287,7 @@ public class BamSummaryReport extends SummaryReport {
 		seqByCycle.toXml(seqElement, "BaseByCycle");
 		SummaryReportUtils.lengthMapToXmlTallyItem(seqElement, "LengthTally", seqLineLengths);
 		SummaryReportUtils.lengthMapToXml(seqElement, "BadBasesInReads", seqBadReadLineLengths);
-		kmersSummary.toXml(seqElement,kmersSummary.maxKmers); //debug
+		kmersSummary.toXml(seqElement,kmersSummary.MAX_KMERS); //debug
 		kmersSummary.toXml(seqElement,1); //add 1-mers
 		kmersSummary.toXml(seqElement,2); //add 2-mers
 		kmersSummary.toXml(seqElement,3); //add 3-mers

--- a/qprofiler/test/org/qcmg/qprofiler/fastq/FastqSummarizerTest.java
+++ b/qprofiler/test/org/qcmg/qprofiler/fastq/FastqSummarizerTest.java
@@ -156,11 +156,6 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 		qs.summarize(f);
 		FastqSummaryReport sr = (FastqSummaryReport) qs.summarize(f);
 		assertEquals(1, sr.getRecordsParsed());
-//		try {
-//			Assert.fail("Should have thrown an Exception");
-//		} catch (Exception e) {
-//			Assert.assertTrue(e.getMessage().startsWith("Bad id format"));
-//		}
 	}
 	
 	@Test

--- a/qprofiler/test/org/qcmg/qprofiler/fastq/FastqSummarizerTest.java
+++ b/qprofiler/test/org/qcmg/qprofiler/fastq/FastqSummarizerTest.java
@@ -70,9 +70,9 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 		FastqSummaryReport sr = (FastqSummaryReport) qs.summarize(f.getAbsolutePath(), null, null);
 
 		Assert.assertNotNull(sr);
-		Assert.assertEquals(4, sr.getRecordsParsed());
-		Assert.assertEquals(4, sr.getFastqBaseByCycle().count(1, 'G').get());
-		Assert.assertEquals(2, sr.getFastqBaseByCycle().count(60, 'T').get());
+		assertEquals(4, sr.getRecordsParsed());
+		assertEquals(4, sr.getFastqBaseByCycle().count(1, 'G').get());
+		assertEquals(2, sr.getFastqBaseByCycle().count(60, 'T').get());
 	}
 
 	@Test
@@ -113,7 +113,7 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 
 		FastqSummarizer qs = new FastqSummarizer();
 		FastqSummaryReport sr = (FastqSummaryReport) qs.summarize(f);
-		Assert.assertEquals(0, sr.getRecordsParsed());
+		assertEquals(0, sr.getRecordsParsed());
 	}
 
 	@Test
@@ -127,7 +127,7 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 			qs.summarize(f);
 			Assert.fail("Should have thrown an Exception");
 		} catch (Exception e) {
-			Assert.assertEquals(true, e.getMessage().startsWith("Sequence header must start with @:"));
+			assertEquals(true, e.getMessage().startsWith("Sequence header must start with @:"));
 		}
 	}
 	
@@ -144,6 +144,23 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 		} catch (Exception e) {
 			Assert.assertTrue(e.getMessage().startsWith("Bad id format"));
 		}
+	}
+	
+	@Test
+	public void testSummarizeActualDuffData2() throws Exception {
+		logger.info("in testSummarizeExtraData()");
+		File f = testFolder.newFile("testSummarizeActualDuffData.fasta");
+		createDodgyDataFile(f, createActualDuffFastqData2());
+		
+		FastqSummarizer qs = new FastqSummarizer();
+		qs.summarize(f);
+		FastqSummaryReport sr = (FastqSummaryReport) qs.summarize(f);
+		assertEquals(1, sr.getRecordsParsed());
+//		try {
+//			Assert.fail("Should have thrown an Exception");
+//		} catch (Exception e) {
+//			Assert.assertTrue(e.getMessage().startsWith("Bad id format"));
+//		}
 	}
 	
 	@Test
@@ -182,7 +199,7 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 		
 		FastqSummarizer qs = new FastqSummarizer();
 		FastqSummaryReport sr = (FastqSummaryReport) qs.summarize(f);
-		Assert.assertEquals(5, sr.getRecordsParsed());
+		assertEquals(5, sr.getRecordsParsed());
 	}
 
 	@Ignore
@@ -193,8 +210,8 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 
 		FastqSummarizer qs = new FastqSummarizer();
 		FastqSummaryReport sr = (FastqSummaryReport) qs.summarize(f);
-		Assert.assertEquals(5, sr.getRecordsParsed());
-		Assert.assertEquals(5, sr.getRecordsParsed());
+		assertEquals(5, sr.getRecordsParsed());
+		assertEquals(5, sr.getRecordsParsed());
 	}
 
 	private void createDodgyDataFile(File f, List<String> dodgyData) {
@@ -284,6 +301,14 @@ BCCFDFFFHHHHHJJJJIJJJJJIJIJJJJJJJGHJJJJJJJJJJIJFHIJJJHHHFFDDDDDCDCDDDDDDDDDDDDDD
 		data.add(">1766_906_1526_F3");
 		data.add("T20010031232011020123300112100233003121221202002022");
 
+		return data;
+	}
+	private static List<String> createActualDuffFastqData2() {
+		List<String> data = new ArrayList<>();
+		data.add("@FCC24DK:1:1101:13935:1361#CATCATAA_TCTTTCCC/2");
+		data.add("TTATACCATTTTCTTTCTTCTTTTTTTCTCTCTCTTCCATCTCCAGCTGCTTCTCCTTCAATCTTTTTACTATCTTCCTCACCCCCAACTTTTTCATTATTATCTTTACTCCATTTCATTTCTATTCTTTTATCCCAGATACCCCTATTACCTGCTTCCTACATTTAGTTATACGTTTGTAAATTCATTGTTAACCTTACCTACTCTTTATTTTATTTTTGTGTTGCTTTCATTTCCTACACTCACTTTTACTTCAACTATTCTTCTTTTTTCTTCCTTGTTTTTTCCCTCACTTTCTTT");
+		data.add("+");
+		data.add("8,,,,<;,C,,,6<,,<,,6,<,;,8+,;6,;,6;;,;,,6666,,,;,,;;@6@@,,,,,,,,<,,;,;,,6,;,,,55,44,77+,,,:,:9=,,9,9,,959A=,,99,,9A?<,99,9@,,,9,94,,99,9,,,,,929,6+99+4+6,+1+32=++++66+++++++++360+++++624+5++43+*1++4+03:+*3***1**0*0*1;;;*)))5))*31;**303*5***)13)))1580**13;***2)**3****0030))118*****.))0-7**0((-*/.*846");
 		return data;
 	}
 

--- a/qprofiler/test/org/qcmg/qprofiler/summarise/KmersSummaryTest.java
+++ b/qprofiler/test/org/qcmg/qprofiler/summarise/KmersSummaryTest.java
@@ -34,7 +34,7 @@ public class KmersSummaryTest {
 	@Test
 	public void bothReversedTest() throws IOException {
 		long start = System.currentTimeMillis();
-		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
+		KmersSummary summary = new KmersSummary(KmersSummary.MAX_KMERS);	
 		System.out.println("time taken to instantiate KmersSummary: " + (System.currentTimeMillis() - start));
 		
 		
@@ -82,8 +82,23 @@ public class KmersSummaryTest {
 	}
 	
 	@Test
+	public void getEntry() {
+		assertEquals(0, KmersSummary.getEntry(new byte[]{}));
+		assertEquals(1, KmersSummary.getEntry(new byte[]{'A'}));
+		assertEquals(9, KmersSummary.getEntry("AA".getBytes()));
+		assertEquals(2, KmersSummary.getEntry("C".getBytes()));
+		assertEquals(18, KmersSummary.getEntry("CC".getBytes()));
+		assertEquals(3, KmersSummary.getEntry("G".getBytes()));
+		assertEquals(27, KmersSummary.getEntry("GG".getBytes()));
+		assertEquals(4, KmersSummary.getEntry("T".getBytes()));
+		assertEquals(36, KmersSummary.getEntry("TT".getBytes()));
+		assertEquals(10, KmersSummary.getEntry("AC".getBytes()));
+		assertEquals(148770, KmersSummary.getEntry("TTCTTC".getBytes()));
+	}
+	
+	@Test
 	public void getPossibleKmerString()  {
-		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+		KmersSummary summary = new KmersSummary(KmersSummary.MAX_KMERS);
 		String [] kmers = summary.getPossibleKmerString(6, true);
 		assertEquals((int)Math.pow(5,6), kmers.length);
 		kmers = summary.getPossibleKmerString(6, false);
@@ -92,14 +107,14 @@ public class KmersSummaryTest {
 	
 	@Test
 	public void toXml() throws ParserConfigurationException {
-		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+		KmersSummary summary = new KmersSummary(KmersSummary.MAX_KMERS);
 //		summary.parseKmers( "AAAAAAAAAAAAAACCCCCCCCCCCCCCCGGGGGGGGGGGGGGGGTTTTTTTTTTTTTTTTTTTTTT".getBytes(), false );
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		DocumentBuilder builder = factory.newDocumentBuilder();
 		
 		Document doc = builder.getDOMImplementation().createDocument(null, "qProfiler", null);
 		org.w3c.dom.Element root = doc.getDocumentElement();
-		summary.toXml(root, KmersSummary.maxKmers);
+		summary.toXml(root, KmersSummary.MAX_KMERS);
 		assertEquals(true, true);	// we made it!
 	}
 	


### PR DESCRIPTION
fixes #42 

The `QCMGAtomicLong` object had a hard limit on its size.
This has been updated (in the ctor) so that a max capacity can be supplied (defaults to the current value of 4 million).

The `KmersSummary` class sets this value when it is instantiating the `QCMGAtomicLong` object (to 6 million).

The reason that such a large array is required is that it tallies all possible kmers for each position in the read, and as the read size increases, so does the size of the array.