### PR TITLE
de-randomise removal of overlapping reads

### DIFF
--- a/qcommon/test/org/qcmg/common/util/PileupElementLiteUtilTest.java
+++ b/qcommon/test/org/qcmg/common/util/PileupElementLiteUtilTest.java
@@ -11,8 +11,6 @@ import org.qcmg.common.model.Accumulator;
 import org.qcmg.common.model.PileupElementLite;
 import org.qcmg.common.model.Rule;
 
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
 
 public class PileupElementLiteUtilTest {
 	
@@ -181,46 +179,6 @@ public class PileupElementLiteUtilTest {
 		assertEquals(true, PileupElementLiteUtil.passesCountCheck(100, 100, new Rule(0,Integer.MAX_VALUE,10), true));
 		
 	}
-	
-//	@Test
-//	public void toSummaryString() {
-//		Accumulator accum = new Accumulator(1);
-//		accum.addBase((byte)'A', (byte) 1, true, 1, 1, 2, 1);
-//		assertEquals("A1[1],0[0]", PileupElementLiteUtil.toSummaryString(accum.getLargestVariant('\u0000'), "A"));
-//		accum.addBase((byte)'T', (byte) 1, true, 1, 1, 2, 1);
-//		assertEquals("T1[1],0[0]", PileupElementLiteUtil.toSummaryString(accum.getLargestVariant('\u0000'), "T"));
-//	}
-//	@Test
-//	public void toOABS() {
-//		Accumulator accum = new Accumulator(1);
-//		accum.addBase((byte)'A', (byte) 1, true, 1, 1, 2, 1);
-//		assertEquals("A1[1]0[0]", PileupElementLiteUtil.toObservedAlleleByStrand(accum.getLargestVariant('\u0000'), "A"));
-//	}
-//	
-//	@Test
-//	public void testGetLargestVariantNovelStarts() {
-//		Accumulator accum = new Accumulator(1);
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'A'));
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'C'));
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'G'));
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'T'));
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'N'));
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'X'));
-//		
-//		accum.addFailedFilterBase((byte)'A');
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'A'));
-//		byte A = 'A';
-//		accum.addBase(A, (byte) 1, true, 1, 1, 2, 1);
-//		assertEquals(0, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'A'));
-//		assertEquals(1, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'C'));
-//		byte C = 'C';
-//		accum.addBase(C, (byte) 1, true, 1, 1, 2, 1);
-//		accum.addBase(C, (byte) 1, true, 2, 1, 2, 1);
-//		assertEquals(1, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'C'));	// still have the A in there
-//		assertEquals(2, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'A'));
-//		assertEquals(2, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'G'));
-//		assertEquals(2, PileupElementLiteUtil.getLargestVariantNovelStarts(accum, 'T'));
-//	}
 	
 	@Test
 	public void testIsAccumulatorAKeeper() {

--- a/qpicard/src/org/qcmg/picard/util/SAMUtils.java
+++ b/qpicard/src/org/qcmg/picard/util/SAMUtils.java
@@ -264,7 +264,7 @@ public class SAMUtils {
 				 isSAMRecordValid(rec)
 				 && (includeDuplicates || ! rec.getDuplicateReadFlag())
 				 && ! rec.getReadUnmappedFlag()
-				 && ! rec.getNotPrimaryAlignmentFlag();
+				 && ! rec.isSecondaryOrSupplementary();
 	 }
 	 
 	 

--- a/qpicard/test/org/qcmg/picard/util/SAMUtilsTest.java
+++ b/qpicard/test/org/qcmg/picard/util/SAMUtilsTest.java
@@ -307,12 +307,28 @@ public class SAMUtilsTest {
 	}
 	
 	@Test
+	public void supplementaryReads() {
+		SAMRecord sam = new SAMRecord(null);
+		sam.setSecondaryAlignment(true);
+		assertEquals(false, SAMUtils.isSAMRecordValidForVariantCalling(sam));
+		sam.setSecondaryAlignment(false);
+		assertEquals(true, SAMUtils.isSAMRecordValidForVariantCalling(sam));
+		sam.setSupplementaryAlignmentFlag(true);
+		assertEquals(false, SAMUtils.isSAMRecordValidForVariantCalling(sam));
+	}
+	
+	@Test
 	public void testIsSAMRecordValidForVariantCallingAllOptions() {
 		
+		/*
+		 * flag values are 1 less than actual position as a right-shift operation is being performed
+		 */
 		int failsVendorCheck = 9;
 		int duplicate = 10;
 		int notPrimaryAlignment = 8;
 		int unmapped = 2;
+		int supplementary = 11;
+		int secondary = 8;
 		SAMRecord sam = new SAMRecord(null);
 		
 		for (int i = 0 ; i < 5000; i++) {
@@ -365,6 +381,10 @@ public class SAMUtilsTest {
 				
 				assertEquals(false, SAMUtils.isSAMRecordValidForVariantCalling(sam));
 				
+			} else if (((i >>> supplementary) & 1) != 0) {
+				assertEquals(false, SAMUtils.isSAMRecordValidForVariantCalling(sam));
+			} else if (((i >>> secondary) & 1) != 0) {
+				assertEquals(false, SAMUtils.isSAMRecordValidForVariantCalling(sam));
 			} else {
 				assertEquals(true, SAMUtils.isSAMRecordValidForVariantCalling(sam));
 			}

--- a/qsnp/src/org/qcmg/snp/Pipeline.java
+++ b/qsnp/src/org/qcmg/snp/Pipeline.java
@@ -871,7 +871,7 @@ public abstract class Pipeline {
 				mainThread.interrupt();
 			} finally {
 				latch.countDown();
-				logger.info("Producer: shutting down - processed " + counter + " records, passed filter: " 
+				logger.info("Producer: shutting down - processed " + ((higherOrderCounter * ONE_MILLION) + counter) + " records, passed filter: " 
 						+ passedFilterCount + ", invalidCount: " + invalidCount);
 			}
 		}


### PR DESCRIPTION
After the release of  [PR 57](https://github.com/AdamaJava/adamajava/pull/57), the trusty regression tests identified a few instances where variants were now being marked with the strand bias filter - `SBIASALT`

This was happening because we would have all but one of the reads on one strand (that one read was preventing the `SBIASALT` filter from being activated)
If that one read happened to be an overlapping read AND the second in the pair (location-wise) then it would be removed, meaning there would be no reads on one strand, thereby triggering the `SBIASALT` filter.

This change will remove the read from the overlapping pair that is on the strand with the most reads.

In making this change, it was noted that supplementary reads were contributing to coverage in `qsnp` std mode. After talking with the biologists, a decision was made to remove this, and so `qpicard`'s `SAMUtils.isSAMRecordValidForVariantCalling` now returns `false` for supplementary records.