### PR TITLE
Fixes #61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # gradle project .gitignore from https://github.com/github/gitignore/blob/master/Gradle.gitignore
 .gradle
 /build/
+/*/build/
+/*/adama/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/qbamfix/src/org/qcmg/qbamfix/ReheadFinalBAM.java
+++ b/qbamfix/src/org/qcmg/qbamfix/ReheadFinalBAM.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.qcmg.common.log.QLogger;
-import org.qcmg.picard.RnameFile;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.picard.SAMOrBAMWriterFactory;
 import org.qcmg.picard.HeaderUtils;

--- a/qbammerge/src/org/qcmg/bammerge/FileMerger.java
+++ b/qbammerge/src/org/qcmg/bammerge/FileMerger.java
@@ -37,6 +37,7 @@ import org.qcmg.common.util.FileUtils;
 import org.qcmg.picard.HeaderUtils;
 import org.qcmg.picard.MultiSAMFileIterator;
 import org.qcmg.picard.MultiSAMFileReader;
+import org.qcmg.picard.RenameFile;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.picard.SAMOrBAMWriterFactory;
 import org.qcmg.picard.util.SAMReadGroupRecordUtils;
@@ -484,12 +485,15 @@ public final class FileMerger {
 		}
 	}
 	
-	private void reheadSingleBamFile() {
+	private void reheadSingleBamFile() throws IOException {
 		File in = new File(allInputFileNames[0]);
 		final SamReader reader = SAMFileReaderFactory.createSAMFileReader(in, validation);
 		final SAMFileHeader header = reader.getFileHeader();
 		replaceUUIDInHeader(header, uuid);
-		BamFileIoUtils.reheaderBamFile(header, in, outputFile, true, true);
+		BamFileIoUtils.reheaderBamFile(header, in, outputFile, false, createIndex);
+		if (createIndex) {
+			RenameFile.renameIndex(outputFile);
+		}
 	}
 
 	/**

--- a/qpicard/src/org/qcmg/picard/RenameFile.java
+++ b/qpicard/src/org/qcmg/picard/RenameFile.java
@@ -8,6 +8,7 @@ package org.qcmg.picard;
 
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,39 +16,29 @@ import java.nio.file.StandardCopyOption;
 
 import htsjdk.samtools.BAMIndex;
 
-public class RnameFile {
+public class RenameFile {
 	/**
 	 * picard index name created by replacing .bam to .bai. But we want to have index name end with .bam.bai
 	 * @param bamFile
 	 * @throws Exception 
 	 */
-	public static void renameIndex(File bamFile) throws Exception{
+	public static void renameIndex(File bamFile) throws IOException{
 		String path = bamFile.getPath();
 	   	String indexFileBase = bamFile.getPath().endsWith(".bam") ? bamFile.getPath().substring(0, path.lastIndexOf(".")) : path;
 	   	
 	   	if(! indexFileBase.equals(path)){
-	        File indexpicard = new File(indexFileBase + BAMIndex.BAMIndexSuffix);
-	        File indexqcmg = new File(path + BAMIndex.BAMIndexSuffix);
-			
-	        rename(indexpicard, indexqcmg);
-        }
+			File indexpicard = new File(indexFileBase + BAMIndex.BAMIndexSuffix);
+			File indexqcmg = new File(path + BAMIndex.BAMIndexSuffix);
+			rename(indexpicard, indexqcmg);
+        	}
 	}
 	
-	public static void rename(File org, File des) throws Exception{
+	public static void rename(File org, File des) throws IOException{
 		Path Porg = Paths.get(org.getPath());
 		Path Pdes = Paths.get(des.getPath());
-		if( ! org.exists()){
-			throw new Exception( "can't rename file, since file not exist: " +org.getPath() );
-		}
 		//do nothing if both File are instance of same real file
-		if( org.getPath().equals(des.getPath())) return;
-		
+		if(org.getPath().equals(des.getPath())) return;
 		//rename files
-		try{
-			Files.move(Porg, Pdes, StandardCopyOption.REPLACE_EXISTING);			
-			org.delete();			 
-		}catch(Exception e){
-			throw new Exception("Exception occured during deleting file: " + org.getPath());
-		}
+		Files.move(Porg, Pdes, StandardCopyOption.REPLACE_EXISTING);			
 	}
 }

--- a/qpicard/src/org/qcmg/picard/SAMOrBAMWriterFactory.java
+++ b/qpicard/src/org/qcmg/picard/SAMOrBAMWriterFactory.java
@@ -92,41 +92,14 @@ public class SAMOrBAMWriterFactory {
 	}
 	public void closeWriter(){
 		writer.close();
- 
 		if (index) {
-			renameIndex(output);
+			try {
+				RenameFile.renameIndex(output);
+			} catch(IOException e) {
+				logMessage = "IOEXception caught whilst trying to move file";
+				logger.error(logMessage, e);
+			}
 		}
-	}
-	
-	/**
-	 * rename index, eg. output.bai to output.bam.bai if the related bam named as output.bam
-	 * @param bamFile
-	 * @throws IOException 
-	 */
-	public void renameIndex(File bamFile)  {
-		String path = bamFile.getPath();
-	   	String indexFileBase = bamFile.getPath().endsWith(".bam") ? bamFile.getPath().substring(0, path.lastIndexOf(".")) : path;
-
-	   	if(! indexFileBase.equals(path)){
-	        File org = new File(indexFileBase + BAMIndex.BAMIndexSuffix);
-	        File des = new File(path + BAMIndex.BAMIndexSuffix);
-			
-	        if(! org.exists()){
-	        	logMessage = "Error: can't rename file, since file not exist: " + org.getPath();
-	        	return;
-	        }else if(! org.getPath().equals(des.getPath())) {
-	        	Path pOrg = Paths.get(org.getPath());
-	    		Path pDes = Paths.get(des.getPath());
-	        	try{
-					Files.move(pOrg, pDes, StandardCopyOption.REPLACE_EXISTING);			
-					org.delete();			 
-				}catch(IOException e){
-					logMessage ="Error: Exception occured during deleting file: " + org.getPath();
-					logger.error("IOEXception caught whilst trying to move file", e);
-				}
-	        }
-	        logMessage = "Succeed: renamed index file to " + des.getPath();
-        }
 	}
 	
 	public String getLogMessage(){

--- a/qpicard/test/org/qcmg/picard/RenameFileTest.java
+++ b/qpicard/test/org/qcmg/picard/RenameFileTest.java
@@ -1,0 +1,53 @@
+package org.qcmg.picard;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RenameFileTest {
+	
+	@Test
+	public void renameIndex() throws IOException {
+		Path dir = Files.createTempDirectory("java-test");
+		File bam = new File(dir.resolve("test.bam").toString());
+		File bai = new File(dir.resolve("test.bai").toString());
+		// create the bam and a picard-style ${stem/bam/bai} index 
+		bam.createNewFile();
+		bai.createNewFile();
+		File baiRenamed = new File(dir.resolve("test.bam.bai").toString());
+
+		Assert.assertTrue(bai.exists());
+		Assert.assertFalse(baiRenamed.exists());
+		RenameFile.renameIndex(bam);
+		Assert.assertTrue(baiRenamed.exists());
+		Assert.assertFalse(bai.exists());
+	}
+	
+	@Test(expected = IOException.class)
+	public void renameNonExistentIndex() throws IOException {
+		Path dir = Files.createTempDirectory("java-test");
+		File bam = new File(dir.resolve("test.bam").toString());
+		// create the bam but no index
+		bam.createNewFile();
+		// expect IOException
+		RenameFile.renameIndex(bam);
+	}
+	
+	@Test(expected = IOException.class)
+	public void renameAlreadyCanonicalIndex() throws IOException {
+		Path dir = Files.createTempDirectory("java-test");
+		File bam = new File(dir.resolve("test.bam").toString());
+		File bai = new File(dir.resolve("test.bam.bai").toString());
+		// create the bam and an already-canonically named index
+		bam.createNewFile();
+		bai.createNewFile();
+		// expect IOException
+		RenameFile.renameIndex(bam);
+	}
+
+}

--- a/qsplit/src/org/qcmg/split/SingleLevelSplit.java
+++ b/qsplit/src/org/qcmg/split/SingleLevelSplit.java
@@ -30,7 +30,7 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.util.TabTokenizer;
 import org.qcmg.picard.HeaderUtils;
-import org.qcmg.picard.RnameFile;
+import org.qcmg.picard.RenameFile;
 import org.qcmg.picard.SAMFileReaderFactory;
 
 public class SingleLevelSplit extends Split {
@@ -120,7 +120,7 @@ public class SingleLevelSplit extends Split {
 		if(createIndex){
 			for(File out: outputNames){
 				try{
-					RnameFile.renameIndex(out);
+					RenameFile.renameIndex(out);
 					logger.info("rename index to " + out.getPath() + ".bai");
 				}catch(Exception e){
 					logger.error(e.toString());

--- a/qsplit/src/org/qcmg/split/Split.java
+++ b/qsplit/src/org/qcmg/split/Split.java
@@ -24,7 +24,7 @@ import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMTagUtil;
 
-import org.qcmg.picard.RnameFile;
+import org.qcmg.picard.RenameFile;
 import org.qcmg.picard.SAMFileReaderFactory;
 
 public class Split {
@@ -300,7 +300,7 @@ public class Split {
 		if(createIndex){
 			for(File out: outputNames){
 				try{
-					RnameFile.renameIndex(out);
+					RenameFile.renameIndex(out);
 				}catch(Exception e){
 					 System.out.println(e.toString());
 				}


### PR DESCRIPTION
remove unnecessary test for existence and Exception rethrow in RenameFile.rename
remove dupe implementation of renameIndex from SAMOrBAMWriterFactory
use RenameFile.renameIndex to canonically rename any output index created for a single input to FileMerger

tests for RenameFile