### PR TITLE
bug fix for bams with lots of clipping

### DIFF
--- a/qsv/src/org/qcmg/qsv/QSVPipeline.java
+++ b/qsv/src/org/qcmg/qsv/QSVPipeline.java
@@ -72,10 +72,10 @@ public class QSVPipeline {
 	private final Map<PairGroup, Map<String, List<DiscordantPairCluster>>> normalRecords;
 	private int somaticCounts = 0;
 	private int  germlineCounts = 0;
-	private int normalGermlineCounts =0;
+	private int normalGermlineCounts = 0;
 	private final String analysisId;
 	private final String resultsDir;
-	private long clipCount =0;
+	private long clipCount = 0;
 
 	public QSVPipeline(Options options, String resultsDir, Date analysisDate, String analysisId, QExec exec) throws Exception {
 

--- a/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
+++ b/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
@@ -252,17 +252,7 @@ public class AnnotateFilterMT implements Runnable {
 					chromosomes = queueIn.poll();               
 
 					if (chromosomes == null) {
-
-						// qIn maybe filled again during sleep, so sleep should
-						// be secondly
-						try {
-							Thread.sleep(sleepUnit);
-							sleepcount++;
-						} catch (final InterruptedException e) {
-							logger.info(Thread.currentThread().getName() + " "
-									+ e.toString());
-						}
-
+						run = false;
 					} else {
 						// pass the record to filter and then to output queue                    	
 						for (final Chromosome chromosome: chromosomes) {
@@ -559,8 +549,14 @@ public class AnnotateFilterMT implements Runnable {
 									}
 								}
 	
-								if (filterLatch.getCount() == 0) {	                        	
-									run = false;
+								if (filterLatch.getCount() == 0) {
+									/*
+									 * the queue could have been added to since our last check (we did have a quick sleep after all
+									 * Check size again before pulling the plug
+									 */
+									if (queue.isEmpty()) {
+										run = false;
+									}
 								}
 	
 							} else {

--- a/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
+++ b/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
@@ -12,14 +12,13 @@ import java.io.FileWriter;
 import java.util.AbstractQueue;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
@@ -54,7 +53,7 @@ import org.qcmg.qsv.util.QSVUtil;
  */
 public class AnnotateFilterMT implements Runnable {
 	
-	private static final int noOfThreads = 3;
+	private static final int noOfThreads = 2;
 	private static final int maxRecords = 500000;
 	private static final int checkPoint = 100000;
 
@@ -128,7 +127,8 @@ public class AnnotateFilterMT implements Runnable {
 	public void run() {
 
 		// create queue to get the chromosomes to reads
-		final AbstractQueue<List<Chromosome>> readQueue = new ConcurrentLinkedQueue<List<Chromosome>>();
+		final AbstractQueue<List<Chromosome>> readQueue = new ConcurrentLinkedQueue<>(parameters.getChromosomes().values().stream().collect(Collectors.toList()));
+		logger.info("readQueue setup with " + readQueue.size() + " lists of chromosomes");
 
 		// create queue to store the satisfied BAM records for discordant pairs
 		final AbstractQueue<SAMRecord> writeQueue = new ConcurrentLinkedQueue<SAMRecord>();
@@ -136,25 +136,20 @@ public class AnnotateFilterMT implements Runnable {
 		// create queue to store the satisfied BAM records for clips and unmapped reads
 		final AbstractQueue<SAMRecord> writeClipQueue = new ConcurrentLinkedQueue<SAMRecord>();
 
-		final CountDownLatch readLatch = new CountDownLatch(1); // reading thread
 		final CountDownLatch filterLatch = new CountDownLatch(noOfThreads); // annotating filtering threads
 		final CountDownLatch writeLatch = new CountDownLatch(2); // writing thread for satisfied records
 
 		// set up executor services
-		final ExecutorService readThread = new CustomThreadPoolExecutor(1, exitStatus, logger);
 		final ExecutorService filterThreads = new CustomThreadPoolExecutor(noOfThreads, exitStatus, logger);
 		final ExecutorService writeThreads = new CustomThreadPoolExecutor(2, exitStatus, logger);
 
 		try {
 
-			// kick-off single reading thread
-			readThread.execute(new Reading(readQueue, Thread.currentThread(), readLatch, filterLatch));
-			readThread.shutdown();
 
 			// kick-off filtering thread
 			for (int i = 0; i < noOfThreads; i++) {
 				filterThreads.execute(new AnnotationFiltering(readQueue,
-						writeQueue, writeClipQueue, Thread.currentThread(), readLatch,
+						writeQueue, writeClipQueue, Thread.currentThread(),
 						filterLatch, writeLatch));
 			}
 			filterThreads.shutdown();
@@ -167,7 +162,6 @@ public class AnnotateFilterMT implements Runnable {
 			writeThreads.shutdown();
 
 			logger.info("waiting for  threads to finish (max wait will be 20 hours)");
-			readThread.awaitTermination(60, TimeUnit.HOURS);
 			filterThreads.awaitTermination(60, TimeUnit.HOURS);
 			writeThreads.awaitTermination(60, TimeUnit.HOURS);
 
@@ -195,7 +189,6 @@ public class AnnotateFilterMT implements Runnable {
 			}
 		} finally {
 			// kill off any remaining threads            	
-			readThread.shutdownNow();
 			writeThreads.shutdownNow();
 			filterThreads.shutdownNow();
 			mainLatch.countDown();
@@ -206,81 +199,6 @@ public class AnnotateFilterMT implements Runnable {
 		return goodClipCount;
 	}
 
-	/**
-	 * Class to determine the chromosomes/contigs to read/write
-	 * @author felicity
-	 *
-	 */
-	private class Reading implements Runnable {
-
-		private final AbstractQueue<List<Chromosome>> queue;
-		private final Thread mainThread;
-		private final CountDownLatch rLatch;
-		private final CountDownLatch fLatch;
-
-		public Reading(AbstractQueue<List<Chromosome>> q, Thread mainThread,
-				CountDownLatch readLatch, CountDownLatch filterLatch) {
-			this.queue = q;
-			this.mainThread = mainThread;
-			this.rLatch = readLatch;
-			this.fLatch = filterLatch;
-		}
-
-		@Override
-		public void run() {
-			logger.info("Starting to read input: " + input.getAbsolutePath());
-			int countSleep = 0;
-			long count = 0;
-			try {
-				final Map<String, List<Chromosome>> chromosomes = parameters.getChromosomes();
-
-				for (final Entry<String, List<Chromosome>> entry: chromosomes.entrySet()) {
-					logger.info("Adding chromosome to queue: " + entry.getKey() + " in sample " + parameters.getFindType());
-					queue.add(entry.getValue());
-
-					if (fLatch.getCount() == 0) {
-						throw new Exception(
-								"No filtering threads left, but reading from input is not yet completed");
-					}
-
-					if (++count % checkPoint == 1) {
-						while (queue.size() >= maxRecords) {
-							try {
-								Thread.sleep(sleepUnit);
-								countSleep++;
-							} catch (final Exception e) {
-								logger.info(Thread.currentThread().getName()
-										+ " " +QSVUtil.getStrackTrace(e));
-							}
-						}
-					}
-
-					if (count % 50000000 == 0) {
-						logger.debug("Read " + count + " records from input: "
-								+ parameters.getFindType());
-					}
-
-				}
-
-				logger.info("Completed reading thread, read " + count
-						+ " records from input: " + input.getAbsolutePath());
-			} catch (final Exception e) {
-				logger.error("Setting exit status in execute thread to 1 as exception caught in reading method: " + QSVUtil.getStrackTrace(e));
-				if (exitStatus.intValue() == 0) {
-					exitStatus.incrementAndGet();
-				}
-				mainThread.interrupt();
-			} finally {
-				rLatch.countDown();
-				logger.info(String
-						.format("Exit Reading thread, total slept %d times * %d milli-seconds, "
-								+ "since input queue are full.fLatch  is %d; queus size is %d ",
-								countSleep, sleepUnit, fLatch.getCount(),
-								queue.size()));
-			}
-
-		}
-	}
 
 	/**
 	 * Class to annotate and filter discordant pairs, clips and unmapped readsS
@@ -291,7 +209,6 @@ public class AnnotateFilterMT implements Runnable {
 		private final AbstractQueue<List<Chromosome>> queueIn;
 		private final AbstractQueue<SAMRecord> queueOutPair;
 		private final Thread mainThread;
-		private final CountDownLatch readLatch;
 		private final CountDownLatch filterLatch;
 		private final CountDownLatch writeLatch;
 		private int countOutputSleep;
@@ -303,13 +220,11 @@ public class AnnotateFilterMT implements Runnable {
 
 		public AnnotationFiltering(AbstractQueue<List<Chromosome>> readQueue,
 				AbstractQueue<SAMRecord> writeQueue, AbstractQueue<SAMRecord> writeClipQueue, Thread mainThread,
-				CountDownLatch readLatch, CountDownLatch fLatch,
-				CountDownLatch wGoodLatch) throws Exception {
+				CountDownLatch fLatch, CountDownLatch wGoodLatch) throws Exception {
 			this.queueIn = readQueue;
 			this.queueOutPair = writeQueue;
 			this.queueOutClip = writeClipQueue;
 			this.mainThread = mainThread;
-			this.readLatch = readLatch;
 			this.filterLatch = fLatch;
 			this.writeLatch = wGoodLatch;
 			if (runPair && ! StringUtils.isNullOrEmpty(query)) {
@@ -337,10 +252,6 @@ public class AnnotateFilterMT implements Runnable {
 					chromosomes = queueIn.poll();               
 
 					if (chromosomes == null) {
-						// must check whether reading thread finished first.
-						if (readLatch.getCount() == 0) {
-							run = false;
-						}
 
 						// qIn maybe filled again during sleep, so sleep should
 						// be secondly
@@ -425,7 +336,7 @@ public class AnnotateFilterMT implements Runnable {
 		
 							//discordant pairs
 							if (runPair && record.getAlignmentStart() >= startPos && record.getAlignmentStart() <= endPos) {
-								writersResult = addToPairWriter(record, count);
+								writersResult = addToPairWriter(record, srgr.getId(), count);
 							}
 		
 							if (runClip) {
@@ -433,7 +344,7 @@ public class AnnotateFilterMT implements Runnable {
 								if (( ! record.getReadUnmappedFlag() && ! record.getDuplicateReadFlag() && record.getCigarString().contains("S"))
 										|| (isSplitRead && record.getReadUnmappedFlag()) ) {
 									
-									pileupResult = pileupSoftClips(writer, record, startPos, endPos, chromosome);
+									pileupResult = pileupSoftClips(writer, record, srgr.getId(), startPos, endPos, chromosome, count);
 								}
 							}
 		
@@ -471,19 +382,19 @@ public class AnnotateFilterMT implements Runnable {
 		/*
 		 * write soft clips and unmapped reads
 		 */
-		private boolean pileupSoftClips(BufferedWriter writer, SAMRecord record, int start, int end, Chromosome chromosome) throws Exception {
+		private boolean pileupSoftClips(BufferedWriter writer, SAMRecord record, String rgId, int start, int end, Chromosome chromosome, int count) throws Exception {
 			if (record.getReadUnmappedFlag()) {
 				unmappedCount.incrementAndGet();
-				QSVUtil.writeUnmappedRecord(writer, record, start, end, parameters.isTumor());						
-				return add2queue(record, queueOutClip, start);
+				QSVUtil.writeUnmappedRecord(writer, record, rgId, start, end, parameters.isTumor());						
+				return add2queue(record, queueOutClip, count);
 			}
 
 
 			//see if clips pass the filter
 			if (clipQueryEx.Execute(record)) {
 				goodClipCount.incrementAndGet();
-				SoftClipStaticMethods.writeSoftClipRecord(writer, record, start, end, chromosome.getName());    			
-				return add2queue(record, queueOutClip, start);
+				SoftClipStaticMethods.writeSoftClipRecord(writer, record, rgId, start, end, chromosome.getName());    			
+				return add2queue(record, queueOutClip, count);
 			} else {
 				return true;
 			}			
@@ -492,14 +403,14 @@ public class AnnotateFilterMT implements Runnable {
 		/*
 		 * Write discordant pairs to bam
 		 */
-		private boolean addToPairWriter(SAMRecord record, int count) throws Exception {
+		private boolean addToPairWriter(SAMRecord record, String rgId, int count) throws Exception {
 
 			if ( ! record.getReadUnmappedFlag()) {
 				
 				if ( ! translocationsOnly || QSVUtil.isTranslocationPair(record)) {
 
 					//annotate the read
-					parameters.getAnnotator().annotate(record);
+					parameters.getAnnotator().annotate(record, rgId);
 					final String zp = (String) record.getAttribute(QSVConstants.ZP_SHORT);
 
 					//make sure it is discordant
@@ -509,29 +420,29 @@ public class AnnotateFilterMT implements Runnable {
 							if (pairQueryEx.Execute(record)) {
 								goodPairRecordCount.incrementAndGet();                 		    
 								return add2queue(record, queueOutPair, count, writeLatch);			                                
-							} else if (lifescopeQueryEx != null && record.getAttribute("SM") == null && record.getAttribute("XC") != null) {
-								//try to filter lifescope reads
-								if (lifescopeQueryEx.Execute(record)) {
-									goodPairRecordCount.incrementAndGet();
-									return add2queue(record, queueOutPair, count, writeLatch);
-								} else {
-									record.setAttribute(QSVConstants.ZP, record.getAttribute("XC"));
-									if (lifescopeQueryEx.Execute(record)) {
-										return add2queue(record, queueOutPair, count, writeLatch);
-									}
-								} 
-								badRecordCount.incrementAndGet();
 							} else {
-								badRecordCount.incrementAndGet();
+								Object xc = record.getAttribute("XC");
+								if (lifescopeQueryEx != null && record.getAttribute("SM") == null && xc != null) {
+									//try to filter lifescope reads
+									if (lifescopeQueryEx.Execute(record)) {
+										goodPairRecordCount.incrementAndGet();
+										return add2queue(record, queueOutPair, count, writeLatch);
+									} else {
+										record.setAttribute(QSVConstants.ZP, xc);
+										if (lifescopeQueryEx.Execute(record)) {
+											return add2queue(record, queueOutPair, count, writeLatch);
+										}
+									}
+									badRecordCount.incrementAndGet();
+								} else {
+									badRecordCount.incrementAndGet();
+								}
 							}
-						}
-					} 	               	
+						} 	               	
+					}
 				}
-				return true;
-
-			} else {
-				return true;
-			}			
+			}
+			return true;
 		}
 		
 		private boolean add2queue(SAMRecord re, AbstractQueue<SAMRecord> queue, int count) {
@@ -539,12 +450,11 @@ public class AnnotateFilterMT implements Runnable {
 		}
 
 		//add to write queue
-		private boolean add2queue(SAMRecord re, AbstractQueue<SAMRecord> queue,
-				int count, CountDownLatch latch) {
+		private boolean add2queue(SAMRecord re, AbstractQueue<SAMRecord> queue,	int count, CountDownLatch latch) {
 			// check queue size in each checkPoint number
 			if (count % checkPoint == 0) {
 				// check mainThread
-				if (!mainThread.isAlive()) {
+				if ( ! mainThread.isAlive()) {
 					logger.error("mainThread died: " + mainThread.getName());
 					return false;
 				}
@@ -564,9 +474,7 @@ public class AnnotateFilterMT implements Runnable {
 				} // end while
 			}
 
-			queue.add(re);
-
-			return true;
+			return queue.add(re);
 		}
 	}
 
@@ -595,12 +503,12 @@ public class AnnotateFilterMT implements Runnable {
 		public void run() {        	
 			int countSleep = 0;
 			boolean run = true;
+			logger.info("Started Writing thread with output file: " + file);
 			try {
 				int count = 0;
 				if (file != null) {
 					final String commandLine = query;
-					HeaderUtils.addProgramRecord(header, "qsv",
-							Messages.getVersionMessage(), commandLine);
+					HeaderUtils.addProgramRecord(header, "qsv",	Messages.getVersionMessage(), commandLine);
 					final SAMFileWriterFactory writeFactory = new SAMFileWriterFactory();
 					if (header.getSortOrder().equals(SortOrder.coordinate)) {
 						writeFactory.setCreateIndex(true);
@@ -621,7 +529,6 @@ public class AnnotateFilterMT implements Runnable {
 					
 					final SAMFileWriter writer = writeFactory.makeBAMWriter(header, false, file, 1);
 					
-//					final File tmpLocation = htsjdk.samtools.util.IOUtil.getDefaultTmpDir();
 					logger.info("all tmp BAMs are located on " + file.getParentFile().getCanonicalPath());
 					logger.info("default maxRecordsInRam " + htsjdk.samtools.SAMFileWriterImpl.getDefaultMaxRecordsInRam());
 
@@ -639,18 +546,16 @@ public class AnnotateFilterMT implements Runnable {
 											+ QSVUtil.getStrackTrace(e));
 								}
 	
-								if ((count % checkPoint == 0)
-										&& (!mainThread.isAlive()))
-									throw new Exception(
-											"Writing thread failed since parent thread died.");
+								if ((count % checkPoint == 0) && (!mainThread.isAlive())) {
+									throw new Exception("Writing thread failed since parent thread died.");
+								}
 	
 								while (queue.size() >= maxRecords) {
 									try {
 										Thread.sleep(sleepUnit);
 										countSleep++;
 									} catch (final Exception e) {
-										logger.info(Thread.currentThread().getName()
-												+ " " + QSVUtil.getStrackTrace(e));
+										logger.info(Thread.currentThread().getName() + " " + QSVUtil.getStrackTrace(e));
 									}
 								}
 	
@@ -662,6 +567,10 @@ public class AnnotateFilterMT implements Runnable {
 	
 								writer.addAlignment(record);
 								count++;
+								
+								if (count % 1000000 == 0) {
+									logger.info("have written " + count + " SAMRecords to file, queue size: " + queue.size());
+								}
 							}
 						}
 					} catch (Exception e) {

--- a/qsv/src/org/qcmg/qsv/softclip/SoftClipStaticMethods.java
+++ b/qsv/src/org/qcmg/qsv/softclip/SoftClipStaticMethods.java
@@ -12,24 +12,25 @@ import java.util.List;
 
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
 
+import org.qcmg.common.util.Constants;
 import org.qcmg.qsv.QSVParameters;
 import org.qcmg.qsv.util.QSVUtil;
 
 public class SoftClipStaticMethods {
 	
 	public static void writeSoftClipRecord(BufferedWriter writer, SAMRecord record, Integer start, Integer end, String chromosome) throws IOException {
-//		public static synchronized void writeSoftClipRecord(BufferedWriter writer, SAMRecord record, Integer start, Integer end, String chromosome) throws IOException {
+		SAMReadGroupRecord rg = record.getReadGroup();
+		writeSoftClipRecord( writer, record, (null != rg ? rg.getId() : Constants.EMPTY_STRING), start, end, chromosome);
+	}
+	public static void writeSoftClipRecord(BufferedWriter writer, SAMRecord record, String rgId, Integer start, Integer end, String chromosome) throws IOException {
 
-		Clip clipRecord = createSoftClipRecord(record, start, end, chromosome);
+		String clipRecordString = createSoftClipRecordString(record, rgId, start, end, chromosome);
 		
-//		if (record.getReadName().equals("HWI-ST1240:47:D12NAACXX:2:2315:11796:5777")) {
-//			System.out.println(record.getSAMString());
-//			System.out.println(record.getAlignmentStart());
-//		}
-		if (clipRecord != null) {			
-			writer.write(clipRecord.toString());
+		if (clipRecordString != null) {			
+			writer.write(clipRecordString);
 		}
 	}
 	
@@ -44,9 +45,9 @@ public class SoftClipStaticMethods {
 				return null;
 			} else if (first.getOperator().equals(CigarOperator.S)) {
 				
-				String sequenceString = record.getReadString();
 				int bpPos = record.getAlignmentStart();
 				if (QSVUtil.createRecord(bpPos, start, end)) {
+					String sequenceString = record.getReadString();
 					int len = first.getLength();
 					String sequence = sequenceString.substring(0, len);
 					String alignedSequence = sequenceString.substring(len);
@@ -54,9 +55,9 @@ public class SoftClipStaticMethods {
 				}			
 			} else if (last.getOperator().equals(CigarOperator.S)) {
 				
-				String sequenceString = record.getReadString();
 				int bpPos = record.getAlignmentEnd();
 				if (QSVUtil.createRecord(bpPos, start, end)) {
+					String sequenceString = record.getReadString();
 					int seqLen = sequenceString.length() - last.getLength();
 					String sequence = sequenceString.substring(seqLen);
 					String alignedSequence = sequenceString.substring(0, seqLen);
@@ -65,6 +66,50 @@ public class SoftClipStaticMethods {
 			}			
 		}		
 		return null;
+	}
+	public static String createSoftClipRecordString(SAMRecord record, String rgId, Integer start, Integer end, String chromosome) {
+		if ( ! record.getReadUnmappedFlag()) {
+			List<CigarElement> elements = record.getCigar().getCigarElements();
+			
+			CigarElement first = elements.get(0);
+			CigarElement last = elements.get(elements.size()-1);
+			
+			if (first.getOperator().equals(CigarOperator.S) && last.getOperator().equals(CigarOperator.S)) {
+				return null;
+			} else if (first.getOperator().equals(CigarOperator.S)) {
+				
+				int bpPos = record.getAlignmentStart();
+				if (QSVUtil.createRecord(bpPos, start, end)) {
+					int len = first.getLength();
+					return createSoftClipRecordString(record, rgId, bpPos, len, true);
+				}			
+			} else if (last.getOperator().equals(CigarOperator.S)) {
+				
+				String sequenceString = record.getReadString();
+				int bpPos = record.getAlignmentEnd();
+				if (QSVUtil.createRecord(bpPos, start, end)) {
+					int cutoff = sequenceString.length() - last.getLength();
+					return createSoftClipRecordString(record,rgId,  bpPos, cutoff, false);				
+				}			
+			}			
+		}		
+		return null;
+	}
+	
+	public static String createSoftClipRecordString(SAMRecord record, String rgId, int bpPos, int cutoff, boolean isLeft) {
+		StringBuilder sb = new StringBuilder(record.getReadName());
+		sb.append(Constants.COLON);
+		sb.append(rgId).append(Constants.COMMA);
+		sb.append(record.getReferenceName()).append(Constants.COMMA);
+		sb.append(bpPos).append(Constants.COMMA);
+		sb.append(record.getReadNegativeStrandFlag() ? QSVUtil.MINUS : QSVUtil.PLUS).append(Constants.COMMA);
+		sb.append(isLeft ? Clip.LEFT : Clip.RIGHT).append(Constants.COMMA);
+		String read = record.getReadString();
+		sb.append(read).append(Constants.COMMA);
+		sb.append(isLeft ? read.substring(0,  cutoff) : read.substring(cutoff)).append(Constants.COMMA);
+		sb.append(isLeft ? read.substring(cutoff) : read.substring(0, cutoff)).append(QSVUtil.NEW_LINE);
+		
+		return sb.toString();
 	}
 
 	public static String getSoftClipFile(String chromosome, String type, String softclipDir) {

--- a/qsv/src/org/qcmg/qsv/util/QSVConstants.java
+++ b/qsv/src/org/qcmg/qsv/util/QSVConstants.java
@@ -88,6 +88,7 @@ public class QSVConstants {
 	public static final short  ZP_SHORT = SAMTagUtil.getSingleton().makeBinaryTag(ZP);
 	public static final String AAA = "AAA";
 	public static final String NH = "NH";
+	public static final short NH_SHORT =SAMTagUtil.getSingleton().makeBinaryTag(NH);
 
 	public static final String Z_STAR_STAR = "Z**";
 	public static final String C_STAR_STAR = "C**";

--- a/qsv/src/org/qcmg/qsv/util/QSVUtil.java
+++ b/qsv/src/org/qcmg/qsv/util/QSVUtil.java
@@ -26,6 +26,7 @@ import htsjdk.samtools.reference.FastaSequenceIndex;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
 
 import org.qcmg.common.meta.QExec;
@@ -487,8 +488,11 @@ public class QSVUtil {
 		}		
 	}
 
-	public static void writeUnmappedRecord(BufferedWriter writer,
-			SAMRecord record, Integer start, Integer end, boolean isTumour) throws IOException, QSVException {
+	public static void writeUnmappedRecord(BufferedWriter writer, SAMRecord record, Integer start, Integer end, boolean isTumour) throws IOException, QSVException {
+		SAMReadGroupRecord rg = record.getReadGroup();
+		writeUnmappedRecord( writer, record, (rg != null ? rg.getId() : Constants.EMPTY_STRING), start, end,  isTumour);
+	}
+	public static void writeUnmappedRecord(BufferedWriter writer, SAMRecord record, String rgId, Integer start, Integer end, boolean isTumour) throws IOException, QSVException {
 
 		int recordStart = record.getMateAlignmentStart();
 
@@ -496,12 +500,11 @@ public class QSVUtil {
 			String readString = record.getReadString();
 
 			if (! QSVUtil.highNCount(readString, 0.2)) {
-
 				StringBuilder sb = new StringBuilder("unmapped,");
-				sb.append(record.getReadName()).append(COLON ).append(record.getReadGroup() != null ? record.getReadGroup().getId() : Constants.EMPTY_STRING).append(Constants.COMMA);
+				sb.append(record.getReadName()).append(COLON ).append(rgId).append(Constants.COMMA);
 				sb.append(record.getReferenceName()).append(Constants.COMMA);
 				sb.append(recordStart).append(Constants.COMMA);
-				sb.append(readString).append(getNewLine());
+				sb.append(readString).append(NEW_LINE);
 
 				writer.write(sb.toString());
 			}

--- a/qsv/test/org/qcmg/qsv/annotate/AnnotateFilterMTTest.java
+++ b/qsv/test/org/qcmg/qsv/annotate/AnnotateFilterMTTest.java
@@ -99,19 +99,19 @@ public class AnnotateFilterMTTest {
 			out.write("input_file=" + testBam.getAbsolutePath()+ Constants.NL);
 			
 			out.write("["+ QSVConstants.DISEASE_SAMPLE +"/size_1]" + Constants.NL);
-		    	out.write("rgid=20110221052813657" + Constants.NL);
-		    	out.write("lower=640" + Constants.NL);
-		    	out.write("upper=2360" + Constants.NL + Constants.NL);
-		    	
-		    	out.write("["+ QSVConstants.CONTROL_SAMPLE +"]" + Constants.NL);
-		    	out.write("name=ND" + Constants.NL);
-		    	out.write("sample_id=ICGC-DBLG-20110506-01-ND" + Constants.NL);
+	    	out.write("rgid=20110221052813657" + Constants.NL);
+	    	out.write("lower=640" + Constants.NL);
+	    	out.write("upper=2360" + Constants.NL + Constants.NL);
+	    	
+	    	out.write("["+ QSVConstants.CONTROL_SAMPLE +"]" + Constants.NL);
+	    	out.write("name=ND" + Constants.NL);
+	    	out.write("sample_id=ICGC-DBLG-20110506-01-ND" + Constants.NL);
 			out.write("input_file=" + controlBam.getAbsolutePath() + Constants.NL);
-		    	out.write("["+ QSVConstants.CONTROL_SAMPLE +"/size_1]" + Constants.NL);
-		    	out.write("rgid=20110221052813657" + Constants.NL);
-		    	out.write("lower=640" + Constants.NL);
-		    	out.write("upper=2360" + Constants.NL + Constants.NL);
-		    	out.write("name=seq_mapped_1" + Constants.NL);
+	    	out.write("["+ QSVConstants.CONTROL_SAMPLE +"/size_1]" + Constants.NL);
+	    	out.write("rgid=20110221052813657" + Constants.NL);
+	    	out.write("lower=640" + Constants.NL);
+	    	out.write("upper=2360" + Constants.NL + Constants.NL);
+	    	out.write("name=seq_mapped_1" + Constants.NL);
 		}
 		return iniFile.getAbsolutePath();
 	}
@@ -123,27 +123,26 @@ public class AnnotateFilterMTTest {
     
     @Test
     public void setupQueryExecutor() throws Exception {
-    		AbstractQueue<List<Chromosome>> readQueue = null;
+    	AbstractQueue<List<Chromosome>> readQueue = null;
 		AbstractQueue<SAMRecord> writeQueue = null;
 		AbstractQueue<SAMRecord> writeClipQueue = null;
 		Thread mainThread = null;
-		CountDownLatch readLatch = null;
 		CountDownLatch fLatch = null;
 		CountDownLatch wGoodLatch = null;
 		
-	   String[] args = getValidOptions();
+	    String[] args = getValidOptions();
 	    Options options = new Options(args);
 	    options.parseIniFile();
 	    String matepairsDir = null;
 		QSVParameters p = new QSVParameters(options, true, testFolder.getRoot().toString() , matepairsDir , new Date(), "test");
 		AnnotateFilterMT afmt = new AnnotateFilterMT(Thread.currentThread(), wGoodLatch, p, null, null, options);
-		afmt.new AnnotationFiltering(readQueue, writeQueue, writeClipQueue, mainThread, readLatch, fLatch, wGoodLatch);
+		afmt.new AnnotationFiltering(readQueue, writeQueue, writeClipQueue, mainThread, fLatch, wGoodLatch);
     	
-	    	try {
-	    		new QueryExecutor("and(Cigar_M > 35, option_SM > 10, MD_mismatch < 3, Flag_DuplicateRead == false)");
-	    	} catch (Exception e) {
-	    		e.printStackTrace();
-	    	}
+    	try {
+    		new QueryExecutor("and(Cigar_M > 35, option_SM > 10, MD_mismatch < 3, Flag_DuplicateRead == false)");
+    	} catch (Exception e) {
+    		e.printStackTrace();
+    	}
     }
 
     @Ignore

--- a/qsv/test/org/qcmg/qsv/annotate/AnnotatorTest.java
+++ b/qsv/test/org/qcmg/qsv/annotate/AnnotatorTest.java
@@ -16,6 +16,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.qcmg.qsv.QSVException;
+import org.qcmg.qsv.util.QSVConstants;
 import org.qcmg.qsv.util.TestUtil;
 
 public class AnnotatorTest {   
@@ -186,6 +188,72 @@ public class AnnotatorTest {
     	sequencingRuns.remove(r);
     }
     
+    @Test
+    public void addNHAttribute() throws QSVException {
+  	    SAMRecord r1 = records.get(0);
+  	    Annotator.setNHAttribute("bwa", r1);
+  	    assertEquals(0, r1.getAttribute(QSVConstants.NH_SHORT));
+  	    Annotator.setNHAttribute("bwa-mem", r1);
+  	    assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+  	    Annotator.setNHAttribute("novoalign", r1);
+  	    assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+  	    
+  	  //singleton, passes vendor check
+        r1 = records.get(1);
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(0, r1.getAttribute(QSVConstants.NH_SHORT));
+        Annotator.setNHAttribute("bwa-mem", r1);
+        assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+        Annotator.setNHAttribute("novoalign", r1);
+        assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+        
+        r1 = records.get(6);
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(0, r1.getAttribute(QSVConstants.NH_SHORT));
+        Annotator.setNHAttribute("bwa-mem", r1);
+        assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+        Annotator.setNHAttribute("novoalign", r1);
+        assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+        
+        r1.setAttribute("X0", Integer.parseInt("12345"));
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(12345, r1.getAttribute(QSVConstants.NH_SHORT));
+        Annotator.setNHAttribute("bwa-mem", r1);
+        assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+        Annotator.setNHAttribute("novoalign", r1);
+        assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+        
+        r1.setAttribute("X0", null);
+        r1.setAttribute("XT", 'X');
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(0, r1.getAttribute(QSVConstants.NH_SHORT));
+        r1.setAttribute("XT", 'M');
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+        r1.setAttribute("XA", "hello world");
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(2, r1.getAttribute(QSVConstants.NH_SHORT));
+        r1.setAttribute("XA", "hello;world");
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(3, r1.getAttribute(QSVConstants.NH_SHORT));
+        r1.setAttribute("XA", "hello;world;a");
+        Annotator.setNHAttribute("bwa", r1);
+        assertEquals(4, r1.getAttribute(QSVConstants.NH_SHORT));
+    }
+    
+    @Test
+    public void addNHAttributeBwaMem() throws QSVException {
+  	    SAMRecord r1 = records.get(6);
+  	    Annotator.setNHAttribute("bwa-mem", r1);
+  	    assertEquals(1, r1.getAttribute(QSVConstants.NH_SHORT));
+  	    
+	  	r1.setAttribute("SA", "toodles");
+	    Annotator.setNHAttribute("bwa-mem", r1);
+	    assertEquals(2, r1.getAttribute(QSVConstants.NH_SHORT));
+	    r1.setAttribute("SA", "t;o;o;d;l;e;s");
+	    Annotator.setNHAttribute("bwa-mem", r1);
+	    assertEquals(8, r1.getAttribute(QSVConstants.NH_SHORT));
+    }    
 
 	@Test
     public void testLMPAnnotate() throws Exception {


### PR DESCRIPTION
fixes #71

Updated `AnnotateFilterMT.addToPairWriter` so that it passes the count to `add2queue` rather than the start position of the record.
This means that every 100000 records, the size of the queue is checked, and if its larger than 500000, it will sleep until less than 500000 before resuming its work.

Also changed the number of filtering threads from 3 to 2. When running in cancer mode, 2 instances of `AnnotateFilterMT` are created, one for the control bam and one for the test bam. This class was creating 6 threads (1 of which was albeit very short-lived), 3 to filter, and 2 to write output (if running in both clip and pair mode, which I believe is the default).
And so, if this process is started with 8 threads overall, the annotate step itself is using 10. By changing the number of filtering threads from 3 to 2, this should come back to 8.

Following on from that, I've also removed the short lived thread that was populating a queue. The queue is now instantiated with what it needs.

Also removed some of the many calls to `SAMRecord.getReadGroup` as this was taking a lot of time (if you look at the SAMRecord source, it is performing a getAttribute call followed by a map lookup).
