### PR TITLE
Qprofiler may2019

### DIFF
--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -34,4 +34,6 @@ task fatJar(type: Jar ) {
 		exclude 'META-INF/.RSA', 'META-INF/.SF','META-INF/*.DSA'		
 }
 
-//artifacts { archives fatJar }
+//leave out: artifacts { archives fatJar }.
+//we don't want to publish automaitcally at moment, but may require it in soon further. 
+//create the fatJar unless we call this task

--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -17,22 +17,21 @@ dependencies {
 }
 
 //create a fat jar file only for dispatching our qprofiler to outside
-/*
-task fatJar(type: Jar ) {
-	baseName = project.name + '-all'
-	version = "$version"
-	from { configurations.compile.collect { it.isDirectory() ? it :  zipTree(it) } }
-	with jar
-	
-	manifest {
-		attributes 'Implementation-Title': baseName,
-				   'Implementation-Version': "$version ($revision)",
-				   'Built-By': System.properties['user.name'],
-				   'Date': new java.util.Date().toString(),
-				   'Main-Class' : mainClassName,
-				   'Class-Path' : "${baseName}-${version}.jar"
-	 }
-	exclude 'META-INF/.RSA', 'META-INF/.SF','META-INF/*.DSA'
+task fatJar(type: Jar ) {	
+		baseName = project.name + '-all'
+		version = "$version"
+		from { configurations.compile.collect { it.isDirectory() ? it :  zipTree(it) } }
+		with jar
+		
+		manifest {
+			attributes 'Implementation-Title': baseName,
+					   'Implementation-Version': "$version ($revision)",
+					   'Built-By': System.properties['user.name'],
+					   'Date': new java.util.Date().toString(),
+					   'Main-Class' : mainClassName,
+					   'Class-Path' : "${baseName}-${version}.jar"
+		 }
+		exclude 'META-INF/.RSA', 'META-INF/.SF','META-INF/*.DSA'		
 }
-artifacts { archives fatJar }
-*/
+
+//artifacts { archives fatJar }

--- a/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
+++ b/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
@@ -104,11 +104,10 @@
 	  <xs:attribute type="xs:integer" name="count" use="optional"/>
 	  <xs:attribute type="xs:integer" name="binSize" use="optional"/>
 	  <xs:attribute type="xs:string" name="tallyCount" use="optional"/>
-	  <xs:assert test="2 > count(@binSize) + count(@tallyCount)"/>
+	  <!--  xs:assert test="2 > count(@binSize) + count(@tallyCount)"/ -->
   </xs:complexType>
 
-    <xs:complexType name="SequenceMetricsType">
-    
+    <xs:complexType name="SequenceMetricsType">    
 	     <xs:choice>
 		     <xs:sequence>
 			     <xs:element name="variableGroup" maxOccurs="unbounded" type="groupType"/>
@@ -116,13 +115,12 @@
 		     <xs:sequence>
 			     <xs:element ref="value" maxOccurs="unbounded"/>
 		     </xs:sequence>			
-	     </xs:choice>
-    
+	     </xs:choice>    
     <xs:attribute type="xs:integer" name="count" use="optional"/>
     <xs:attribute type="xs:integer" name="readCount" use="optional"/>
     <xs:attribute type="xs:integer" name="pairCount" use="optional"/>
     <xs:attribute type="xs:string" name="name" use="optional"/>
-    <xs:assert test="2 > count(@readCount) + count(@pairCount) + count(@count)"/>
+    <!--  xs:assert test="2 > count(@readCount) + count(@pairCount) + count(@count)"/ -->
    </xs:complexType>
 
   <xs:complexType name="SequenceMetricsGroup">

--- a/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
+++ b/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
@@ -104,7 +104,7 @@
 	  <xs:attribute type="xs:integer" name="count" use="optional"/>
 	  <xs:attribute type="xs:integer" name="binSize" use="optional"/>
 	  <xs:attribute type="xs:string" name="tallyCount" use="optional"/>
-	  <!--  xs:assert test="2 > count(@binSize) + count(@tallyCount)"/ -->
+	  <!--  xs:assert test="2 > count(@binSize) + count(@tallyCount)" -->
   </xs:complexType>
 
     <xs:complexType name="SequenceMetricsType">    
@@ -120,7 +120,7 @@
     <xs:attribute type="xs:integer" name="readCount" use="optional"/>
     <xs:attribute type="xs:integer" name="pairCount" use="optional"/>
     <xs:attribute type="xs:string" name="name" use="optional"/>
-    <!--  xs:assert test="2 > count(@readCount) + count(@pairCount) + count(@count)"/ -->
+    <!--  xs:assert test="2 > count(@readCount) + count(@pairCount) + count(@count)" -->
    </xs:complexType>
 
   <xs:complexType name="SequenceMetricsGroup">


### PR DESCRIPTION
remove artifacts from build file, It make fatJar task independent, unless run "gradle fatJar" and then it will create qprofiler2-all-2.0.jar; 
remove "/" from comment out line from xsd file