### PR TITLE
fix homopolymer bug at start/end of contigs

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/Main.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Main.java
@@ -16,58 +16,105 @@ public class Main {
 	public static void main(final String[] args) throws Exception {	
 
 		try {
-            final Options options = new Options(args);             
+           final Options options = new Options(args);             
         		//LoadReferencedClasses.loadClasses(Main.class);    
            logger = QLoggerFactory.getLogger(Main.class, options.getLogFileName(),  options.getLogLevel());	            		               
-           logger.logInitialExecutionStats(options.getPGName(), options.getVersion(),args);	    
-                     
+           logger.logInitialExecutionStats(options.getPGName(), options.getVersion(),args);
+           
+           checkOptions(options);
+           
            if (options.getMode() == Options.MODE.dbsnp) {
-        	   		new DbsnpMode( options );
+    	   		new DbsnpMode( options );
            	} else if (options.getMode() == Options.MODE.germline) {
-        	   		new GermlineMode( options );
+    	   		new GermlineMode( options );
 			} else if (options.getMode() == Options.MODE.snpeff) {
-        	    		new SnpEffMode(   options  );
+	    		new SnpEffMode(   options  );
 			} else if (options.getMode() == Options.MODE.confidence) {
-        	    		new ConfidenceMode(   options);
+	    		new ConfidenceMode(   options);
 			} else if (options.getMode() == Options.MODE.ccm) {
 				new CCMMode(   options);
 			} else if (options.getMode() == Options.MODE.vcf2maf) {
 				new Vcf2maf(  options );
 			} else if (options.getMode() == Options.MODE.cadd) {
-        	   		new CaddMode(   options   );
-           } else if (options.getMode() == Options.MODE.indelconfidence) {
-        	   		new IndelConfidenceMode(options);
-           } else if (options.getMode() == Options.MODE.hom) {
-        	   		new HomoplymersMode(options);
-           } else if (options.getMode() == Options.MODE.trf) {
-        	   		new TandemRepeatMode( options );
-           } else if (options.getMode() == Options.MODE.make_valid) {
-        	   		new MakeValidMode( options );
+    	   		new CaddMode(   options   );
+            } else if (options.getMode() == Options.MODE.indelconfidence) {
+    	   		new IndelConfidenceMode(options);
+            } else if (options.getMode() == Options.MODE.hom) {
+    	   		new HomoplymersMode(options);
+            } else if (options.getMode() == Options.MODE.trf) {
+    	   		new TandemRepeatMode( options );
+            } else if (options.getMode() == Options.MODE.make_valid) {
+    	   		new MakeValidMode( options );
 //           } else if (options.getMode() == Options.MODE.snppileup) {
 //   	   			new SnpPileupMode( options );
-   	   	   } else if (options.getMode() == Options.MODE.overlap) {
+   	   	    } else if (options.getMode() == Options.MODE.overlap) {
    	   			new OverlapMode( options );
 	   	   	} else if (options.getMode() == Options.MODE.vcf2maftmp) {
 				new Vcf2mafTmp(  options );
-           } else {
-        	   		logger.error("No valid mode are specified on commandline: " + options.getMode());
-        	   		throw new Exception("No valid mode are specified on commandline: " + options.getMode()) ;
-           }
+	   	   	} else if (options.getMode() == null) {
+	   	   		throw new IllegalArgumentException("No mode was specified on the commandline - please add the \"-mode\" option") ;
+            } else {
+    	   		throw new IllegalArgumentException("No valid mode are specified on commandline - please run \"qannotate -help\" to see the list of available modes");
+            }
 
             logger.logFinalExecutionStats(0);
                
         } catch (Exception e) {
-	        	System.out.println("Exception caught!");
-	        	e.printStackTrace();
-	        	System.err.println(Thread.currentThread().getName() + " " + e.toString() + " : " + e.getLocalizedMessage());
-	        	if (null != logger) {
-		        	logger.info(Thread.currentThread().getName() + " " + e.toString() + " : " + e.getMessage());	            
-		        	logger.logFinalExecutionStats(1);
-	        	}
-        		System.out.println("About to return exit code of 1");
-            System.exit(1);
-        }			
-		
-		
+        	System.out.println("Exception caught!");
+        	e.printStackTrace();
+        	System.err.println(Thread.currentThread().getName() + " " + e.toString() + " : " + e.getLocalizedMessage());
+        	if (null != logger) {
+	        	logger.info(Thread.currentThread().getName() + " " + e.toString() + " : " + e.getMessage());	            
+	        	logger.logFinalExecutionStats(1);
+        	}
+    		System.out.println("About to return exit code of 1");
+    		System.exit(1);
+        }
+	}
+	
+	
+	public static void checkOptions(Options o) {
+		Options.MODE m = o.getMode();
+		switch (m) {
+		/*
+		 * some modes need a database
+		 */
+		case dbsnp:
+		case germline:
+		case hom:
+		case cadd:
+		case snpeff:
+		case trf:
+			if (null == o.getDatabaseFileName()) {
+        		throw new IllegalArgumentException("Please supply a reference file using the \"-d\" option");
+        	}
+			
+		/*
+		 * modst modes need an output
+		 */
+		case overlap:
+		case confidence:
+		case indelconfidence:
+		case ccm:
+		case make_valid:
+			if (null == o.getOutputFileName()) {
+				throw new IllegalArgumentException("Please supply an output file using the \"-output\" or \"-o\" option");
+			}
+			if (null == o.getInputFileName()) {
+				throw new IllegalArgumentException("Please supply an input file using the \"-input\" option");
+			}
+			break;
+		/*
+		 * all modes need an input
+		 */
+		case vcf2maf:
+		case vcf2maftmp:
+			if (null == o.getInputFileName()) {
+				throw new IllegalArgumentException("Please supply an input file using the \"-input\" option");
+			}
+			if (null == o.getOutputDir() && null == o.getOutputFileName()) {
+				throw new IllegalArgumentException("Please supply an output dir using the \"-outdir\" option, or an output file using the \"-output\" or \"-o\" option");
+			}
+		}
 	}
 }

--- a/qannotate/src/au/edu/qimr/qannotate/Main.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Main.java
@@ -72,7 +72,14 @@ public class Main {
         }
 	}
 	
-	
+	/**
+	 * Checks the Options object to see if the minimal options (input, output, database) have been supplied.
+	 * Using the switch statements fall through process here.
+	 * 
+	 * Assuming that the individual modes will perform any more specific Options checking internally 
+	 *  
+	 * @param o
+	 */
 	public static void checkOptions(Options o) {
 		Options.MODE m = o.getMode();
 		switch (m) {
@@ -90,7 +97,8 @@ public class Main {
         	}
 			
 		/*
-		 * modst modes need an output
+		 * most modes need an output and input
+		 * there is a break after these checks as the vcf2mafs are a slightly special case
 		 */
 		case overlap:
 		case confidence:
@@ -105,7 +113,7 @@ public class Main {
 			}
 			break;
 		/*
-		 * all modes need an input
+		 * apart from the vcf2maf modes which can take either a outdir or output option
 		 */
 		case vcf2maf:
 		case vcf2maftmp:

--- a/qannotate/src/au/edu/qimr/qannotate/Options.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Options.java
@@ -103,14 +103,14 @@ public class Options {
         
         //log, input and output are compulsory
         inputFileName = (String) options.valueOf("i") ;      	 
-        outputFileName = (String) options.valueOf("o") ; 
-	    	logFileName = (String) options.valueOf("log");  	
-	    	logLevel = (String) options.valueOf("loglevel");
-	    	
-	    	 if (null == inputFileName) { 
-		        	displayHelp(mode);  
-		        	System.exit(0);	
-	        }
+        outputFileName = (String) options.valueOf("output") ; 
+    	logFileName = (String) options.valueOf("log");  	
+    	logLevel = (String) options.valueOf("loglevel");
+    	
+    	if (null == inputFileName) { 
+        	displayHelp(mode);  
+        	System.exit(0);	
+        }
     	
     	//
 		List<String> dbList = (List<String>) options.valuesOf("d");		 
@@ -120,11 +120,9 @@ public class Options {
 		  	displayHelp(mode);  
         	System.exit(0);	
 		}
-		
         
         gap = (options.has("gap"))? (int)options.valueOf("gap") : 1000;  //CADD default is 1000
         bufferSize = (options.has("buffer"))? (Integer) options.valueOf("buffer") : 0; //TRF default is 0
-        
         
         miunCutoff = ((Integer) options.valueOf("miunCutoff"));
         minCutoff = ((Integer) options.valueOf("minCutoff"));
@@ -136,7 +134,6 @@ public class Options {
         testCoverageCutoff = ((Integer) options.valueOf("testCoverageCutoff"));
         mrPercentage = ((Float) options.valueOf("mrPercentage"));
         filtersToIgnore = (List<String>) options.valuesOf("filtersToIgnore");
-        
         
         //vcf2maf
         outputDir = (options.has("outdir"))? (String)options.valueOf("outdir") : null;
@@ -192,19 +189,19 @@ public class Options {
 
         OptionSet options  = parser.parse(args);  
         if (options.has("v") || options.has("version")){
-	    		System.err.println( "qannotate: Current version is " + getVersion());
-	    		System.exit(0);
+    		System.err.println( "qannotate: Current version is " + getVersion());
+    		System.exit(0);
         }  
         
         Options.MODE mm = null;   	
-        if(options.has("mode")){
-	        	final String	m = ((String) options.valueOf("mode")).toLowerCase();
-	        	try{
-	        		mm = MODE.valueOf(m);
-	        	}catch(IllegalArgumentException | NullPointerException e){
-	        		System.err.println("invalid mode specified: "  + m);
-	        		System.exit(1);
-	        	}
+        if (options.has("mode")){
+        	final String m = ((String) options.valueOf("mode")).toLowerCase();
+        	try{
+        		mm = MODE.valueOf(m);
+        	}catch(IllegalArgumentException | NullPointerException e){
+        		System.err.println("invalid mode specified: " + m);
+        		System.exit(1);
+        	}
         }
         
         if (mm == null) return options;
@@ -240,7 +237,6 @@ public class Options {
          }
          
          return parser.parse(args);
-        
 	} 
        
     public String getVersion(){
@@ -286,7 +282,7 @@ public class Options {
     	for (File out : outputs)  {   
     		//out.getParentFile() maybe null if file name string exclude path eg. out = "ok.txt"
     		File parent = out.getAbsoluteFile().getParentFile();    		    		
-    		if ( (out.exists() && ! out.canWrite()) || ( !out.exists() && !parent.canWrite())) {    				 
+    		if ( (out.exists() && ! out.canWrite()) || ( ! out.exists() && ! parent.canWrite())) {    				 
     			throw new IllegalArgumentException( Messages.getMessage("OUTPUT_ERR_DESCRIPTION", out.getName()));
     		}
     	}	
@@ -301,11 +297,11 @@ public class Options {
     	//check whether file unique
  	    inputs.addAll(outputs);
        	for (int  i = inputs.size() -1; i > 0; i --) {
-	    		for (int j = i-1; j >= 0; j -- ){
-	    			if (inputs.get(i).getCanonicalFile().equals(inputs.get(j).getCanonicalFile())) {
-	    				throw new IllegalArgumentException( "below command line values are point to same file: \n\t" + inputs.get(i) + "\n\t" + inputs.get(j) );
-	    			}
-	    		}
+    		for (int j = i - 1; j >= 0; j-- ){
+    			if (inputs.get(i).getCanonicalFile().equals(inputs.get(j).getCanonicalFile())) {
+    				throw new IllegalArgumentException( "below command line values are point to same file: \n\t" + inputs.get(i) + "\n\t" + inputs.get(j) );
+    			}
+    		}
        	}
     }
 
@@ -315,7 +311,7 @@ public class Options {
 	public String getInputFileName(){return inputFileName;}
 	public String getOutputFileName(){return outputFileName;}
 	public String getDatabaseFileName(){return null != databaseFiles && databaseFiles.length > 0 ? databaseFiles[0] : null;}	
-	public String[] getDatabaseFiles(){ return  (mode.equals(MODE.cadd) || mode.equals(MODE.overlap))? databaseFiles : null;}
+	public String[] getDatabaseFiles(){ return (mode.equals(MODE.cadd) || mode.equals(MODE.overlap)) ? databaseFiles : null;}
     public MODE getMode(){	return  mode; }
    
     private void displayHelp(MODE mode) throws IOException {   

--- a/qannotate/test/au/edu/qimr/qannotate/OptionsTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/OptionsTest.java
@@ -24,5 +24,19 @@ public class OptionsTest {
 		o = new Options(new String[]{"--mode", "make_valid","-i",i.getAbsolutePath(), "-d", d.getAbsolutePath()});
 		assertEquals(d.getAbsolutePath(), o.getDatabaseFileName());
 	}
+	
+	@Test
+	public void outputOption() throws IOException {
+		File i = testFolder.newFile();
+		File output = testFolder.newFile();
+		Options o = new Options(new String[]{"--mode", "make_valid","-output",output.getAbsolutePath(),"-i",i.getAbsolutePath(),});
+		assertEquals(output.getAbsolutePath(), o.getOutputFileName());
+		o = new Options(new String[]{"--mode", "make_valid","-o",output.getAbsolutePath(),"-i",i.getAbsolutePath(),});
+		assertEquals(output.getAbsolutePath(), o.getOutputFileName());
+		o = new Options(new String[]{"--mode", "hom","-o",output.getAbsolutePath(),"-i",i.getAbsolutePath(),});
+		assertEquals(output.getAbsolutePath(), o.getOutputFileName());
+		o = new Options(new String[]{"--mode", "hom","-output",output.getAbsolutePath(),"-i",i.getAbsolutePath(),});
+		assertEquals(output.getAbsolutePath(), o.getOutputFileName());
+	}
 
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
@@ -10,6 +10,38 @@ import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 
 public class HomoplymersModeTest {
+	
+	@Test
+	public void startOfContig() {
+		//SNP
+		VcfRecord re = new VcfRecord(new String[] {  "chr1", "1", null, "T", "A" });		
+		HomoplymersMode  homo = new HomoplymersMode(3,3);	
+		re = homo.annotate(re, getReference());
+		assertEquals("0,tATG", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		
+		re = new VcfRecord(new String[] {  "chr1", "0", null, "T", "A" });		
+		homo = new HomoplymersMode(3,3);
+		try {
+			re = homo.annotate(re, getReference());
+			fail("Should have thrown an IllegalArgumentException");
+		} catch (IllegalArgumentException iae){};
+	}
+	
+	@Test
+	public void endOfContig() {
+		//SNP
+		VcfRecord re = new VcfRecord(new String[] {  "chr1", "40", null, "T", "A" });		
+		HomoplymersMode  homo = new HomoplymersMode(3,3);	
+		re = homo.annotate(re, getReference());
+		assertEquals("3,CCCt", re.getInfoRecord().getField(VcfHeaderUtils.INFO_HOM));
+		
+		re = new VcfRecord(new String[] {  "chr1", "41", null, "T", "A" });		
+		homo = new HomoplymersMode(3,3);	
+		try {
+			re = homo.annotate(re, getReference());
+			fail("Should have thrown an IllegalArgumentException");
+		} catch (IllegalArgumentException iae){};
+	}
  	
 
 	@Test
@@ -302,7 +334,7 @@ public class HomoplymersModeTest {
 		refs[0] = "TCAAGAGTTT".getBytes();
 		refs[1] = "CTTTATTTTT".getBytes();
 		
-		assertEquals(3, findHomopolymer(refs, "C", SVTYPE.SNP));
+		assertEquals(3, HomoplymersMode.findHomopolymer(refs, "C", SVTYPE.SNP));
 		assertEquals(3, HomoplymersMode.findHomopolymer(refs, "C", SVTYPE.SNP));
 		
 	}

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
@@ -121,7 +121,7 @@ public class Vcf2mafIndelTest {
         };
             try {
                 Vcf2mafTest.createVcf(input, str);
-                final String[] command = {"--mode", "vcf2maf",  "--log", log.getAbsolutePath(),  "-i", input.getAbsolutePath() , "-o" , out.getAbsolutePath()};
+                final String[] command = {"--mode", "vcf2maf",  "--log", log.getAbsolutePath(),  "-i", input.getAbsolutePath() , "-output" , out.getAbsolutePath()};
                 au.edu.qimr.qannotate.Main.main(command);
             } catch ( Exception e) {
                 e.printStackTrace(); 


### PR DESCRIPTION
`Qannotate` was throwing an exception when running `homopolymer` mode and variants were present at the very beginning (position 1) of the contig (see #54 )

Added null guards and checks to ensure that variants at the beginnings of contigs are handled appropriately (in my view)
example output for a position at the start of a contig:
```
GL000192.1   1    .    G    C  ...   FLANK=-----CAATTC;IN=1;HOM=2,gAATTCATTCA ...
```

If a genome biologist takes a look at #54 and decides that this is not the desired output, then this will need to be revisited, but for now, it allows `qannotate` to proceed error free.

Have also added some checks for variants that are beyond the ends of the contigs.

Added more meaningful error messages when options are missing from `qannotate`.