### PR TITLE
Qsnp min threshold

### DIFF
--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -110,6 +110,42 @@ public class ConfidenceModeTest {
 	 }
 	 
 	 @Test
+	 public void minForCompoundSnps() {
+		 
+		 StringBuilder sb = new StringBuilder();
+		 Map<String, int[]> alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40]");
+		 ConfidenceMode.checkMIN(new String [] {"AA"}, 20,  alleleDist,  sb, 1, 5f);
+		 assertEquals("MIN", sb.toString());
+		 
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIN(new String [] {"AC"}, 20,  alleleDist,  sb, 1, 5f);
+		 assertEquals("", sb.toString());
+		 
+		 sb = new StringBuilder();
+		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]0[0]");
+		 ConfidenceMode.checkMIN(new String [] {"AC"}, 21,  alleleDist,  sb, 1, 5f);
+		 assertEquals("MIN", sb.toString());
+		 
+		 sb = new StringBuilder();
+		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]0[0]");
+		 ConfidenceMode.checkMIN(new String [] {"AC"}, 21,  alleleDist,  sb, 2, 5f);
+		 assertEquals("", sb.toString());
+		 
+		 sb = new StringBuilder();
+		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]10[40]");
+		 ConfidenceMode.checkMIN(new String [] {"AC"}, 32,  alleleDist,  sb, Integer.MAX_VALUE, 5f);
+		 assertEquals("MIN", sb.toString());
+		 
+		 sb = new StringBuilder();
+		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA100[40]10[40];AC1[40]10[40]");
+		 ConfidenceMode.checkMIN(new String [] {"AC"}, 122,  alleleDist,  sb, Integer.MAX_VALUE, 10f);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIN(new String [] {"AA"}, 122,  alleleDist,  sb, Integer.MAX_VALUE, 10f);
+		 assertEquals("MIN", sb.toString());
+		 
+	 }
+	 
+	 @Test
 	 public void checkMIUN() {
 		 StringBuilder sb = null;
 		 ConfidenceMode.checkMIUN(null,   null,  sb, -1);

--- a/qsnp/src/org/qcmg/snp/util/PipelineUtil.java
+++ b/qsnp/src/org/qcmg/snp/util/PipelineUtil.java
@@ -33,7 +33,6 @@ import org.qcmg.common.util.AccumulatorUtils;
 import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Pair;
 import org.qcmg.common.util.Constants;
-import org.qcmg.common.util.SnpUtils;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
@@ -382,20 +381,6 @@ public class PipelineUtil {
 			return true;
 			});
 		
-		
-		
-//		TMap<String, int[]> basesAndCounts = new THashMap<>(); 
-//		moReadIdsAndBases.forEachEntry((i,sb) -> {
-//			int [] counts = basesAndCounts.get(sb.toString());
-//			if (null == counts) {
-//				counts = new int[2];
-//				basesAndCounts.put(sb.toString(), counts);
-//			}
-//			counts[i > 0 ? 0 : 1]++;
-//			
-//			return true;
-//		});
-		
 		return allelesCountsNNS;
 	}
 	
@@ -572,51 +557,6 @@ public class PipelineUtil {
 			.filter(e -> ! e.getKey().contains("_"))
 			.mapToInt(e -> e.getValue()[0] + e.getValue()[2])
 			.sum();
-	}
-	
-	public static String getCSFilters(String [] alts, int fg, int sg, int totalCov, Map<String, short[]> map, int sBiasCov, int sBiasAlt, boolean runSBias, boolean isControl) {
-		
-		
-		/*
-		 * sbias and coverage for now
-		 */
-		StringBuilder sb = new StringBuilder();
-		if (runSBias) {
-			if (fg > 0) {
-				boolean bothStrands = AccumulatorUtils.bothStrandsByPercentageCS(map, sBiasCov);
-				String alt = alts[fg -1];
-				short[] data = map.get(alt);
-				boolean sBiasAltPresent = AccumulatorUtils.areBothStrandsRepresented(data[0], data[2], sBiasAlt);
-				if ( ! sBiasAltPresent) {
-					sb.append ( ! bothStrands ? SnpUtils.STRAND_BIAS_COVERAGE : SnpUtils.STRAND_BIAS_ALT);
-				}
-			}
-			if (sg != fg && sg > 0) {
-				String alt = alts[sg -1];
-				short[] data = map.get(alt);
-				boolean sBiasAltPresent = AccumulatorUtils.areBothStrandsRepresented(data[0], data[2], sBiasAlt);
-				if ( ! sBiasAltPresent) {
-					boolean bothStrands = AccumulatorUtils.bothStrandsByPercentageCS(map, sBiasCov);
-					sb.append ( ! bothStrands ? SnpUtils.STRAND_BIAS_COVERAGE : SnpUtils.STRAND_BIAS_ALT);
-				}
-			}
-		}
-		
-		/*
-		 * MIN annotation - only applies if we are dealing with the control sample, and the control genotype is 0/0
-		 */
-		if (isControl && fg == 0 && sg == 0) {
-			for (String s : alts) {
-				int count = getTotalCounts(map, s);
-				if (count > 0) {
-					if (VcfUtils.mutationInNorma(count, totalCov, GenotypeUtil.MUTATION_IN_NORMAL_MIN_PERCENTAGE, GenotypeUtil.MUTATION_IN_NORMAL_MIN_COVERAGE)) {
-						StringUtils.updateStringBuilder(sb, SnpUtils.MUTATION_IN_NORMAL, Constants.SEMI_COLON);
-						break;
-					}
-				}
-			}
-		}
-		return sb.length() == 0 ? Constants.MISSING_DATA_STRING : sb.toString();
 	}
 	
 	/**
@@ -838,10 +778,12 @@ public class PipelineUtil {
 		StringBuilder cSB = new StringBuilder(altsAndGTs.get(1));
 		StringUtils.updateStringBuilder(cSB, VcfUtils.getAD(ref.get(), altsAndGTs.get(0), oabs), Constants.COLON);
 		StringUtils.updateStringBuilder(cSB, controlCov > 0 ? controlCov+"" : "0", Constants.COLON);
-		StringUtils.updateStringBuilder(cSB, getCSFilters(aAlts, controlFirstG, controlSecondG, controlCov, cBasesCountsNNS, sBiasCov, sBiasAlt, runSBias, true), Constants.COLON);
+		/*
+		 * filters are applied in qannotate now
+		 */
+		StringUtils.updateStringBuilder(cSB, Constants.MISSING_DATA_STRING, Constants.COLON);
 		String [] mrNNS =  getMR(cBasesCountsNNS, aAlts, controlFirstG, controlSecondG);
 		StringUtils.updateStringBuilder(cSB, Constants.MISSING_DATA_STRING, Constants.COLON);	// INF field
-//		StringUtils.updateStringBuilder(cSB, mrNNS[0], Constants.COLON);
 		StringUtils.updateStringBuilder(cSB, mrNNS[1], Constants.COLON);
 		StringUtils.updateStringBuilder(cSB, oabs, Constants.COLON);
 		
@@ -851,10 +793,12 @@ public class PipelineUtil {
 		StringBuilder tSB = new StringBuilder(altsAndGTs.get(2));
 		StringUtils.updateStringBuilder(tSB, VcfUtils.getAD(ref.get(), altsAndGTs.get(0), oabs), Constants.COLON);
 		StringUtils.updateStringBuilder(tSB, testCov > 0 ? testCov +"" :  "0", Constants.COLON);
-		StringUtils.updateStringBuilder(tSB, getCSFilters(aAlts, testFirstG, testSecondG, testCov, tBasesCountsNNS, sBiasCov, sBiasAlt, runSBias, false), Constants.COLON);
+		/*
+		 * filters are applied in qannotate now
+		 */
+		StringUtils.updateStringBuilder(tSB, Constants.MISSING_DATA_STRING, Constants.COLON);
 		StringUtils.updateStringBuilder(tSB, (c == Classification.SOMATIC ? VcfHeaderUtils.INFO_SOMATIC : Constants.MISSING_DATA_STRING), Constants.COLON);	// INF field
 		mrNNS =  getMR(tBasesCountsNNS,aAlts, testFirstG, testSecondG);
-//		StringUtils.updateStringBuilder(tSB, mrNNS[0], Constants.COLON);
 		StringUtils.updateStringBuilder(tSB, mrNNS[1], Constants.COLON);
 		StringUtils.updateStringBuilder(tSB, oabs, Constants.COLON);
 		

--- a/qsnp/test/org/qcmg/snp/util/GenotypeUtilTest.java
+++ b/qsnp/test/org/qcmg/snp/util/GenotypeUtilTest.java
@@ -29,13 +29,11 @@ public class GenotypeUtilTest {
 		Accumulator acc = new Accumulator(100);
 		acc.addBase((byte)'A', (byte)40, true, 90, 100, 200, 1);
 		assertEquals(gt + ":0,1:1:.:.:.:SOMATIC:1:A1[40]0[0]", GenotypeUtil.getFormatValues(acc, gt, "A", 'C', false, 0,0, Classification.SOMATIC, false));
-//		assertEquals("1/1:1:SBIASALT:1:1:A1[40]0[0]", GenotypeUtil.getFormatValues(acc, GenotypeEnum.AA, "A", 'C', true, 0, 0,Classification.SOMATIC, false));
 		
 		acc = new Accumulator(100);
 		acc.addBase((byte)'C', (byte)40, true, 90, 100, 200, 1);
 		 gt = "0/0";
 		assertEquals(gt + ":1,0:1:.:.:.:.:.:C1[40]0[0]", GenotypeUtil.getFormatValues(acc, gt, "A", 'C', false, 0, 0,Classification.SOMATIC, true));
-//		assertEquals("1/1:1:SBIASALT;COVN12:1:1:A1[40]0[0]", GenotypeUtil.getFormatValues(acc, GenotypeEnum.AA, "A", 'C', true, 0,0,Classification.SOMATIC, true));
 	}
 	
 	@Test
@@ -71,55 +69,6 @@ public class GenotypeUtilTest {
 		assertEquals("2", mrNns.get(1));
 	}
 	
-	
-	
-//	@Test
-//	public void dontPutSAN3IfCoverageExists() {
-//		/*
-//		 * .:.:.:SAN3:.:SOMATIC:.:.:T57[38.09]62[36.97]
-//		 * This should not have the SAN3 filter
-//		 */
-//		Accumulator acc = AccumulatorUtils.createFromOABS("T57[38.09]62[36.97]", 15986933);
-//		assertEquals(Constants.MISSING_DATA_STRING, GenotypeUtil.getFormatFilter(acc, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-//	}
-	
-	/*
-	 * no longer populate coverage based filters
-	 */
-//	@Ignore
-//	public void whereIsSAM3() {
-//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "0/0", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "0/0", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "0/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "0/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "1/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "1/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "1/2", new String[]{"C","G"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "1/2", new String[]{"C","G"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-//	}
-	
-//	@Test
-//	public void fivePercentMIN() {
-//		
-//		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T2[11]1[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T2[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T1[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//		
-//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C14[40.21]19[41.74];T1[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C18[41.17]15[39.33];T0[0]1[11]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("A0[0]1[11];G13[38.15]20[40]", 1), "0/0", new String[]{"A"}, 'G', true, 3, 3, Classification.SOMATIC, true));
-//	}
-	
-//	@Test
-//	public void fivePercentMINAM() {
-//		
-//		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C9[0]0[0];T0[0]1[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C19[0]0[0];T0[0]1[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C29[0]0[0];T0[0]1[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-//	}
-	
 	@Test
 	public void  isSomatic() {
 		Accumulator control = AccumulatorUtils.createFromOABS("A2[37]0[0];G2[37]8[36.5]", 985450);
@@ -149,7 +98,6 @@ public class GenotypeUtilTest {
 		//AA8[]6[];GA8[]11[];TA0[]1[]
 		Accumulator control = AccumulatorUtils.createFromOABS("A8[37]6[11];G8[37]11[36.5];T0[0]1[40]", 54817257);
 		//AA33[]20[];AG1[]1[];A_2[]0[]
-//		Accumulator test = AccumulatorUtils.createFromOABS("A36[37]21[11]", 54817257);
 		String cGt = "0/1";
 		String tGt = "0/0";
 		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification(control.getCompressedPileup(), cGt, tGt, "G"));
@@ -203,7 +151,6 @@ public class GenotypeUtilTest {
 		 * chr1    16534   .       C       T       .       MER;COVN12;MR;NNS;MIUN  SOMATIC;FLANK=CTTAACAAACC       GT:GD:AC:MR:NNS 1/1:T/T:T2[32],1[2]:0:3 0/0:C/C:C2[34],1[2],T1[34],1[2]:3:2
 		 */
 		assertEquals(Classification.SOMATIC, GenotypeUtil.getClassification("1/1", "0/0"));
-//		assertEquals(Classification.SOMATIC, GenotypeUtil.getClassification(GenotypeEnum.TT, GenotypeEnum.CC, 'C'));
 		
 		String cOABS = "T2[32]1[2]";
 		String tOABS = "C2[34]1[2];T1[34]1[2]";
@@ -225,7 +172,6 @@ public class GenotypeUtilTest {
 		Accumulator control = AccumulatorUtils.createFromOABS(cOABS, 16571);
 		Accumulator test = AccumulatorUtils.createFromOABS(tOABS, 16571);
 		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification("ACG", ".", "1/1","A"));
-//		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification(control, null, test, GenotypeEnum.AA, 'G'));
 		String gt = "1/1";
 		assertEquals("./.:2,1:"+control.getCoverage()+":.:.:.:.:.:"+cOABS, GenotypeUtil.getFormatValues(control, null, "A", 'G', true, 5, 5,Classification.GERMLINE, true));
 		assertEquals(gt + ":2,3:"+test.getCoverage()+":.:.:.:.:1:"+tOABS, GenotypeUtil.getFormatValues(test, gt, "A", 'G', true, 5, 5,Classification.GERMLINE, false));
@@ -235,7 +181,6 @@ public class GenotypeUtilTest {
 		control = AccumulatorUtils.createFromOABS(cOABS, 16571);
 		test = AccumulatorUtils.createFromOABS(tOABS, 16571);
 		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification("ACG", ".", "1/1","A"));
-//		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification(control, null, test, GenotypeEnum.AA, 'G'));
 		assertEquals("./.:0,1:"+control.getCoverage()+":.:.:.:.:.:"+cOABS, GenotypeUtil.getFormatValues(control, null, "A", 'G', true, 5, 5,Classification.GERMLINE, true));
 		assertEquals(gt + ":2,3:"+test.getCoverage()+":.:.:.:.:1:"+tOABS, GenotypeUtil.getFormatValues(test, gt, "A", 'G', true, 5, 5,Classification.GERMLINE, false));
 	}
@@ -250,7 +195,6 @@ public class GenotypeUtilTest {
 		Accumulator control = AccumulatorUtils.createFromOABS(cOABS, 133129);
 		Accumulator test = AccumulatorUtils.createFromOABS(tOABS, 133129);
 		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification("AG", "1/1", ".","A"));
-//		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification(control, GenotypeEnum.AA, test, null, 'G'));
 		String gt = "1/1";
 		assertEquals(gt + ":1,3:"+control.getCoverage()+":.:.:.:.:2:"+cOABS, GenotypeUtil.getFormatValues(control, gt, "A", 'G', true, 5, 5,Classification.GERMLINE, true));
 		assertEquals("./.:2,1:"+test.getCoverage()+":.:.:.:.:.:"+tOABS, GenotypeUtil.getFormatValues(test, null, "A", 'G', true, 5, 5,Classification.GERMLINE, false));
@@ -260,7 +204,6 @@ public class GenotypeUtilTest {
 		control = AccumulatorUtils.createFromOABS(cOABS, 133129);
 		test = AccumulatorUtils.createFromOABS(tOABS, 133129);
 		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification("AG", "1/1", ".","A"));
-//		assertEquals(Classification.GERMLINE, GenotypeUtil.getClassification(control, GenotypeEnum.AA, test, null, 'G'));
 		assertEquals(gt + ":1,3:"+control.getCoverage()+":.:.:.:.:2:"+cOABS, GenotypeUtil.getFormatValues(control, gt, "A", 'G', true, 5, 5,Classification.GERMLINE, true));
 		assertEquals("./.:1,1:"+test.getCoverage()+":.:.:.:.:.:"+tOABS, GenotypeUtil.getFormatValues(test, null, "A", 'G', true, 5, 5,Classification.GERMLINE, false));
 	}
@@ -308,7 +251,6 @@ public class GenotypeUtilTest {
 		Accumulator test = AccumulatorUtils.createFromOABS(tOABS, 802026);
 		Classification c = Classification.SOMATIC;
 		assertEquals(Classification.SOMATIC, GenotypeUtil.getClassification("GT", "2/2", "1/2","G,T"));
-//		assertEquals(c, GenotypeUtil.getClassification(control, GenotypeEnum.GG, test, GenotypeEnum.AG, 'G'));
 		String gt = "0/0";
 		assertEquals(gt + ":356,6:"+control.getCoverage()+":.:.:.:.:.:"+cOABS, GenotypeUtil.getFormatValues(control, gt, "A", 'G', true, 5, 5,c, true));
 		gt = "0/1";

--- a/qsnp/test/org/qcmg/snp/util/GenotypeUtilTest.java
+++ b/qsnp/test/org/qcmg/snp/util/GenotypeUtilTest.java
@@ -73,44 +73,44 @@ public class GenotypeUtilTest {
 	
 	
 	
-	@Test
-	public void dontPutSAN3IfCoverageExists() {
-		/*
-		 * .:.:.:SAN3:.:SOMATIC:.:.:T57[38.09]62[36.97]
-		 * This should not have the SAN3 filter
-		 */
-		Accumulator acc = AccumulatorUtils.createFromOABS("T57[38.09]62[36.97]", 15986933);
-		assertEquals(Constants.MISSING_DATA_STRING, GenotypeUtil.getFormatFilter(acc, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-	}
+//	@Test
+//	public void dontPutSAN3IfCoverageExists() {
+//		/*
+//		 * .:.:.:SAN3:.:SOMATIC:.:.:T57[38.09]62[36.97]
+//		 * This should not have the SAN3 filter
+//		 */
+//		Accumulator acc = AccumulatorUtils.createFromOABS("T57[38.09]62[36.97]", 15986933);
+//		assertEquals(Constants.MISSING_DATA_STRING, GenotypeUtil.getFormatFilter(acc, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
+//	}
 	
 	/*
 	 * no longer populate coverage based filters
 	 */
-	@Ignore
-	public void whereIsSAM3() {
-		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "0/0", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "0/0", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "0/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "0/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "1/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "1/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "1/2", new String[]{"C","G"}, 'T', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "1/2", new String[]{"C","G"}, 'T', true, 3, 3, Classification.SOMATIC, false));
-	}
+//	@Ignore
+//	public void whereIsSAM3() {
+//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, null, new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
+//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "0/0", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "0/0", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
+//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "0/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "0/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
+//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "1/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "1/1", new String[]{"C"}, 'T', true, 3, 3, Classification.SOMATIC, false));
+//		assertEquals("SAN3", GenotypeUtil.getFormatFilter(null, "1/2", new String[]{"C","G"}, 'T', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals("SAT3", GenotypeUtil.getFormatFilter(null, "1/2", new String[]{"C","G"}, 'T', true, 3, 3, Classification.SOMATIC, false));
+//	}
 	
-	@Test
-	public void fivePercentMIN() {
-		
-		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T2[11]1[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T2[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T1[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-		
-		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C14[40.21]19[41.74];T1[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C18[41.17]15[39.33];T0[0]1[11]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
-		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("A0[0]1[11];G13[38.15]20[40]", 1), "0/0", new String[]{"A"}, 'G', true, 3, 3, Classification.SOMATIC, true));
-	}
+//	@Test
+//	public void fivePercentMIN() {
+//		
+//		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T2[11]1[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals("MIN", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T2[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C10[36.4]23[39.61];T1[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
+//		
+//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C14[40.21]19[41.74];T1[11]0[0]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("C18[41.17]15[39.33];T0[0]1[11]", 1), "0/0", new String[]{"T"}, 'C', true, 3, 3, Classification.SOMATIC, true));
+//		assertEquals(".", GenotypeUtil.getFormatFilter(AccumulatorUtils.createFromOABS("A0[0]1[11];G13[38.15]20[40]", 1), "0/0", new String[]{"A"}, 'G', true, 3, 3, Classification.SOMATIC, true));
+//	}
 	
 //	@Test
 //	public void fivePercentMINAM() {

--- a/qsnp/test/org/qcmg/snp/util/PipelineUtilTest.java
+++ b/qsnp/test/org/qcmg/snp/util/PipelineUtilTest.java
@@ -312,8 +312,6 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		acc1.addBase((byte)'G', (byte) 1, true, 1, 1, 2, 1);
 		acc1.addBase((byte)'G', (byte) 1, true, 1, 1, 2, 2);
 		acc1.addBase((byte)'G', (byte) 1, false, 1, 1, 2, 3);
-//		Accumulator acc2 = new Accumulator(2);
-//		acc2.addBase((byte)'A', (byte) 1, true, 2, 2, 3, 1);
 		List<Accumulator> accs = Arrays.asList(acc1);
 		
 		Map<String, short[]> basesAndCounts = PipelineUtil.getBasesFromAccumulators(accs);
@@ -376,12 +374,6 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		assertEquals(Constants.MISSING_GT, altsGTs.get(1));
 		assertEquals("1/1", altsGTs.get(2));
 	}
-	
-//	@Test
-//	public void csFilter() {
-//		assertEquals(".", PipelineUtil.getCSFilters(null, -1, -1, 0, null, 3, 3, true, true));
-//		assertEquals(".", PipelineUtil.getCSFilters(null, -1, -1, 0, null, 3, 3, true, false));
-//	}
 	
 	@Test
 	public void getAltsAndGTs() {
@@ -564,8 +556,6 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 	
 	@Test
 	public void createCSSinglePos() {
-//		List<VcfRecord> snps = new ArrayList<>();
-//		snps.add(VcfUtils.createVcfRecord(new ChrPointPosition("1", 100),null,"A","C"));
 		VcfRecord origV = VcfUtils.createVcfRecord(new ChrPointPosition("1", 100),null,"A","C");
 		
 		Accumulator controlAcc100 = new Accumulator(100);

--- a/qsnp/test/org/qcmg/snp/util/PipelineUtilTest.java
+++ b/qsnp/test/org/qcmg/snp/util/PipelineUtilTest.java
@@ -377,11 +377,11 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		assertEquals("1/1", altsGTs.get(2));
 	}
 	
-	@Test
-	public void csFilter() {
-		assertEquals(".", PipelineUtil.getCSFilters(null, -1, -1, 0, null, 3, 3, true, true));
-		assertEquals(".", PipelineUtil.getCSFilters(null, -1, -1, 0, null, 3, 3, true, false));
-	}
+//	@Test
+//	public void csFilter() {
+//		assertEquals(".", PipelineUtil.getCSFilters(null, -1, -1, 0, null, 3, 3, true, true));
+//		assertEquals(".", PipelineUtil.getCSFilters(null, -1, -1, 0, null, 3, 3, true, false));
+//	}
 	
 	@Test
 	public void getAltsAndGTs() {
@@ -1003,7 +1003,10 @@ chr4    8046421 .       A       T       .       .       BaseQRankSum=0.727;Clipp
 		assertEquals("CG", v.getAlt());
 		List<String> ff = v.getFormatFields();
 		assertEquals("./.:.:0:.:.:.:.", ff.get(1));	// control
-		assertEquals("1/1:0,4:4:SBIASCOV:SOMATIC:1:CG4[]0[];C_1[]0[]", ff.get(2));	// tumour
+		/*
+		 * filters are now applied in qannotate
+		 */
+		assertEquals("1/1:0,4:4:.:SOMATIC:1:CG4[]0[];C_1[]0[]", ff.get(2));	// tumour
 	}
 	
 	@Test


### PR DESCRIPTION
Remove the code that adds filter information to compound snps from `qsnp`.
The ability to add to the filter field is already present in `qannotate`.
Added test for `MIN` filter in compound snps to `ConfidenceModeTest`

See Issue #47 for more details