### PR TITLE
Qprofiler jun2019

### DIFF
--- a/qpicard/src/org/qcmg/picard/BwaPair.java
+++ b/qpicard/src/org/qcmg/picard/BwaPair.java
@@ -1,0 +1,99 @@
+package org.qcmg.picard;
+
+import htsjdk.samtools.SAMRecord;
+
+public class BwaPair {
+
+
+	public enum Pair{ 
+		F3F5(1), F5F3(2), Inward(3), Outward(4), Others(5); 
+		public int id;
+		Pair(int id){this.id = id;}
+	}
+
+	/**
+	 *  
+	 * @param record a samRrecord
+	 * @return overlapped base counts;
+	 * @return 0 if no overlap, or record with negative tLen value or secondOfPair with zero tLen value
+	 * 
+	 */
+	public static int getOverlapBase(SAMRecord  record) {
+		
+		int tLen = record.getInferredInsertSize();
+		
+		//to avoid double counts, we only select one of Pair: tLen > 0 
+		//that is we only select the one behind the mate: --selected---    ---mated--
+	   	if(tLen < 0) return 0;  
+	   	//two reads not overlapped due to far distance:  --selected---    ---mated---
+	    if(record.getMateAlignmentStart() - record.getAlignmentEnd() > 0) return 0;
+	  	       	
+	   	//pick up first of pair if same strand read and tlen=0
+	    //warning, mate unmapped/different ref, also tLen == 0; default tLen == 0 if the tLen value is not sure. 
+	   	if(tLen == 0 && !record.getFirstOfPairFlag() ) return 0;
+	   	       
+	   	int result  = 0;  	
+		// |--selected--->    <---mated---|  mate end = tLen -1 + read start  
+		if( record.getReadNegativeStrandFlag() != record.getMateNegativeStrandFlag()  ) {  		
+			//if tLen == 0; mateEnd = read.start, Math.min( readEnd, mateEnd ) = read.start; max(starts) = read.start
+			//result = read.start - read.start + 1 = 1
+			// outward pair only one base overlap
+			if( tLen == 0) {  return 1;   } 
+			  			
+			//here tLen >= 0 && mate.start <= read.end 
+			//so here read must forward  and mate reverse 
+			int mateEnd = tLen + record.getAlignmentStart()-1 ;  //reverse mate end
+			int readEnd = record.getAlignmentEnd();   //forward read end
+			
+			result = Math.min( readEnd, mateEnd ) - Math.max(record.getAlignmentStart(), record.getMateAlignmentStart() ) + 1;   
+		}else if( !record.getReadNegativeStrandFlag()) { 
+	   		//|--->    or     |-----> (read end - mate start>0) or       |----->
+	   		//|----->              |----->                      |---> (read end - mate start < 0)  		
+			//if tLen >= 0, then mate_start > read_start; so min_end will be read end if we assue pair with same length.    			
+			result = record.getAlignmentEnd() - record.getMateAlignmentStart() + 1; 			
+		}else {  		
+	  		//<---|    or     <-----| (read end - mate start>0) or       <-----|
+	   		//<-----|             <-----|                      <---| (read end - mate start < 0)
+	   		result = record.getAlignmentEnd() - Math.max( record.getAlignmentStart(), record.getMateAlignmentStart()) + 1;			
+		}
+		
+		return result > 0? result : 0; 	
+	}
+
+	public static Pair getPairType( SAMRecord  record ) {
+	
+		if(record.getReadUnmappedFlag() ||  record.getMateUnmappedFlag() || ! record.getReferenceName().equals(record.getMateReferenceName()) )
+			return Pair.Others;
+		
+		// pair with different orientation 
+		if( record.getReadNegativeStrandFlag() != record.getMateNegativeStrandFlag()  ) {	
+			// |----->  <-------|(read is reverse)
+			if( record.getReadNegativeStrandFlag() && record.getAlignmentStart() >= record.getMateAlignmentStart())
+				return Pair.Inward;
+				
+			// (read is forward)|----->  <-------| 
+			if( !record.getReadNegativeStrandFlag() && record.getAlignmentStart() <= record.getMateAlignmentStart())
+				return Pair.Inward;
+	 					
+			return Pair.Outward;
+		}
+				
+		//non-canonical: pair with same orientation  		
+		//first of pair start
+		int s1 = ( record.getFirstOfPairFlag())? record.getAlignmentStart() : record.getMateAlignmentStart();		
+		//second of pair start
+		int s2 = ( !record.getFirstOfPairFlag())? record.getAlignmentStart() : record.getMateAlignmentStart();
+						    	 		 
+		//F3(s1)|---->  F5(s2)|------>
+		if( !record.getReadNegativeStrandFlag() &&  s1 <= s2)  return Pair.F3F5;
+		//F5(s2)<----|  F3(s1)<------|
+		if( record.getReadNegativeStrandFlag() &&  s1 >= s2)  return Pair.F3F5;		
+		//F5(s2)|---->  F3(s1)|------>
+		if( !record.getReadNegativeStrandFlag() &&  s1 > s2)  return Pair.F5F3;
+		//F3(s1)<----|  F5(s2)<----|
+		if( record.getReadNegativeStrandFlag() &&  s1 < s2)  return Pair.F5F3;
+				
+		return Pair.Others;
+	}
+
+}

--- a/qpicard/test/org/qcmg/picard/BwaPairTest.java
+++ b/qpicard/test/org/qcmg/picard/BwaPairTest.java
@@ -1,0 +1,196 @@
+package org.qcmg.picard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.qcmg.picard.BwaPair.Pair;
+
+import htsjdk.samtools.SAMRecord;
+
+public class BwaPairTest {
+
+	@Test
+	public void isOverlapF3F5() {
+		//read   : first of pair    |---->        or  	   <------|      
+		//read   : second of pair        |---->   or  <-----|    
+		SAMRecord recorda = new SAMRecord(null);
+		// second of mapped pair, both forward 
+		recorda.setFlags(131);		
+		recorda.setAlignmentStart(120);
+		recorda.setMateAlignmentStart(100);
+		assertFalse( BwaPair.getPairType(recorda).equals(Pair.F5F3 ));
+		assertEquals( BwaPair.getPairType(recorda), Pair.F3F5 );
+		
+		//only count overlap on reads with positive tlen
+		recorda.setInferredInsertSize(-20);		//100-120	
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0);
+				
+		//first pair  fully overlap with tLen == 0 since both forward orientation
+		recorda.setCigarString("75M");
+		//first of mapped pair, both forward
+		recorda.setFlags(65);
+		recorda.setAlignmentStart(7480169);
+		recorda.setMateAlignmentStart(7480169);		
+		assertEquals( BwaPair.getPairType(recorda), Pair.F3F5 );
+		//same start first of pair
+		recorda.setInferredInsertSize(0);	
+		assertTrue(BwaPair.getOverlapBase(recorda) == 75); 
+		//same start second of pair
+		recorda.setFlags(179);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0); 
+		
+		//now set to second of mapped pair, both reverse 
+		//ST-E00180:52:H5LNMCCXX:1:1116:24274:5247 113 chr1 27977105 60 5S145M = 27977205 0 
+		recorda.setAlignmentStart(105);
+		recorda.setMateAlignmentStart(205);
+		assertEquals( BwaPair.getPairType(recorda), Pair.F3F5 );
+		
+		//reverse mate end - reverse read end = (120+21-1) - (100 + 21-1) = 20 (just example)
+		recorda.setInferredInsertSize(20);	
+		recorda.setCigarString("121M"); //set cigar, read end is 100 = 25 -1
+		//min_end - max_starts = (105+121-1) - 205, since cigar is nothing
+		assertTrue(BwaPair.getOverlapBase(recorda) == 21); 		 
+		
+		// 105 <------------|225
+		// 		205 <-------|225		
+		recorda.setInferredInsertSize(0);
+		//second of pair overlap ignor if tLen = 0
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0); 
+		//first of pair overlap >= 0 if tLen = 0
+		recorda.setFlags(115);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 21); 
+	}
+
+	@Test
+	public void isOverlapF5F3() {
+		//read   : first of pair 	   |---->  or  <------|      
+		//read   : second of pair  |---->      or  	        <-----|    
+		SAMRecord recorda = new SAMRecord(null);		
+		
+		//second Of Pair with positive tlen, and both forward
+		//ST-E00180:52:H5LNMCCXX:1:2111:15616:38526 129 chr1 56131814 60 150M = 56131947 134 		
+		recorda.setFlags(129);
+		recorda.setInferredInsertSize(134 );
+		recorda.setCigarString("150M");
+		recorda.setAlignmentStart(56131814);
+		recorda.setMateAlignmentStart(56131947);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 56131964 - 56131947); 		
+						
+		//now set to first of mapped pair, both reverse 
+		recorda.setFlags(115);
+		recorda.setAlignmentStart(100);
+		recorda.setMateAlignmentStart(119);
+		//reverse mate end - reverse read end = (119+149) - (100 + 149) + 1 = 20 (just example)
+		recorda.setInferredInsertSize(20);
+		//overlap = read_ends - max_starts = 249 - 119 + 1 = 131
+		assertTrue(BwaPair.getOverlapBase(recorda) == 131);
+		 		
+		//now set to second of mapped pair, both forward 
+		recorda.setFlags(131);
+		assertEquals( BwaPair.getPairType(recorda), Pair.F5F3 );
+		assertTrue(BwaPair.getOverlapBase(recorda) == 131);
+		
+		//when there is no overlap
+		recorda.setMateAlignmentStart(250);
+		recorda.setInferredInsertSize(151);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0);			
+		recorda.setMateAlignmentStart(260);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0);	
+	}
+
+	@Test
+		public void isOverlapInward() {
+	//		PairSummary pairS = new PairSummary(Pair.Inward, true );	
+			// |--------->    <---------|		
+			SAMRecord recorda = new SAMRecord(null);		
+			// second of mapped pair, read reverse, mate forward
+			recorda.setFlags(147);
+			recorda.setAlignmentStart(120);
+			recorda.setMateAlignmentStart(100);
+			assertEquals( BwaPair.getPairType(recorda), Pair.Inward );
+		
+			//100-120 when read length is 0
+			recorda.setInferredInsertSize(-20);	
+			//set overlap  = 0 sinve tLen  < 0
+			assertTrue(BwaPair.getOverlapBase(recorda) == 0);
+			
+			// first of mapped pair, read reverse, mate forward
+			recorda.setFlags(83);
+			//inward disregards first or second
+			assertEquals( BwaPair.getPairType(recorda), Pair.Inward );
+			assertTrue(BwaPair.getOverlapBase(recorda) ==0);
+			 
+	
+			// first of mapped pair, read forward, mate reverse
+			recorda.setFlags(99);
+			recorda.setAlignmentStart(100);
+			recorda.setMateAlignmentStart(120);
+			assertEquals( BwaPair.getPairType(recorda), Pair.Inward );
+			
+			//120-100 when read length is 0
+			recorda.setInferredInsertSize(20);
+			//min_ends - max_starts = 99 -120 (cigar string is nothing)
+			assertTrue(BwaPair.getOverlapBase(recorda) == 0);
+	
+			//120+20-100 when read length is 20
+			recorda.setInferredInsertSize(40);
+			//min_ends - max_starts = 99 -120 (cigar string is nothing)
+			assertTrue(BwaPair.getOverlapBase(recorda) == 0);
+			//min_ends - max_starts = min(140, 125) -120 =25
+			
+			
+			// 100|--------->124
+			//       120 <----|	140			 
+			recorda.setCigarString("25M");
+			//min_ends - max_starts = 124 -120+1 (end = start + cigar.M-1)
+			assertTrue(BwaPair.getOverlapBase(recorda) == 5);
+			assertEquals( BwaPair.getPairType(recorda), Pair.Inward  );
+			
+			// 100|--------------------->149
+			//       120<----|139		
+			// first of mapped pair, read forward, mate reverse
+			recorda.setCigarString("50M");
+			assertEquals( BwaPair.getPairType(recorda), Pair.Inward );
+			//min_ends - max_starts = 140 -120 (read end = start + cigar.M-1 = 149. mateEnd2= readStart-1+tLen = 139)
+			assertTrue(BwaPair.getOverlapBase(recorda) == 20);
+			
+		}
+
+	@Test
+	public void isOverlapOutward() {
+	
+		SAMRecord recorda = new SAMRecord(null);			
+		// <---------|(mate)    |--------->(read)	
+		// first of mapped pair, read forward, mate reverse
+		recorda.setFlags(99);
+		recorda.setAlignmentStart(120);
+		recorda.setMateAlignmentStart(100);
+		assertEquals( BwaPair.getPairType(recorda), Pair.Outward);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 1); //tLen == 0
+		recorda.setInferredInsertSize(-10); //tLen < 0
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0);		
+		
+		//100 <---------------|150 mate
+		//          120|---->124 read
+		//set mate length = 50; tlen = (100+50) - 119 = 31
+		recorda.setInferredInsertSize(31);
+		recorda.setCigarString("5M");
+		assertEquals( BwaPair.getPairType(recorda), Pair.Outward);
+		//min(120-1+31, 120+5-1) - max(100, 120) +1= 5
+		assertTrue(BwaPair.getOverlapBase(recorda) == 5);
+			
+		// 100<----|104(read)    120|--------->(mate)	
+		recorda.setFlags(83);
+		recorda.setAlignmentStart(100);
+		recorda.setMateAlignmentStart(120);
+		assertEquals( BwaPair.getPairType(recorda), Pair.Outward);
+		//since readlength = 5, tlen = 120-104 + 1
+		recorda.setInferredInsertSize(17);
+		//overlap = min_ends - max_start + 1= min(104, 120+?) - 120 + 1
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0);
+		
+	}
+
+}

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -53,7 +53,7 @@ public class BamSummaryReport2 extends SummaryReport {
 
 	public static final Character cc = Character.MAX_VALUE;
 	public static final Integer ii = Integer.MAX_VALUE;	
-	public static final String[] sourceName = new String[]{ "unPaired", XmlUtils.firstOfPair, XmlUtils.secondOfPair };	
+	public static final String[] sourceName = new String[]{ "unPaired", XmlUtils.FIRST_PAIR, XmlUtils.SECOND_PAIR };	
 	
 	private final ConcurrentMap<String, ReadIDSummary> readIdSummary = new ConcurrentHashMap<String, ReadIDSummary>();
 	//SEQ first of pair, secondof pair, unpaired
@@ -129,23 +129,23 @@ public class BamSummaryReport2 extends SummaryReport {
 		summaryToXml(bamReportElement ); 	//Summary for all read group
 		
 		//create bamMertrics
-		bamReportElement = XmlElementUtils.createSubElement( bamReportElement, ProfileType.BAM.getReportName()+ XmlUtils.metrics );
-		createQNAME( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.qname ));	
-		createFLAG( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.flag )  );		
-		createRNAME( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.rname  )); //it is same to RNEXT
-		createPOS( XmlElementUtils.createSubElement( bamReportElement,XmlUtils.pos ));	
-		createMAPQ( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.mapq ));	
-		createCigar( XmlElementUtils.createSubElement( bamReportElement,XmlUtils.cigar ));
-		createTLen( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.tlen ));
-		createSeq( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.seq)  );
-		createQual( XmlElementUtils.createSubElement( bamReportElement,XmlUtils.qual ));
-		tagReport.toXml( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.tag )); 
+		bamReportElement = XmlElementUtils.createSubElement( bamReportElement, ProfileType.BAM.getReportName()+ XmlUtils.METRICS );
+		createQNAME( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.QNAME ));	
+		createFLAG( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.FLAG )  );		
+		createRNAME( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.RNAME  )); //it is same to RNEXT
+		createPOS( XmlElementUtils.createSubElement( bamReportElement,XmlUtils.POS ));	
+		createMAPQ( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.MAPQ ));	
+		createCigar( XmlElementUtils.createSubElement( bamReportElement,XmlUtils.CIGAR ));
+		createTLen( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.TLEN ));
+		createSeq( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.SEQ)  );
+		createQual( XmlElementUtils.createSubElement( bamReportElement,XmlUtils.QUAL ));
+		tagReport.toXml( XmlElementUtils.createSubElement( bamReportElement, XmlUtils.TAG )); 
 
 	}
 	
 	private void createQNAME(Element parent ){
 		 //read name will be under RT Tab	
-		Element rgsElement = XmlElementUtils.createSubElement(parent, XmlUtils.readGroupsEle);
+		Element rgsElement = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUP_ELE);
 		for( Entry<String, ReadIDSummary> entry:  readIdSummary.entrySet()){
 			//"analysis read name pattern for read group
 			Element ele = XmlUtils.createReadGroupNode(rgsElement, entry.getKey());
@@ -155,31 +155,31 @@ public class BamSummaryReport2 extends SummaryReport {
 	
 	private void createFLAG(Element parent ){
 		 if ( null == flagBinaryCount || flagBinaryCount.isEmpty() ) return;
-	     XmlUtils.outputTallyGroup( XmlUtils.createMetricsNode(parent,  null,  null) , "FLAG", flagBinaryCount, true);		
+	     XmlUtils.outputTallyGroup( XmlUtils.createMetricsNode(parent,  null,  null) , "FLAG", flagBinaryCount, true, true);		
 	}
  		
 	//<SEQ>
 	private void createSeq(Element parent){			
 		
 		//sequenceBase	
-		Element ele = XmlUtils.createMetricsNode( parent,  XmlUtils.seqBase,  null); 
+		Element ele = XmlUtils.createMetricsNode( parent,  XmlUtils.SEQ_BASE,  null); 
 		for(int order = 0; order < 3; order++) { 	
 			seqByCycle[order].toXml( ele,  sourceName[order] );
 		}
 				
 		//seqLength
-		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.seqLength,  null); 
+		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.SEQ_LENGTH,  null); 
 		for(int order = 0; order < 3; order++) { 
 			if(seqByCycle[order].getLengthMapFromCycle().isEmpty()) continue;
-			XmlUtils.outputTallyGroup( ele, sourceName[order] ,  seqByCycle[order].getLengthMapFromCycle(), true );		
+			XmlUtils.outputTallyGroup( ele, sourceName[order] ,  seqByCycle[order].getLengthMapFromCycle(), true, true );		
 		}
 		
 		//badBase:  
-		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.badBase,  null); 
+		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.BAD_READ,  null); 
 		XmlUtils.addCommentChild(ele, FastqSummaryReport.badBaseComment );
 		for(int order = 0; order < 3; order++) {
 			if( seqBadReadLineLengths[order].toMap().isEmpty() )continue;
-			XmlUtils.outputTallyGroup( ele, sourceName[order],  seqBadReadLineLengths[order].toMap(), true );			
+			XmlUtils.outputTallyGroup( ele, sourceName[order],  seqBadReadLineLengths[order].toMap(), true , true);			
 		}
 				
 		//1mers is same to baseByCycle
@@ -191,30 +191,30 @@ public class BamSummaryReport2 extends SummaryReport {
 	private void createQual(Element parent){
 		
 		//"count on quality base",
-		Element ele = XmlUtils.createMetricsNode( parent,  XmlUtils.qualBase,  null); 
+		Element ele = XmlUtils.createMetricsNode( parent,  XmlUtils.QUAL_BASE,  null); 
 		for(int order = 0; order < 3; order++) 			
 			qualByCycleInteger[order].toXml(ele, sourceName[order]);
 		
 		//qual length
-		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.qualLength,  null); 
+		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.QUAL_LENGTH,  null); 
 		for(int order = 0; order < 3; order++) {
 			if(qualByCycleInteger[order].getLengthMapFromCycle().isEmpty()) continue;		
-			XmlUtils.outputTallyGroup( ele, sourceName[order],  qualByCycleInteger[order].getLengthMapFromCycle(), true );	
+			XmlUtils.outputTallyGroup( ele, sourceName[order],  qualByCycleInteger[order].getLengthMapFromCycle(), true , true);	
 		}
 		
 		//badBase:  
-		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.badBase,  null); 
+		ele = XmlUtils.createMetricsNode( parent,  XmlUtils.BAD_READ,  null); 
 		XmlUtils.addCommentChild(ele, FastqSummaryReport.badQualComment);
 		for(int order = 0; order < 3; order++) { 
 			if( qualBadReadLineLengths[order].toMap().isEmpty() )continue;
-			XmlUtils.outputTallyGroup( ele, sourceName[order], qualBadReadLineLengths[order].toMap(), true );
+			XmlUtils.outputTallyGroup( ele, sourceName[order], qualBadReadLineLengths[order].toMap(), true , true);
 		}		
 	}	
 	
 	private void createTLen(Element parent){
         // ISIZE
         Set<String> readGroups =  rgSummaries.keySet();     
-        parent = XmlElementUtils.createSubElement(parent, XmlUtils.readGroupsEle );  
+        parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUP_ELE );  
         
         for(String rg : readGroups ) {
         	String rgName = (readGroups.size() == 1 && rg.equals(XmlUtils.UNKNOWN_READGROUP))? null : rg;
@@ -226,19 +226,16 @@ public class BamSummaryReport2 extends SummaryReport {
 	private void createCigar(Element parent) {
 				
         Set<String> readGroups =  rgSummaries.keySet();    
-        parent = XmlElementUtils.createSubElement(parent, XmlUtils.readGroupsEle );  
+        parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUP_ELE );  
         
         for(String rg : readGroups ) {
         	String rgName = (readGroups.size() == 1 && rg.equals(XmlUtils.UNKNOWN_READGROUP))? null : rg;
         	Element ele = XmlUtils.createMetricsNode( XmlUtils.createReadGroupNode(parent, rgName), null, null);
         	
-        	//add comment
-        	String comment = "cigar string from reads including duplicateReads, notProperPairs and unmappedReads but excluding discardedReads (failed, secondary and supplementary).";
-        	ele.appendChild( ele.getOwnerDocument().createComment(comment) );
-        	
+        	//cigar string from reads including duplicateReads, notProperPairs and unmappedReads but excluding discardedReads (failed, secondary and supplementary).
         	Map<String, AtomicLong> tallys = new TreeMap<>(new CigarStringComparator());
         	tallys.putAll(	rgSummaries.get(rg).getCigarCount() );
-        	XmlUtils.outputTallyGroup( ele ,XmlUtils.cigar , tallys, true );	
+        	XmlUtils.outputTallyGroup( ele ,XmlUtils.CIGAR , tallys, true, false );	
         }       
 	}	
 	
@@ -252,7 +249,7 @@ public class BamSummaryReport2 extends SummaryReport {
 			if(cov > 0)
 				tallys.put(chr, new AtomicLong(cov));
 		}
-		XmlUtils.outputTallyGroup( XmlUtils.createMetricsNode(parent, null, null), XmlUtils.rname, tallys, true );
+		XmlUtils.outputTallyGroup( XmlUtils.createMetricsNode(parent, null, null), XmlUtils.RNAME, tallys, true, true );
 	}
 	
 	private void createMAPQ(Element parent) {
@@ -268,19 +265,18 @@ public class BamSummaryReport2 extends SummaryReport {
 					}
 				}
 			//XmlUtils.outputTallyGroup(ele, StringUtils.getJoinedString( QprofilerXmlUtils.mapq, sourceName[j],"_"), tallys, true);	
-			XmlUtils.outputTallyGroup(ele, sourceName[j] , tallys, true);			
+			XmlUtils.outputTallyGroup(ele, sourceName[j] , tallys, true, true);			
 		}	 
 	}
 	
 	private void createPOS(Element parent){
-		parent = XmlElementUtils.createSubElement( parent, XmlUtils.readGroupsEle );
+		parent = XmlElementUtils.createSubElement( parent, XmlUtils.READGROUP_ELE );
 		
 		for( String rg :  rgSummaries.keySet()) {
 			ReadGroupSummary summary = rgSummaries.get(rg);			
 			Element ele = XmlUtils.createMetricsNode(XmlUtils.createReadGroupNode(parent, rg)  , null, new Pair(ReadGroupSummary.READ_COUNT, summary.getReadCount()));			
 			rNamePosition.keySet().stream().sorted(new ReferenceNameComparator()).forEach( ref-> 
-				XmlUtils.outputBins(ele, ref, rNamePosition.get(ref).getCoverageByRg(rg), PositionSummary.BUCKET_SIZE));
-		
+				XmlUtils.outputBins(ele, ref, rNamePosition.get(ref).getCoverageByRg(rg), PositionSummary.BUCKET_SIZE));		
 		}
 	}
 
@@ -350,37 +346,38 @@ public class BamSummaryReport2 extends SummaryReport {
 	}
 		
 	private void summaryToXml( Element parent ){
-		Element summaryElement = XmlElementUtils.createSubElement(parent, XmlUtils.summary);
+		Element summaryElement = XmlElementUtils.createSubElement(parent, XmlUtils.BAM_SUMMARY);
 		
 		long  discardReads = 0,maxBases = 0,duplicateBase = 0, unmappedBase = 0, noncanonicalBase = 0;
 		long  trimBases = 0,overlappedBase = 0, softClippedBase = 0, hardClippedBase = 0;
 		long  readCount = 0, lostBase=0; //baseCount = 0,
-		Element rgsElement = XmlElementUtils.createSubElement(summaryElement, XmlUtils.readGroupsEle);		
+		Element rgsElement = XmlElementUtils.createSubElement(summaryElement, XmlUtils.READGROUP_ELE);		
 		for(ReadGroupSummary summary: rgSummaries.values()) { 					
-				try {	
-					
-					Element rgEle = XmlUtils.createReadGroupNode(rgsElement, summary.getReadGroupId());
-					summary.readSummary2Xml(rgEle);
-					summary.pairSummary2Xml(rgEle); 
-					//presummary
-					lostBase += summary.getDuplicateBase() + summary.getUnmappedBase() + summary.getnotPoperPairedBase() + 
-							summary.getTrimmedBase() + summary.getOverlappedBase() + summary.getSoftClippedBase() + summary.getHardClippedBase();
-					maxBases += summary.getReadCount() * summary.getMaxReadLength();						
-					duplicateBase += summary.getDuplicateBase();
-					unmappedBase += summary.getUnmappedBase();
-					noncanonicalBase += summary.getnotPoperPairedBase();
-					trimBases += summary.getTrimmedBase();
-					overlappedBase += summary.getOverlappedBase();
-					softClippedBase += summary.getSoftClippedBase();
-					hardClippedBase += summary.getHardClippedBase();
-					
-					discardReads += summary.getDiscardreads();
-					readCount += summary.getReadCount();
-				} catch (Exception e) {	logger.warn(e.getMessage()); }
-			}
+			try {	
+				
+				Element rgEle = XmlUtils.createReadGroupNode(rgsElement, summary.getReadGroupId());
+				summary.readSummary2Xml(rgEle);
+				summary.pairSummary2Xml(rgEle); 
+				//presummary
+				lostBase += summary.getDuplicateBase() + summary.getUnmappedBase() + summary.getnotPoperPairedBase() + 
+						summary.getTrimmedBase() + summary.getOverlappedBase() + summary.getSoftClippedBase() + summary.getHardClippedBase();
+				maxBases += summary.getReadCount() * summary.getMaxReadLength();						
+				duplicateBase += summary.getDuplicateBase();
+				unmappedBase += summary.getUnmappedBase();
+				noncanonicalBase += summary.getnotPoperPairedBase();
+				trimBases += summary.getTrimmedBase();
+				overlappedBase += summary.getOverlappedBase();
+				softClippedBase += summary.getSoftClippedBase();
+				hardClippedBase += summary.getHardClippedBase();
+				
+				discardReads += summary.getDiscardreads();
+				readCount += summary.getReadCount();
+			} catch (Exception e) {	logger.warn(e.getMessage()); }
+		}
 	
 		//overall readgroup 
-		Element metricsE = XmlUtils.createMetricsNode(summaryElement, "summary1", new Pair( ReadGroupSummary.READ_COUNT, getRecordsInputed()));						
+		//Element metricsE = XmlUtils.createMetricsNode(summaryElement, "summary1", new Pair( ReadGroupSummary.READ_COUNT, getRecordsInputed()));	
+		Element metricsE = XmlUtils.createMetricsNode(summaryElement, XmlUtils.OVERALL, null);	
 		XmlUtils.outputValueNode(metricsE, "Number of cycles with greater than 1% mismatches",
 				CycleSummaryUtils.getBigMDCycleNo(tagReport.tagMDMismatchByCycle, (float) 0.01, tagReport.allReadsLineLengths));		
 				
@@ -402,13 +399,16 @@ public class BamSummaryReport2 extends SummaryReport {
 		XmlUtils.outputValueNode(metricsE, "Total reads including discarded reads", getRecordsInputed());	
 		
 		
-		metricsE = XmlUtils.createMetricsNode(summaryElement, "summary2", new Pair( ReadGroupSummary.READ_COUNT, getRecordsInputed()));		
+		metricsE = XmlUtils.createMetricsNode(summaryElement, XmlUtils.ALL_BASE_LOST, null);		
 		
-		XmlUtils.outputValueNode(metricsE, ReadGroupSummary.READ_COUNT, readCount, "readCount: includes duplicateReads, notProperPairs and unmappedReads but excludes discardedReads (failed, secondary and supplementary)" );	
-		XmlUtils.outputValueNode(metricsE, ReadGroupSummary.BASE_COUNT, maxBases, "baseCount: the sum of baseCount from all read group" );	
-
-		double percentage = (maxBases == 0)? 0: 100 * (double) lostBase /  maxBases ;				
-		XmlUtils.outputValueNode(metricsE, ReadGroupSummary.BASE_LOST_COUNT + "_" +ReadGroupSummary.BASE_LOST_PERCENT,  percentage , "basePercent: basesLost / baseCount, basesLost: the sum of basesLost from all read group, ");	
+		//readCount: includes duplicateReads, notProperPairs and unmappedReads but excludes discardedReads (failed, secondary and supplementary).
+		XmlUtils.outputValueNode(metricsE, ReadGroupSummary.READ_COUNT, readCount);	
+		//baseCount: the sum of baseCount from all read group
+		XmlUtils.outputValueNode(metricsE, ReadGroupSummary.BASE_COUNT, maxBases);	
+		
+		double percentage = (maxBases == 0)? 0: 100 * (double) lostBase /  maxBases ;
+		//basePercent: basesLost / baseCount, basesLost: the sum of basesLost from all read group
+		XmlUtils.outputValueNode(metricsE, ReadGroupSummary.BASE_LOST_COUNT + "_" +ReadGroupSummary.BASE_LOST_PERCENT,  percentage);	
 
 		percentage = (maxBases == 0)? 0: 100 * (double) duplicateBase /  maxBases ;				
 		XmlUtils.outputValueNode(metricsE, ReadGroupSummary.NODE_DUPLICATE + "_" +ReadGroupSummary.BASE_LOST_PERCENT,  percentage );	

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -145,7 +145,7 @@ public class BamSummaryReport2 extends SummaryReport {
 	
 	private void createQNAME(Element parent ){
 		 //read name will be under RT Tab	
-		Element rgsElement = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUP_ELE);
+		Element rgsElement = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUPS);
 		for( Entry<String, ReadIDSummary> entry:  readIdSummary.entrySet()){
 			//"analysis read name pattern for read group
 			Element ele = XmlUtils.createReadGroupNode(rgsElement, entry.getKey());
@@ -214,7 +214,7 @@ public class BamSummaryReport2 extends SummaryReport {
 	private void createTLen(Element parent){
         // ISIZE
         Set<String> readGroups =  rgSummaries.keySet();     
-        parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUP_ELE );  
+        parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUPS );  
         
         for(String rg : readGroups ) {
         	String rgName = (readGroups.size() == 1 && rg.equals(XmlUtils.UNKNOWN_READGROUP))? null : rg;
@@ -226,7 +226,7 @@ public class BamSummaryReport2 extends SummaryReport {
 	private void createCigar(Element parent) {
 				
         Set<String> readGroups =  rgSummaries.keySet();    
-        parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUP_ELE );  
+        parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUPS );  
         
         for(String rg : readGroups ) {
         	String rgName = (readGroups.size() == 1 && rg.equals(XmlUtils.UNKNOWN_READGROUP))? null : rg;
@@ -270,7 +270,7 @@ public class BamSummaryReport2 extends SummaryReport {
 	}
 	
 	private void createPOS(Element parent){
-		parent = XmlElementUtils.createSubElement( parent, XmlUtils.READGROUP_ELE );
+		parent = XmlElementUtils.createSubElement( parent, XmlUtils.READGROUPS );
 		
 		for( String rg :  rgSummaries.keySet()) {
 			ReadGroupSummary summary = rgSummaries.get(rg);			
@@ -351,7 +351,7 @@ public class BamSummaryReport2 extends SummaryReport {
 		long  discardReads = 0,maxBases = 0,duplicateBase = 0, unmappedBase = 0, noncanonicalBase = 0;
 		long  trimBases = 0,overlappedBase = 0, softClippedBase = 0, hardClippedBase = 0;
 		long  readCount = 0, lostBase=0; //baseCount = 0,
-		Element rgsElement = XmlElementUtils.createSubElement(summaryElement, XmlUtils.READGROUP_ELE);		
+		Element rgsElement = XmlElementUtils.createSubElement(summaryElement, XmlUtils.READGROUPS);		
 		for(ReadGroupSummary summary: rgSummaries.values()) { 					
 			try {	
 				

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/TagSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/TagSummaryReport2.java
@@ -97,7 +97,7 @@ public class TagSummaryReport2 {
 				}
 				String name = BamSummaryReport2.sourceName[order] + strand; 
 				
-				XmlUtils.outputTallyGroup(ele,  name, mdRefAltLengthsString, true);				
+				XmlUtils.outputTallyGroup(ele,  name, mdRefAltLengthsString, true, true);				
 			}		
 		}			
 		

--- a/qprofiler2/src/org/qcmg/qprofiler2/cohort/CohortSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/cohort/CohortSummaryReport.java
@@ -76,7 +76,7 @@ public class CohortSummaryReport extends SummaryReport {
 			String titv = "-" ;
 			 
 			//for(Element ele :QprofilerXmlUtils.getOffspringElementByTagName(report, SampleSummary.variantType)){
-			for(Element ele :XmlElementUtils.getOffspringElementByTagName(report, XmlUtils.METRICS_ELE)){
+			for(Element ele :XmlElementUtils.getOffspringElementByTagName(report, XmlUtils.SEQUENCE_METRICS)){
 				//record counts and dbsnp for all type variants
 				String type = ele.getAttribute(XmlUtils.NAME);	
 				int count = Integer.parseInt(ele.getAttribute("count"));
@@ -91,7 +91,7 @@ public class CohortSummaryReport extends SummaryReport {
 					titv = e1.getTextContent();	
 					
 					//ti
-					Optional<Element> streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP_ELE).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transitions)).findFirst();				
+					Optional<Element> streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transitions)).findFirst();				
 					if( streams.isPresent()   ) {
 						List<Integer> sums = new ArrayList<>();						
 						XmlElementUtils.getChildElementByTagName(streams.get(), XmlUtils.TALLY).stream()
@@ -100,7 +100,7 @@ public class CohortSummaryReport extends SummaryReport {
 					} 
 					
 					//tv
-					streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP_ELE).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transversions)).findFirst() ;				
+					streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transversions)).findFirst() ;				
 					if( streams.isPresent() ) {
 						List<Integer> sums = new ArrayList<>();
 						XmlElementUtils.getChildElementByTagName(streams.get(), XmlUtils.TALLY).stream()

--- a/qprofiler2/src/org/qcmg/qprofiler2/cohort/CohortSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/cohort/CohortSummaryReport.java
@@ -29,7 +29,7 @@ public class CohortSummaryReport extends SummaryReport {
 	
 	CohortSummaryReport(File fxml, Element sampleNode) throws IOException{
 		this.file = fxml.getCanonicalPath();
-		this.sampleId = sampleNode.getAttribute(XmlUtils.sName);
+		this.sampleId = sampleNode.getAttribute(XmlUtils.NAME);
 		
 		for( Element ele : XmlElementUtils.getChildElementByTagName( sampleNode, SampleSummary.report ) ) {
 			Category cat = new Category( ele.getAttribute(SampleSummary.values), ele ); 
@@ -76,35 +76,35 @@ public class CohortSummaryReport extends SummaryReport {
 			String titv = "-" ;
 			 
 			//for(Element ele :QprofilerXmlUtils.getOffspringElementByTagName(report, SampleSummary.variantType)){
-			for(Element ele :XmlElementUtils.getOffspringElementByTagName(report, XmlUtils.metricsEle)){
+			for(Element ele :XmlElementUtils.getOffspringElementByTagName(report, XmlUtils.METRICS_ELE)){
 				//record counts and dbsnp for all type variants
-				String type = ele.getAttribute(XmlUtils.sName);	
+				String type = ele.getAttribute(XmlUtils.NAME);	
 				int count = Integer.parseInt(ele.getAttribute("count"));
 				variantsCounts.put(type, count );
 				
-				Element e1 = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.sValue).stream().filter(e -> e.getAttribute(XmlUtils.sName).equals(SampleSummary.dbSNP)).findFirst().get();				
+				Element e1 = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VALUE).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.dbSNP)).findFirst().get();				
 				int db = Integer.parseInt( e1.getTextContent() );
 				dbSnpCounts.put(type, db);
 				
 				if(type.equals(SVTYPE.SNP.toVariantType())){
-					e1 = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.sValue).stream().filter(e -> e.getAttribute(XmlUtils.sName).equals(SampleSummary.tiTvRatio)).findFirst().get();				
+					e1 = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VALUE).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.tiTvRatio)).findFirst().get();				
 					titv = e1.getTextContent();	
 					
 					//ti
-					Optional<Element> streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.variableGroupEle).stream().filter(e -> e.getAttribute(XmlUtils.sName).equals(SampleSummary.transitions)).findFirst();				
+					Optional<Element> streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP_ELE).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transitions)).findFirst();				
 					if( streams.isPresent()   ) {
 						List<Integer> sums = new ArrayList<>();						
-						XmlElementUtils.getChildElementByTagName(streams.get(), XmlUtils.sTally).stream()
-							.forEach( e ->   sums.add(  Integer.parseInt(e.getAttribute(XmlUtils.sCount)) ) );
+						XmlElementUtils.getChildElementByTagName(streams.get(), XmlUtils.TALLY).stream()
+							.forEach( e ->   sums.add(  Integer.parseInt(e.getAttribute(XmlUtils.COUNT)) ) );
 						ti = sums.stream().mapToInt(i -> i.intValue()).sum();
 					} 
 					
 					//tv
-					streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.variableGroupEle).stream().filter(e -> e.getAttribute(XmlUtils.sName).equals(SampleSummary.transversions)).findFirst() ;				
+					streams = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP_ELE).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transversions)).findFirst() ;				
 					if( streams.isPresent() ) {
 						List<Integer> sums = new ArrayList<>();
-						XmlElementUtils.getChildElementByTagName(streams.get(), XmlUtils.sTally).stream()
-							.forEach( e ->   sums.add(  Integer.parseInt(e.getAttribute(XmlUtils.sCount)) ) );
+						XmlElementUtils.getChildElementByTagName(streams.get(), XmlUtils.TALLY).stream()
+							.forEach( e ->   sums.add(  Integer.parseInt(e.getAttribute(XmlUtils.COUNT)) ) );
 						tv = sums.stream().mapToInt(i -> i.intValue()).sum();
 					}
 					

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -51,22 +51,22 @@ public class FastqSummaryReport extends SummaryReport {
 	@Override
 	public void toXml(Element parent1) {		
 		Element parent = init( parent1, ProfileType.FASTQ, null, null );
-		parent = XmlElementUtils.createSubElement( parent, ProfileType.FASTQ.getReportName() +  XmlUtils.metrics   );
+		parent = XmlElementUtils.createSubElement( parent, ProfileType.FASTQ.getReportName() +  XmlUtils.METRICS   );
 		
 		//header line:"analysis read name pattern for read group
-		Element element =   XmlElementUtils.createSubElement(parent, XmlUtils.qname ) ;							
+		Element element =   XmlElementUtils.createSubElement(parent, XmlUtils.QNAME ) ;							
 		readHeaderSummary.toXml(element );		
 
 		//seq								 			
-		element =   XmlElementUtils.createSubElement(parent,XmlUtils.seq  ) ;
-		Element ele = XmlUtils.createMetricsNode( element, XmlUtils.seqBase , null); 
-		seqByCycle.toXml( ele, XmlUtils.seqBase);	
+		element =   XmlElementUtils.createSubElement(parent,XmlUtils.SEQ  ) ;
+		Element ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_BASE , null); 
+		seqByCycle.toXml( ele, XmlUtils.SEQ_BASE);	
 		
-		ele = XmlUtils.createMetricsNode( element, XmlUtils.seqLength , null); 
-		XmlUtils.outputTallyGroup( ele, XmlUtils.seqLength, seqByCycle.getLengthMapFromCycle(), true );	
+		ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_LENGTH , null); 
+		XmlUtils.outputTallyGroup( ele, XmlUtils.SEQ_LENGTH, seqByCycle.getLengthMapFromCycle(), true, true );	
 		
-		ele = XmlUtils.createMetricsNode( element, XmlUtils.badBase, null);
-		XmlUtils.outputTallyGroup( ele, XmlUtils.badBase,   seqBadReadLineLengths.toMap(), true );	
+		ele = XmlUtils.createMetricsNode( element, XmlUtils.BAD_READ, null);
+		XmlUtils.outputTallyGroup( ele, XmlUtils.BAD_READ,   seqBadReadLineLengths.toMap(), true, true );	
 		XmlUtils.addCommentChild(ele, FastqSummaryReport.badBaseComment );
 		
 		//1mers is same to baseByCycle
@@ -75,18 +75,17 @@ public class FastqSummaryReport extends SummaryReport {
 		}
 		
 		//QUAL
-		element = XmlElementUtils.createSubElement(parent, XmlUtils.qual) ;
-		ele = XmlUtils.createMetricsNode( element, XmlUtils.qualBase , null); 
-		qualByCycleInteger.toXml(element,XmlUtils.qualBase) ;
+		element = XmlElementUtils.createSubElement(parent, XmlUtils.QUAL) ;
+		ele = XmlUtils.createMetricsNode( element, XmlUtils.QUAL_BASE , null); 
+		qualByCycleInteger.toXml(element,XmlUtils.QUAL_BASE) ;
 		
-		ele = XmlUtils.createMetricsNode( element, XmlUtils.qualLength, null) ;
-		XmlUtils.outputTallyGroup( ele,  XmlUtils.qualLength,  qualByCycleInteger.getLengthMapFromCycle(), true ) ;	
+		ele = XmlUtils.createMetricsNode( element, XmlUtils.QUAL_LENGTH, null) ;
+		XmlUtils.outputTallyGroup( ele,  XmlUtils.QUAL_LENGTH,  qualByCycleInteger.getLengthMapFromCycle(), true, true ) ;	
 		
-		ele = XmlUtils.createMetricsNode( element,  XmlUtils.badBase, null) ;
-		XmlUtils.outputTallyGroup( ele,  XmlUtils.badBase ,  qualBadReadLineLengths.toMap(), false ) ;
+		ele = XmlUtils.createMetricsNode( element,  XmlUtils.BAD_READ, null) ;
+		XmlUtils.outputTallyGroup( ele,  XmlUtils.BAD_READ ,  qualBadReadLineLengths.toMap(), false, true ) ;
 		XmlUtils.addCommentChild(ele, FastqSummaryReport.badQualComment );
-		
-		
+			
  	}
 	
 	/**

--- a/qprofiler2/src/org/qcmg/qprofiler2/report/SummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/report/SummaryReport.java
@@ -91,16 +91,22 @@ public abstract class SummaryReport {
 		//xml reorganise
 		element.setAttribute("startTime", getStartTime());
 		element.setAttribute("finishTime", getFinishTime());
+		logger.info("retriving checksum for input file...");
+		element.setAttribute("file_checksum", FileUtils.getFileCheckSum(getFileName()));
+		logger.info("checksum is done!");
 				
 		//don't list records_parsed on xml for BAM type
-		if(!reportType.equals(ProfileType.BAM))
+		if(!reportType.equals(ProfileType.BAM)) {
 			element.setAttribute("records_parsed", String.format("%,d", getRecordsInputed()) );	
-		if(reportType.equals(ProfileType.VCF  ))
-			element.setAttribute("file_checksum", FileUtils.getFileCheckSum(getFileName()));
-		if (null != maxRecords)
+		}
+		
+		
+		if (null != maxRecords) {
 			element.setAttribute("max_no_of_records", String.format("%,d",maxRecords) );
-		if (null != noOfDuplicates)
+		}
+		if (null != noOfDuplicates) {
 			element.setAttribute("duplicate_records", String.format("%,d", noOfDuplicates));
+		}
 		
 		return element;
 	}

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadGroupSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadGroupSummary.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.qcmg.common.model.QCMGAtomicLongArray;
 import org.qcmg.common.util.Pair;
+import org.qcmg.picard.BwaPair;
 import org.qcmg.qprofiler2.util.SummaryReportUtils;
 import org.qcmg.qprofiler2.util.XmlUtils;
 import org.w3c.dom.Element;
@@ -146,7 +147,7 @@ public class ReadGroupSummary {
 		
 		//check pair orientaiton, tLen, mate
 		if(record.getReadPairedFlag()) {
-			PairSummary.Pair pairType = PairSummary.getPairType(record);
+			BwaPair.Pair pairType = BwaPair.getPairType(record);
 			boolean isProper = record.getProperPairFlag();
 			int key = isProper? pairType.id   :  pairType.id * -1;	
 			pairCategory.computeIfAbsent(key, e-> new PairSummary( pairType, isProper)).parse(record);
@@ -229,7 +230,7 @@ public class ReadGroupSummary {
 				
 		//create node for overall	
 		rgElement = XmlUtils.createMetricsNode(parent,"reads", new Pair(READ_COUNT, inputReadCounts.get()));		
-		Element ele = XmlUtils.createGroupNode(rgElement, XmlUtils.discardReads );
+		Element ele = XmlUtils.createGroupNode(rgElement, XmlUtils.DISCARD_READS );
 		XmlUtils.outputValueNode(ele, "supplementaryAlignmentCount", supplementary.get());
 		XmlUtils.outputValueNode(ele, "secondaryAlignmentCount", secondary.get());
 		XmlUtils.outputValueNode(ele, "failedVendorQualityCount",failedVendorQuality.get()  );
@@ -291,11 +292,11 @@ public class ReadGroupSummary {
 		for(PairSummary p : pairCategory.values()) {
 			String name = p.isProperPair? "tLenInProperPair" : "tLenInNotProperPair";
 			Element ele = metricEs.computeIfAbsent(name,  k-> XmlUtils.createMetricsNode( parent, k, null )); 
-			XmlUtils.outputTallyGroup( ele, p.type.name(), p.getTLENCounts().toMap(), false );  
+			XmlUtils.outputTallyGroup( ele, p.type.name(), p.getTLENCounts().toMap(), false, true );  
 			
 			name = p.isProperPair? "overlapBaseInProperPair" : "overlapBaseInNotProperPair";
 			ele = metricEs.computeIfAbsent(name,  k-> XmlUtils.createMetricsNode( parent, k, null )); 			
-			XmlUtils.outputTallyGroup( ele, p.type.name(), p.getoverlapCounts().toMap(), false ); 							
+			XmlUtils.outputTallyGroup( ele, p.type.name(), p.getoverlapCounts().toMap(), false , true); 							
 		}
 	}
 	

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
@@ -296,16 +296,16 @@ static final int MAX_POOL_SIZE = 500;
 	public void toXml(Element ele){		
 		
 		Element element = XmlUtils.createMetricsNode(ele, "qnameInfo", new Pair(ReadGroupSummary.READ_COUNT, getInputReadNumber()));
-		XmlUtils.outputTallyGroup( element,  "QNAME Format", patterns , false );
+		XmlUtils.outputTallyGroup( element,  "QNAME Format", patterns , false , true);
 		for(int i = 0; i < columns.length; i ++) {
 			if(columns[i].size() > 0)
-				XmlUtils.outputTallyGroup( element,  (i+1)+"thColumnSplitByColon", columns[i] , false );
+				XmlUtils.outputTallyGroup( element,  (i+1)+"thColumnSplitByColon", columns[i] , false, true );
 		}
 				
-		XmlUtils.outputTallyGroup( element,  "Instrument", instruments , false );
-		XmlUtils.outputTallyGroup( element,  "Flow Cell Id", flowCellIds , false );
-		XmlUtils.outputTallyGroup( element,  "Run Id", runIds , false );
-		XmlUtils.outputTallyGroup( element,  "Flow Cell Lane", flowCellLanes , false );
+		XmlUtils.outputTallyGroup( element,  "Instrument", instruments , false , true);
+		XmlUtils.outputTallyGroup( element,  "Flow Cell Id", flowCellIds , false , true);
+		XmlUtils.outputTallyGroup( element,  "Run Id", runIds , false , true);
+		XmlUtils.outputTallyGroup( element,  "Flow Cell Lane", flowCellLanes , false , true);
 		XmlUtils.outputTallyGroupWithSize(element,  "Tile Number", tileNumbers, TALLY_SIZE);
 		XmlUtils.outputTallyGroupWithSize( element,  "Pair infomation", pairs, TALLY_SIZE);
 		XmlUtils.outputTallyGroupWithSize( element,  "Index", indexes , TALLY_SIZE);

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/SampleSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/SampleSummary.java
@@ -138,7 +138,7 @@ public class SampleSummary {
 			AtomicLong totalAL = summary.get( type.name());
 			if( null == totalAL) continue;						
 						
-			Element reportE1  = XmlUtils.createMetricsNode( reportE,  type.toVariantType(),new Pair(XmlUtils.sCount, totalAL) );
+			Element reportE1  = XmlUtils.createMetricsNode( reportE,  type.toVariantType(),new Pair(XmlUtils.COUNT, totalAL) );
 			String key =  type.name() + "dbSNP";
 			XmlUtils.outputValueNode(reportE1, "inDBSNP", summary .containsKey(key)? summary.get(key).get() : 0 ); 
 						
@@ -160,8 +160,8 @@ public class SampleSummary {
 				double rate = sumTi * sumTv == 0 ? 0 : (double) sumTi/sumTv;			 
 				XmlUtils.outputValueNode(reportE1, tiTvRatio,  rate );
 				 
-				XmlUtils.outputTallyGroup(reportE1 ,  transitions,  tiFreq, true);
-				XmlUtils.outputTallyGroup(reportE1 ,  transversions,  tvFreq, true);
+				XmlUtils.outputTallyGroup(reportE1 ,  transitions,  tiFreq, true, true);
+				XmlUtils.outputTallyGroup(reportE1 ,  transversions,  tvFreq, true, true);
 			}				
 						
 			Map<String, AtomicLong> gtvalues = new HashMap<>();
@@ -170,7 +170,7 @@ public class SampleSummary {
 				if(gtv != null) gtvalues.put( gt, gtv );				
 			}
 
-			XmlUtils.outputTallyGroup( reportE1 , genotype, gtvalues, true );
+			XmlUtils.outputTallyGroup( reportE1 , genotype, gtvalues, true , true);
 
 			QCMGAtomicLongArray array = summaryAD.get(type.name());
 			if(array != null ) {					

--- a/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
@@ -27,7 +27,7 @@ public class XmlUtils {
 	public static final String READGROUPS ="readGroups";
 	public static final String VARIABLE_GROUP = "variableGroup";
 	public static final String VALUE = "value";
-	public static final String COLSED_BIN = "closedBin";
+	public static final String CLOSED_BIN = "closedBin";
 	public static final String SEQUENCE_METRICS = "sequence" + METRICS;
 	public static final String NAME = "name";
 	public static final String COUNT = "count";
@@ -223,7 +223,7 @@ public class XmlUtils {
     	Element ele;
     	for (Entry<Integer, AtomicLong> entry : bins.entrySet() ) {
     		if(entry.getValue().get() > 0) {
-    			ele = XmlElementUtils.createSubElement(cateEle, COLSED_BIN);
+    			ele = XmlElementUtils.createSubElement(cateEle, CLOSED_BIN);
     	    	ele.setAttribute(START,  String.valueOf(entry.getKey() * binSize));   	    	
     	    	ele.setAttribute(COUNT, String.valueOf(entry.getValue().get())); 			
     		}  	    		

--- a/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
@@ -24,11 +24,11 @@ public class XmlUtils {
 	public static final String UNKNOWN_READGROUP = "unkown_readgroup_id";	
 	
 	public static final String METRICS = "Metrics";
-	public static final String READGROUP_ELE ="readGroups";
-	public static final String VARIABLE_GROUP_ELE = "variableGroup";
+	public static final String READGROUPS ="readGroups";
+	public static final String VARIABLE_GROUP = "variableGroup";
 	public static final String VALUE = "value";
 	public static final String COLSED_BIN = "closedBin";
-	public static final String METRICS_ELE = "sequence" + METRICS;
+	public static final String SEQUENCE_METRICS = "sequence" + METRICS;
 	public static final String NAME = "name";
 	public static final String COUNT = "count";
 	public static final String PERCENT = "percent";
@@ -37,8 +37,8 @@ public class XmlUtils {
 	public static final String START = "start";
 	public static final String END = "end";
 	public static final String CYCLE = "cycle";
-	public static final String BASE_CYCLE_ELE = "baseCycle";
-	public static final String RECORD_ELE ="record";
+	public static final String BASE_CYCLE = "baseCycle";
+	public static final String RECORD ="record";
 	public static final String DISCARD_READS = "discardedReads";		
 	public static final String SEQ_BASE = "seqBase";
 	public static final String SEQ_LENGTH = "seqLength";
@@ -95,7 +95,7 @@ public class XmlUtils {
                     element.setAttribute( cateName, cateValue);
                     element.setAttribute( "description", des);
                     for(T re: records) {
-                            Element elechild = XmlElementUtils.createSubElement(parent, RECORD_ELE );
+                            Element elechild = XmlElementUtils.createSubElement(parent, RECORD );
                             //set txt content
                             if(re instanceof String)
                                     elechild.setTextContent((String)re);
@@ -158,7 +158,7 @@ public class XmlUtils {
 	 * @return
 	 */       
     public static Element createMetricsNode(Element parent,  String name, Pair<?, ?> totalCounts ) {	
-    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.METRICS_ELE );
+    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.SEQUENCE_METRICS );
     						
 		if( totalCounts != null ) ele.setAttribute((String)totalCounts.getLeft(), String.valueOf( totalCounts.getRight()));		 
 		if(name != null) ele.setAttribute( NAME, name );
@@ -174,7 +174,7 @@ public class XmlUtils {
 	 * @return
 	 */
     public static Element createGroupNode(Element parent, String name) {
-    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.VARIABLE_GROUP_ELE );	
+    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.VARIABLE_GROUP );	
     	ele.setAttribute( NAME, name); 
     	return ele;
     }
@@ -192,7 +192,7 @@ public class XmlUtils {
 	 * @return
 	 */
     public static Element createCycleNode(Element parent, String name) {
-    	Element ele = XmlElementUtils.createSubElement( parent,  BASE_CYCLE_ELE );	
+    	Element ele = XmlElementUtils.createSubElement( parent,  BASE_CYCLE );	
     	ele.setAttribute( CYCLE, name); 
     	return ele;
     }
@@ -215,18 +215,6 @@ public class XmlUtils {
     	ele.setTextContent( v );    
     	return ele;
     }
-    /**
-     * utput <value name="name" note="comment">value</value>
-     * @param parent
-     * @param name
-     * @param value
-     * @param comment
-     */
-//    public static <T> void outputValueNode(Element parent, String name, Number value, String comment) {   
-//    	parent.insertBefore( parent.getOwnerDocument().createComment( comment ), parent.getFirstChild() ); 
-//    	outputValueNode( parent,  name,  value);
-//    	    	    	 
-//    }
     
     public static Element outputBins( Element parent, String name, Map<Integer, AtomicLong> bins, int binSize) {
     	
@@ -289,7 +277,7 @@ public class XmlUtils {
     public static <T>  void outputCycleTallyGroup( Element parent, String name, Map<T, AtomicLong> tallys, boolean hasPercent ) {
     	if(tallys == null || tallys.isEmpty()) return;
     	       	
-    	Element ele = XmlElementUtils.createSubElement( parent,  BASE_CYCLE_ELE );	
+    	Element ele = XmlElementUtils.createSubElement( parent,  BASE_CYCLE );	
     	ele.setAttribute( CYCLE, name); 
  
     	outputTallys(  ele,  name,  tallys,  hasPercent );  

--- a/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
@@ -20,47 +20,49 @@ import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMSequenceRecord;
 
 public class XmlUtils {
-	public final static String OTHER = "others";
-	
-	public static final String metrics = "Metrics";
-	public static final String readGroupsEle ="readGroups";
-	public static final String variableGroupEle = "variableGroup";
-	public static final String sValue = "value";
-	public static final String sBin = "closedBin";
-	public static final String metricsEle = "sequence" + metrics;
-	public static final String sName = "name";
-	public static final String sCount = "count";
-	public static final String sPercent = "percent";
-	public static final String sTally = "tally";
-	public static final String sTallyCount = "tallyCount";
-	public static final String sStart = "start";
-	public static final String sEnd = "end";
-	public static final String Scycle = "cycle";
-	public static final String baseCycleEle = "baseCycle";
-	public static final String recordEle ="record";
-	public static final String discardReads = "discardedReads";
-		
-	public static final String seqBase = "seqBase";
-	public static final String seqLength = "seqLength";
-	public static final String badBase = "badBase";
-	public static final String qualBase = "qualBase";
-	public static final String qualLength = "qualLength";	
-	public static final String firstOfPair = "firstReadInPair"; 
-	public static final String secondOfPair = "secondReadInPair";
+	public static final String OTHER = "others";
 	public static final String UNKNOWN_READGROUP = "unkown_readgroup_id";	
-	public static final String summary = "bamSummary";
 	
+	public static final String METRICS = "Metrics";
+	public static final String READGROUP_ELE ="readGroups";
+	public static final String VARIABLE_GROUP_ELE = "variableGroup";
+	public static final String VALUE = "value";
+	public static final String COLSED_BIN = "closedBin";
+	public static final String METRICS_ELE = "sequence" + METRICS;
+	public static final String NAME = "name";
+	public static final String COUNT = "count";
+	public static final String PERCENT = "percent";
+	public static final String TALLY = "tally";
+	public static final String TALLY_COUNT = "tallyCount";
+	public static final String START = "start";
+	public static final String END = "end";
+	public static final String CYCLE = "cycle";
+	public static final String BASE_CYCLE_ELE = "baseCycle";
+	public static final String RECORD_ELE ="record";
+	public static final String DISCARD_READS = "discardedReads";		
+	public static final String SEQ_BASE = "seqBase";
+	public static final String SEQ_LENGTH = "seqLength";
+	public static final String BAD_READ = "badBase";
+	public static final String QUAL_BASE = "qualBase";
+	public static final String QUAL_LENGTH = "qualLength";	
+	public static final String FIRST_PAIR = "firstReadInPair"; 
+	public static final String SECOND_PAIR = "secondReadInPair";
+
+	public static final String BAM_SUMMARY = "bamSummary";
+	public static final String OVERALL = "Overall";
+	public static final String ALL_BASE_LOST = "OverallBasesLost";
+	 	
 	//commly used on fastq bam
-	public static final String qname = "QNAME";
-	public static final String flag = "FLAG";	
-	public static final String rname = "RNAME";
-	public static final String pos = "POS";
-	public static final String mapq = "MAPQ";
-	public static final String cigar = "CIGAR";
-	public static final String tlen = "TLEN";
-	public static final String seq = "SEQ"; 
-	public static final String qual = "QUAL";
-	public static final String tag = "TAG";	
+	public static final String QNAME = "QNAME";
+	public static final String FLAG = "FLAG";	
+	public static final String RNAME = "RNAME";
+	public static final String POS = "POS";
+	public static final String MAPQ = "MAPQ";
+	public static final String CIGAR = "CIGAR";
+	public static final String TLEN = "TLEN";
+	public static final String SEQ = "SEQ"; 
+	public static final String QUAL = "QUAL";
+	public static final String TAG = "TAG";	
 	
    public static void bamHeaderToXml(Element parent1, SAMFileHeader header, boolean isFullBamHeader){
 
@@ -93,7 +95,7 @@ public class XmlUtils {
                     element.setAttribute( cateName, cateValue);
                     element.setAttribute( "description", des);
                     for(T re: records) {
-                            Element elechild = XmlElementUtils.createSubElement(parent, recordEle );
+                            Element elechild = XmlElementUtils.createSubElement(parent, RECORD_ELE );
                             //set txt content
                             if(re instanceof String)
                                     elechild.setTextContent((String)re);
@@ -104,15 +106,15 @@ public class XmlUtils {
 
                             //set id
                             if (re instanceof SAMSequenceRecord) {
-                                    elechild.setAttribute(sName, ((SAMSequenceRecord)re).getSequenceName()  );
+                                    elechild.setAttribute(NAME, ((SAMSequenceRecord)re).getSequenceName()  );
                             }else if (re instanceof SAMReadGroupRecord) {
-                                    elechild.setAttribute(sName, ((SAMReadGroupRecord)re).getId()  );
+                                    elechild.setAttribute(NAME, ((SAMReadGroupRecord)re).getId()  );
                             }else if (re instanceof SAMProgramRecord) {
-                                elechild.setAttribute(sName, ((SAMProgramRecord)re).getId()  );
+                                elechild.setAttribute(NAME, ((SAMProgramRecord)re).getId()  );
                              //   elechild.setAttribute(Sname, ((SAMProgramRecord)re).getProgramName()  );
                                 
                             }else if(re instanceof VcfHeaderRecord) {
-                                    elechild.setAttribute(sName,((VcfHeaderRecord) re).getId() != null ? ((VcfHeaderRecord) re).getId(): ((VcfHeaderRecord) re).getMetaKey().replace("##", "") );
+                                    elechild.setAttribute(NAME,((VcfHeaderRecord) re).getId() != null ? ((VcfHeaderRecord) re).getId(): ((VcfHeaderRecord) re).getMetaKey().replace("##", "") );
                             }
                             element.appendChild(elechild);
                     }
@@ -156,10 +158,10 @@ public class XmlUtils {
 	 * @return
 	 */       
     public static Element createMetricsNode(Element parent,  String name, Pair<?, ?> totalCounts ) {	
-    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.metricsEle );
+    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.METRICS_ELE );
     						
 		if( totalCounts != null ) ele.setAttribute((String)totalCounts.getLeft(), String.valueOf( totalCounts.getRight()));		 
-		if(name != null) ele.setAttribute( sName, name );
+		if(name != null) ele.setAttribute( NAME, name );
 				
 		return ele;        	
     }      
@@ -172,13 +174,13 @@ public class XmlUtils {
 	 * @return
 	 */
     public static Element createGroupNode(Element parent, String name) {
-    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.variableGroupEle );	
-    	ele.setAttribute( sName, name); 
+    	Element ele = XmlElementUtils.createSubElement( parent,  XmlUtils.VARIABLE_GROUP_ELE );	
+    	ele.setAttribute( NAME, name); 
     	return ele;
     }
     public static Element createGroupNode(Element parent, String name, Number totalcount) {
     	Element ele = createGroupNode(  parent,   name);
-    	 ele.setAttribute( sCount, String.valueOf(totalcount));  
+    	 ele.setAttribute( COUNT, String.valueOf(totalcount));  
     	 return ele; 
     }
     
@@ -190,8 +192,8 @@ public class XmlUtils {
 	 * @return
 	 */
     public static Element createCycleNode(Element parent, String name) {
-    	Element ele = XmlElementUtils.createSubElement( parent,  baseCycleEle );	
-    	ele.setAttribute( Scycle, name); 
+    	Element ele = XmlElementUtils.createSubElement( parent,  BASE_CYCLE_ELE );	
+    	ele.setAttribute( CYCLE, name); 
     	return ele;
     }
         
@@ -202,8 +204,8 @@ public class XmlUtils {
      * @param value
      */
     public static <T> Element outputValueNode(Element parent, String name, Number value) {        	
-    	Element ele = XmlElementUtils.createSubElement(parent, sValue);
-    	ele.setAttribute(sName, name);
+    	Element ele = XmlElementUtils.createSubElement(parent, VALUE);
+    	ele.setAttribute(NAME, name);
     	String v = String.valueOf(value);
 
     	if( value instanceof Double ) {
@@ -220,11 +222,11 @@ public class XmlUtils {
      * @param value
      * @param comment
      */
-    public static <T> void outputValueNode(Element parent, String name, Number value, String comment) {   
-    	parent.insertBefore( parent.getOwnerDocument().createComment( comment ), parent.getFirstChild() ); 
-    	outputValueNode( parent,  name,  value);
-    	    	    	 
-    }
+//    public static <T> void outputValueNode(Element parent, String name, Number value, String comment) {   
+//    	parent.insertBefore( parent.getOwnerDocument().createComment( comment ), parent.getFirstChild() ); 
+//    	outputValueNode( parent,  name,  value);
+//    	    	    	 
+//    }
     
     public static Element outputBins( Element parent, String name, Map<Integer, AtomicLong> bins, int binSize) {
     	
@@ -233,9 +235,9 @@ public class XmlUtils {
     	Element ele;
     	for (Entry<Integer, AtomicLong> entry : bins.entrySet() ) {
     		if(entry.getValue().get() > 0) {
-    			ele = XmlElementUtils.createSubElement(cateEle, sBin);
-    	    	ele.setAttribute(sStart,  String.valueOf(entry.getKey() * binSize));   	    	
-    	    	ele.setAttribute(sCount, String.valueOf(entry.getValue().get())); 			
+    			ele = XmlElementUtils.createSubElement(cateEle, COLSED_BIN);
+    	    	ele.setAttribute(START,  String.valueOf(entry.getKey() * binSize));   	    	
+    	    	ele.setAttribute(COUNT, String.valueOf(entry.getValue().get())); 			
     		}  	    		
     	}
     	
@@ -243,70 +245,56 @@ public class XmlUtils {
     }
 	
 	public static <T> void outputTallyGroupWithSize(Element parent, String name, Map<T, AtomicLong> tallys, int sizeLimits) {
-		if(tallys == null ) return; 
+		boolean hasPercent = tallys.size() > sizeLimits ? false : true;		
+		Element ele = outputTallyGroup(parent, name, tallys, hasPercent, true) ;		
 		
-		String comment = null; 
-		boolean hasPercent =  true;
-		String tallyCount = null; 
-		if( tallys.size() > sizeLimits) { 			 
-			comment = "here only list top "+ sizeLimits + " tally element" ;
-			hasPercent = false;
-			tallyCount =sizeLimits + "+";
-		}
-       	
-    	Element e1 = outputTallyGroup(parent, name, tallys, hasPercent, comment) ;		
-    	 
-		if(tallyCount != null) {			 
-			e1.setAttribute(XmlUtils.sTallyCount, tallyCount);
+		if( ele != null && tallys.size() > sizeLimits) { 			
+			ele.appendChild( ele.getOwnerDocument().createComment( "here only list top "+ sizeLimits + " tally element" ) );	
+			ele.setAttribute(XmlUtils.TALLY_COUNT, sizeLimits + "+");		
 		}
 	}
     
     
     private static <T> void outputTallys( Element ele, String name, Map<T, AtomicLong> tallys, boolean hasPercent) {
     	
-    	double sum = hasPercent ? tallys.values().stream().mapToDouble( x -> (double) x.get() ).sum() : 0;	
-    	   	
+    	double sum = hasPercent ? tallys.values().stream().mapToDouble( x -> (double) x.get() ).sum() : 0;	   	   	
     	for(T t: tallys.keySet()) {
 			//skip zero value for output
 			if(tallys.get(t).get() == 0 ) continue;
 			double percent = (sum == 0)? 0 : 100 * (double)tallys.get(t).get() / sum;
-			Element ele1 = XmlElementUtils.createSubElement( ele, sTally );
-			ele1.setAttribute( sValue, String.valueOf( t ));
-			ele1.setAttribute( sCount, String.valueOf( tallys.get(t).get() )); 
+			Element ele1 = XmlElementUtils.createSubElement( ele, TALLY );
+			ele1.setAttribute( VALUE, String.valueOf( t ));
+			ele1.setAttribute( COUNT, String.valueOf( tallys.get(t).get() )); 
 			if( hasPercent == true) {
-				ele1.setAttribute(sPercent, String.format("%,.2f", percent));	
+				ele1.setAttribute(PERCENT, String.format("%,.2f", percent));	
 			}					
-		}  	
-    	long counts = tallys.values().stream().mapToLong( x -> (long) x.get() ).sum() ;	
-    	ele.setAttribute(sCount, counts+"");
-    	
-    }
-    
-    public static <T> Element outputTallyGroup( Element parent, String name, Map<T, AtomicLong> tallys, boolean hasPercent, String comment ) {
-    	if(tallys == null || tallys.isEmpty()) return null;
-    	       	
-    	Element ele = createGroupNode( parent, name);	//<category>      
-    	
-    	if( comment != null ) 
-    		ele.appendChild( ele.getOwnerDocument().createComment(comment) );	
-		
-    	outputTallys(  ele,  name,  tallys,  hasPercent );
-    	return ele; 
-      	
+		}  	    	
     }
    
-    public static  <T> Element outputTallyGroup( Element parent, String name, Map< T, AtomicLong> tallys, boolean hasPercent ) {
-    	return outputTallyGroup(  parent,  name,  tallys,  hasPercent, null );    	
+    public static  <T> Element outputTallyGroup( Element parent, String name, Map< T, AtomicLong> tallys, boolean hasPercent, boolean outputSum ) {
+    	if(tallys == null || tallys.isEmpty()) return null;
+    	
+    	Element ele = createGroupNode( parent, name);	//<category> 
+    	outputTallys( ele, name, tallys, hasPercent);
+    	
+    	if(outputSum) {
+	    	long counts = tallys.values().stream().mapToLong( x -> (long) x.get() ).sum() ;	
+	    	ele.setAttribute(COUNT, counts+"");
+    	}
+    	
+    	return ele;   	
     }
     
     
     public static <T>  void outputCycleTallyGroup( Element parent, String name, Map<T, AtomicLong> tallys, boolean hasPercent ) {
     	if(tallys == null || tallys.isEmpty()) return;
     	       	
-    	Element ele = XmlElementUtils.createSubElement( parent,  baseCycleEle );	
-    	ele.setAttribute( Scycle, name); 
+    	Element ele = XmlElementUtils.createSubElement( parent,  BASE_CYCLE_ELE );	
+    	ele.setAttribute( CYCLE, name); 
  
-    	outputTallys(  ele,  name,  tallys,  hasPercent );        	
+    	outputTallys(  ele,  name,  tallys,  hasPercent );  
+    	long counts = tallys.values().stream().mapToLong( x -> (long) x.get() ).sum() ;	
+    	ele.setAttribute(COUNT, counts+"");
     }
     
     public static void addCommentChild(Element ele, String comment) {
@@ -316,7 +304,7 @@ public class XmlUtils {
 
     public static Element createReadGroupNode( Element parent, String rgid) {
      	Element ele = XmlElementUtils.createSubElement( parent, "readGroup" );
-    	ele.setAttribute(sName, rgid);
+    	ele.setAttribute(NAME, rgid);
     	return ele;
     }
     

--- a/qprofiler2/src/org/qcmg/qprofiler2/vcf/VcfSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/vcf/VcfSummaryReport.java
@@ -90,7 +90,7 @@ public class VcfSummaryReport  extends SummaryReport {
 		Element summaryElement =  XmlElementUtils.createSubElement(parent,  ProfileType.VCF.getReportName()+"Metrics" );		
 		for( String sample : summaries.keySet() ) {	
 			Element ele =  XmlElementUtils.createSubElement( summaryElement, Sample);
-			ele.setAttribute(XmlUtils.sName, sample);
+			ele.setAttribute(XmlUtils.NAME, sample);
 						
 			for(String cates : summaries.get(sample).keySet() ) {			
 				if( formatsTypes.isEmpty() ) {

--- a/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportTest.java
@@ -118,12 +118,12 @@ public class BamSummaryReportTest {
 		assertEquals(1, lists.size());
 		
 		//get node <sequenceMetrics name="seqLength"> or <sequenceMetrics name="qualLength">		
-		lists = XmlElementUtils.getOffspringElementByTagName( lists.get( 0 ), XmlUtils.METRICS_ELE ).stream()
+		lists = XmlElementUtils.getOffspringElementByTagName( lists.get( 0 ), XmlUtils.SEQUENCE_METRICS ).stream()
 			.filter( e -> e.getAttribute(XmlUtils.NAME).equals( sLength)).collect(Collectors.toList());
 		assertEquals(1, lists.size());
 		
 		//<variableGroup name="firstReadInPair"> or <variableGroup name="secondReadInPair">				
-		lists = XmlElementUtils.getOffspringElementByTagName( lists.get( 0 ), XmlUtils.VARIABLE_GROUP_ELE ).stream()
+		lists = XmlElementUtils.getOffspringElementByTagName( lists.get( 0 ), XmlUtils.VARIABLE_GROUP ).stream()
 				.filter( e -> e.getAttribute(XmlUtils.NAME).equals(pairName)).collect(Collectors.toList());		
 		assertEquals(1, lists.size());				
 		
@@ -225,7 +225,7 @@ public class BamSummaryReportTest {
 	
 	private List<Element> getTallys(List<Element> rgsE,String rgName, String metricName,  int size){		
 		Element ele = rgsE.stream().filter( e -> e.getAttribute(XmlUtils.NAME).equals( rgName )  ).findFirst().get();
-		ele = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.METRICS_ELE).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals( metricName )  ).findFirst().get();
+		ele = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.SEQUENCE_METRICS).stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals( metricName )  ).findFirst().get();
 		List<Element> eles = XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY);
 		assertEquals(size, eles.size());	
 	 

--- a/qprofiler2/test/org/qcmg/qprofiler2/bam/TagSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/bam/TagSummaryReportTest.java
@@ -80,21 +80,21 @@ public class TagSummaryReportTest {
 	
 	private void checkXml(Element root){
 		 		
-		assertEquals( 2, XmlElementUtils.getChildElementByTagName( root, XmlUtils.METRICS_ELE ).size()  );				
+		assertEquals( 2, XmlElementUtils.getChildElementByTagName( root, XmlUtils.SEQUENCE_METRICS ).size()  );				
 		
 		//<sequenceMetrics name="tags:MDM:Z">
-		Element metricE = getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:MD:Z" ).get(0);
+		Element metricE = getChildNameIs( root, XmlUtils.SEQUENCE_METRICS, "tags:MD:Z" ).get(0);
 		assertEquals( metricE.getChildNodes().getLength() , 3 );
 		
 		//check mutation on each base cycle
-		Element ele = getChildNameIs( metricE, XmlUtils.VARIABLE_GROUP_ELE, XmlUtils.FIRST_PAIR ).get(0);
+		Element ele = getChildNameIs( metricE, XmlUtils.VARIABLE_GROUP, XmlUtils.FIRST_PAIR ).get(0);
 		//three of firstOfPair have four mutation base
 		String[] values = new String[] { "A", "T", "C", "C" };
 		String[] counts =  new String[] { "1", "10", "11", "37" };
 		for(int i = 0; i < counts.length; i++ ) {
 			
 			String count = counts[i];
-			Element vE = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.BASE_CYCLE_ELE).stream().
+			Element vE = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.BASE_CYCLE).stream().
 				filter( e -> e.getAttribute( XmlUtils.CYCLE ).equals( String.valueOf(count))  ).findFirst().get();		
 			assertEquals( vE.getChildNodes().getLength() , 1 );
 			vE = (Element) vE.getChildNodes().item(0);
@@ -103,20 +103,20 @@ public class TagSummaryReportTest {
 		}
 		
 		//check mutaiton type on forward reads
-		ele = getChildNameIs(metricE, XmlUtils.VARIABLE_GROUP_ELE, XmlUtils.FIRST_PAIR+"ForwardStrand" ).get(0);
+		ele = getChildNameIs(metricE, XmlUtils.VARIABLE_GROUP, XmlUtils.FIRST_PAIR+"ForwardStrand" ).get(0);
 		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
 			.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("A>C") && e.getAttribute(XmlUtils.COUNT).equals("2") ).count() );
 		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
 			.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("T>A") && e.getAttribute(XmlUtils.COUNT).equals("1") ).count() );		
 		
 		//check mutaiton type on reverse reads
-		ele = getChildNameIs( metricE, XmlUtils.VARIABLE_GROUP_ELE, XmlUtils.FIRST_PAIR+"ReverseStrand" ).get(0);
+		ele = getChildNameIs( metricE, XmlUtils.VARIABLE_GROUP, XmlUtils.FIRST_PAIR+"ReverseStrand" ).get(0);
 		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).size());
 		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
 				.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("A>T") && e.getAttribute(XmlUtils.COUNT).equals("1") ).count() );
 		
 		//check tag RG
-		ele = getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:RG:Z" ).get(0);
+		ele = getChildNameIs( root, XmlUtils.SEQUENCE_METRICS, "tags:RG:Z" ).get(0);
 		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
 				.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("first") && e.getAttribute(XmlUtils.COUNT).equals("3") ).count() );
 		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
@@ -201,7 +201,7 @@ public class TagSummaryReportTest {
 		Element root = XmlElementUtils.createRootElement( XmlUtils.TAG, null );
 		report.toXml( root );	
 		
-		Element ele = getChildNameIs( getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:NM:Z" ).get(0), XmlUtils.VARIABLE_GROUP_ELE, "NM" ).get(0);
+		Element ele = getChildNameIs( getChildNameIs( root, XmlUtils.SEQUENCE_METRICS, "tags:NM:Z" ).get(0), XmlUtils.VARIABLE_GROUP, "NM" ).get(0);
 		assertEquals( ele.getAttribute(XmlUtils.TALLY_COUNT) , TagSummaryReport2.ADDI_TAG_MAP_LIMIT+"+" ); 
 		assertEquals( ele.getAttribute(XmlUtils.COUNT) , "200" );		
 		assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY).size(), 101);
@@ -210,7 +210,7 @@ public class TagSummaryReportTest {
 		assertEquals(findNo, 1);
 		
 		
-		ele = getChildNameIs( getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:NM:i" ).get(0), XmlUtils.VARIABLE_GROUP_ELE, "NM" ).get(0);
+		ele = getChildNameIs( getChildNameIs( root, XmlUtils.SEQUENCE_METRICS, "tags:NM:i" ).get(0), XmlUtils.VARIABLE_GROUP, "NM" ).get(0);
 		assertEquals( ele.getAttribute(XmlUtils.TALLY_COUNT) , TagSummaryReport2.ADDI_TAG_MAP_LIMIT+"+" ); 
 		assertEquals( ele.getAttribute(XmlUtils.COUNT) , "401" );
 		assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY).size(), 101);

--- a/qprofiler2/test/org/qcmg/qprofiler2/bam/TagSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/bam/TagSummaryReportTest.java
@@ -68,59 +68,59 @@ public class TagSummaryReportTest {
 		record.setAttribute("RG", "last");
 		report.parseTAGs(record);
 		
-		Element root = XmlElementUtils.createRootElement( XmlUtils.tag, null );
+		Element root = XmlElementUtils.createRootElement( XmlUtils.TAG, null );
 		report.toXml( root );		
 		checkXml( root );
 	}	
 		
 	private List<Element> getChildNameIs(Element parent, String eleName, String nameValue){		
 		return XmlElementUtils.getChildElementByTagName(parent,eleName).stream().
-			filter( e -> e.getAttribute( XmlUtils.sName ).equals( nameValue ) ).collect(Collectors.toList());		
+			filter( e -> e.getAttribute( XmlUtils.NAME ).equals( nameValue ) ).collect(Collectors.toList());		
 	}
 	
 	private void checkXml(Element root){
 		 		
-		assertEquals( 2, XmlElementUtils.getChildElementByTagName( root, XmlUtils.metricsEle ).size()  );				
+		assertEquals( 2, XmlElementUtils.getChildElementByTagName( root, XmlUtils.METRICS_ELE ).size()  );				
 		
 		//<sequenceMetrics name="tags:MDM:Z">
-		Element metricE = getChildNameIs( root, XmlUtils.metricsEle, "tags:MD:Z" ).get(0);
+		Element metricE = getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:MD:Z" ).get(0);
 		assertEquals( metricE.getChildNodes().getLength() , 3 );
 		
 		//check mutation on each base cycle
-		Element ele = getChildNameIs( metricE, XmlUtils.variableGroupEle, XmlUtils.firstOfPair ).get(0);
+		Element ele = getChildNameIs( metricE, XmlUtils.VARIABLE_GROUP_ELE, XmlUtils.FIRST_PAIR ).get(0);
 		//three of firstOfPair have four mutation base
 		String[] values = new String[] { "A", "T", "C", "C" };
 		String[] counts =  new String[] { "1", "10", "11", "37" };
 		for(int i = 0; i < counts.length; i++ ) {
 			
 			String count = counts[i];
-			Element vE = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.baseCycleEle).stream().
-				filter( e -> e.getAttribute( XmlUtils.Scycle ).equals( String.valueOf(count))  ).findFirst().get();		
+			Element vE = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.BASE_CYCLE_ELE).stream().
+				filter( e -> e.getAttribute( XmlUtils.CYCLE ).equals( String.valueOf(count))  ).findFirst().get();		
 			assertEquals( vE.getChildNodes().getLength() , 1 );
 			vE = (Element) vE.getChildNodes().item(0);
-			assertEquals( vE.getAttribute(XmlUtils.sValue), values[i]);
-			assertEquals( vE.getAttribute(XmlUtils.sCount), "1");
+			assertEquals( vE.getAttribute(XmlUtils.VALUE), values[i]);
+			assertEquals( vE.getAttribute(XmlUtils.COUNT), "1");
 		}
 		
 		//check mutaiton type on forward reads
-		ele = getChildNameIs(metricE, XmlUtils.variableGroupEle, XmlUtils.firstOfPair+"ForwardStrand" ).get(0);
-		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.sTally).stream()
-			.filter(e -> e.getAttribute(XmlUtils.sValue).equals("A>C") && e.getAttribute(XmlUtils.sCount).equals("2") ).count() );
-		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.sTally).stream()
-			.filter(e -> e.getAttribute(XmlUtils.sValue).equals("T>A") && e.getAttribute(XmlUtils.sCount).equals("1") ).count() );		
+		ele = getChildNameIs(metricE, XmlUtils.VARIABLE_GROUP_ELE, XmlUtils.FIRST_PAIR+"ForwardStrand" ).get(0);
+		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
+			.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("A>C") && e.getAttribute(XmlUtils.COUNT).equals("2") ).count() );
+		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
+			.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("T>A") && e.getAttribute(XmlUtils.COUNT).equals("1") ).count() );		
 		
 		//check mutaiton type on reverse reads
-		ele = getChildNameIs( metricE, XmlUtils.variableGroupEle, XmlUtils.firstOfPair+"ReverseStrand" ).get(0);
-		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.sTally).size());
-		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.sTally).stream()
-				.filter(e -> e.getAttribute(XmlUtils.sValue).equals("A>T") && e.getAttribute(XmlUtils.sCount).equals("1") ).count() );
+		ele = getChildNameIs( metricE, XmlUtils.VARIABLE_GROUP_ELE, XmlUtils.FIRST_PAIR+"ReverseStrand" ).get(0);
+		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).size());
+		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
+				.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("A>T") && e.getAttribute(XmlUtils.COUNT).equals("1") ).count() );
 		
 		//check tag RG
-		ele = getChildNameIs( root, XmlUtils.metricsEle, "tags:RG:Z" ).get(0);
-		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.sTally).stream()
-				.filter(e -> e.getAttribute(XmlUtils.sValue).equals("first") && e.getAttribute(XmlUtils.sCount).equals("3") ).count() );
-		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.sTally).stream()
-				.filter(e -> e.getAttribute(XmlUtils.sValue).equals("last") && e.getAttribute(XmlUtils.sCount).equals("1") ).count() );
+		ele = getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:RG:Z" ).get(0);
+		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
+				.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("first") && e.getAttribute(XmlUtils.COUNT).equals("3") ).count() );
+		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName(ele, XmlUtils.TALLY).stream()
+				.filter(e -> e.getAttribute(XmlUtils.VALUE).equals("last") && e.getAttribute(XmlUtils.COUNT).equals("1") ).count() );
 	}
 		
 	
@@ -198,24 +198,24 @@ public class TagSummaryReportTest {
 			report.parseTAGs(record);			
 		}		
 		
-		Element root = XmlElementUtils.createRootElement( XmlUtils.tag, null );
+		Element root = XmlElementUtils.createRootElement( XmlUtils.TAG, null );
 		report.toXml( root );	
 		
-		Element ele = getChildNameIs( getChildNameIs( root, XmlUtils.metricsEle, "tags:NM:Z" ).get(0), XmlUtils.variableGroupEle, "NM" ).get(0);
-		assertEquals( ele.getAttribute(XmlUtils.sTallyCount) , TagSummaryReport2.ADDI_TAG_MAP_LIMIT+"+" ); 
-		assertEquals( ele.getAttribute(XmlUtils.sCount) , "200" );		
-		assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.sTally).size(), 101);
-		long findNo = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.sTally).stream()
-			.filter(e -> e.getAttribute( XmlUtils.sValue ).equals(XmlUtils.OTHER ) && e.getAttribute( XmlUtils.sCount ).equals("100" )).count() ;
+		Element ele = getChildNameIs( getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:NM:Z" ).get(0), XmlUtils.VARIABLE_GROUP_ELE, "NM" ).get(0);
+		assertEquals( ele.getAttribute(XmlUtils.TALLY_COUNT) , TagSummaryReport2.ADDI_TAG_MAP_LIMIT+"+" ); 
+		assertEquals( ele.getAttribute(XmlUtils.COUNT) , "200" );		
+		assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY).size(), 101);
+		long findNo = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY).stream()
+			.filter(e -> e.getAttribute( XmlUtils.VALUE ).equals(XmlUtils.OTHER ) && e.getAttribute( XmlUtils.COUNT ).equals("100" )).count() ;
 		assertEquals(findNo, 1);
 		
 		
-		ele = getChildNameIs( getChildNameIs( root, XmlUtils.metricsEle, "tags:NM:i" ).get(0), XmlUtils.variableGroupEle, "NM" ).get(0);
-		assertEquals( ele.getAttribute(XmlUtils.sTallyCount) , TagSummaryReport2.ADDI_TAG_MAP_LIMIT+"+" ); 
-		assertEquals( ele.getAttribute(XmlUtils.sCount) , "401" );
-		assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.sTally).size(), 101);
-		findNo = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.sTally).stream()
-				.filter(e -> e.getAttribute( XmlUtils.sValue ).equals(XmlUtils.OTHER ) && e.getAttribute( XmlUtils.sCount ).equals("203" )).count() ;
+		ele = getChildNameIs( getChildNameIs( root, XmlUtils.METRICS_ELE, "tags:NM:i" ).get(0), XmlUtils.VARIABLE_GROUP_ELE, "NM" ).get(0);
+		assertEquals( ele.getAttribute(XmlUtils.TALLY_COUNT) , TagSummaryReport2.ADDI_TAG_MAP_LIMIT+"+" ); 
+		assertEquals( ele.getAttribute(XmlUtils.COUNT) , "401" );
+		assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY).size(), 101);
+		findNo = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY).stream()
+				.filter(e -> e.getAttribute( XmlUtils.VALUE ).equals(XmlUtils.OTHER ) && e.getAttribute( XmlUtils.COUNT ).equals("203" )).count() ;
 			assertEquals(findNo, 1);
 		
 	}

--- a/qprofiler2/test/org/qcmg/qprofiler2/cohort/CohortSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/cohort/CohortSummaryReportTest.java
@@ -70,7 +70,7 @@ public class CohortSummaryReportTest {
 			List<String> outputs = xReport.outputCounts();
 			outputSize += outputs.size();
 			
-			if(ele.getAttribute(XmlUtils.sName).equals("test1") ){
+			if(ele.getAttribute(XmlUtils.NAME).equals("test1") ){
 				assertTrue(outputs.size() == 4);
 				for(String output : outputs ){								 
 					String[] subs = new String[]{"5BP=3:SOMATIC;GERM=42,185", "5BP=3:SOMATIC", "PASS:SOMATIC\tSNV" ,"PASS:SOMATIC\tDNV" };					
@@ -83,7 +83,7 @@ public class CohortSummaryReportTest {
 					else
 						assertEquals( input.getCanonicalPath() + "\ttest1\t" + subs[3] + "\t10\t0.000\t-",  output );	 
 				}
-			}else if(ele.getAttribute(XmlUtils.sName).equals("control1") ){
+			}else if(ele.getAttribute(XmlUtils.NAME).equals("control1") ){
 				assertTrue(outputs.size() == 3);
 				for(String output : outputs ){					
 					if(output.contains("\tSNV\t"))

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/CycleSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/CycleSummaryTest.java
@@ -34,14 +34,14 @@ public class CycleSummaryTest {
 		
 		
 		//eg. <sequenceMetrics name="seqBase"><variableGroup name="firstReadInPair">	
-		List<Element> elements = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.VARIABLE_GROUP_ELE ).stream()
+		List<Element> elements = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.VARIABLE_GROUP ).stream()
 			.filter( e -> e.getAttribute(XmlUtils.NAME).equals(pairName ) &&
 					 ((Element) e.getParentNode()).getAttribute(XmlUtils.NAME).equals(metricName)).collect(Collectors.toList());
 		Assert.assertEquals(elements.size(), 1);
 		
 
 		//eg, <baseCycle cycle="1">
-		Element ele = XmlElementUtils.getOffspringElementByTagName( elements.get(0), XmlUtils.BASE_CYCLE_ELE ).stream()
+		Element ele = XmlElementUtils.getOffspringElementByTagName( elements.get(0), XmlUtils.BASE_CYCLE ).stream()
 			.filter( e -> e.getAttribute(XmlUtils.CYCLE).equals(cycle + "" )).findFirst().get();	
 		assertEquals(values.length, ele.getChildNodes().getLength());	
 		

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/CycleSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/CycleSummaryTest.java
@@ -34,15 +34,15 @@ public class CycleSummaryTest {
 		
 		
 		//eg. <sequenceMetrics name="seqBase"><variableGroup name="firstReadInPair">	
-		List<Element> elements = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.variableGroupEle ).stream()
-			.filter( e -> e.getAttribute(XmlUtils.sName).equals(pairName ) &&
-					 ((Element) e.getParentNode()).getAttribute(XmlUtils.sName).equals(metricName)).collect(Collectors.toList());
+		List<Element> elements = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.VARIABLE_GROUP_ELE ).stream()
+			.filter( e -> e.getAttribute(XmlUtils.NAME).equals(pairName ) &&
+					 ((Element) e.getParentNode()).getAttribute(XmlUtils.NAME).equals(metricName)).collect(Collectors.toList());
 		Assert.assertEquals(elements.size(), 1);
 		
 
 		//eg, <baseCycle cycle="1">
-		Element ele = XmlElementUtils.getOffspringElementByTagName( elements.get(0), XmlUtils.baseCycleEle ).stream()
-			.filter( e -> e.getAttribute(XmlUtils.Scycle).equals(cycle + "" )).findFirst().get();	
+		Element ele = XmlElementUtils.getOffspringElementByTagName( elements.get(0), XmlUtils.BASE_CYCLE_ELE ).stream()
+			.filter( e -> e.getAttribute(XmlUtils.CYCLE).equals(cycle + "" )).findFirst().get();	
 		assertEquals(values.length, ele.getChildNodes().getLength());	
 		
 		
@@ -51,9 +51,9 @@ public class CycleSummaryTest {
 		for(int i = 0; i < values.length; i ++) {
 			String v =  (metricName.contains("qual"))? ((byte) values[i].toCharArray()[0]-33) + ""   : (String)values[i] ;
 			String c = counts[i] + "";
-			long count = XmlElementUtils.getChildElementByTagName( ele, XmlUtils.sTally ).stream()
-					.filter( e -> e.getAttribute(XmlUtils.sValue).equals(v) 
-							&& e.getAttribute(XmlUtils.sCount).equals(c) ).count();
+			long count = XmlElementUtils.getChildElementByTagName( ele, XmlUtils.TALLY ).stream()
+					.filter( e -> e.getAttribute(XmlUtils.VALUE).equals(v) 
+							&& e.getAttribute(XmlUtils.COUNT).equals(c) ).count();
 			assertTrue(count == 1);
 		}	 
 	}
@@ -61,26 +61,26 @@ public class CycleSummaryTest {
 	@Test
 	public void getBaseByCycleTest() throws Exception{
  		Element root = getSummarizedRoot();			  
- 		checklength( root, XmlUtils.seqBase , XmlUtils.firstOfPair, 1, new String[] {"C","T"}, new int[] { 1,1 } ) ;
- 		checklength( root, XmlUtils.seqBase , XmlUtils.firstOfPair, 141, new String[] {"G","N"}, new int[] { 1,1 } ) ;
- 		checklength( root, XmlUtils.seqBase , XmlUtils.firstOfPair, 142, new String[] {"N"}, new int[] { 1 } ) ;
- 		checklength( root, XmlUtils.seqBase , XmlUtils.firstOfPair, 151, new String[] {"M" }, new int[] { 1 } ) ; 		
- 		checklength( root, XmlUtils.seqBase , XmlUtils.secondOfPair , 2, new String[] {"N"}, new int[] { 1} ) ;
- 		checklength( root, XmlUtils.seqBase , XmlUtils.secondOfPair , 4, new String[] {"T"}, new int[] { 1} ) ;
- 		checklength( root, XmlUtils.seqBase , XmlUtils.secondOfPair , 151, new String[] {"G"}, new int[] { 1} ) ; 		
+ 		checklength( root, XmlUtils.SEQ_BASE , XmlUtils.FIRST_PAIR, 1, new String[] {"C","T"}, new int[] { 1,1 } ) ;
+ 		checklength( root, XmlUtils.SEQ_BASE , XmlUtils.FIRST_PAIR, 141, new String[] {"G","N"}, new int[] { 1,1 } ) ;
+ 		checklength( root, XmlUtils.SEQ_BASE , XmlUtils.FIRST_PAIR, 142, new String[] {"N"}, new int[] { 1 } ) ;
+ 		checklength( root, XmlUtils.SEQ_BASE , XmlUtils.FIRST_PAIR, 151, new String[] {"M" }, new int[] { 1 } ) ; 		
+ 		checklength( root, XmlUtils.SEQ_BASE , XmlUtils.SECOND_PAIR , 2, new String[] {"N"}, new int[] { 1} ) ;
+ 		checklength( root, XmlUtils.SEQ_BASE , XmlUtils.SECOND_PAIR , 4, new String[] {"T"}, new int[] { 1} ) ;
+ 		checklength( root, XmlUtils.SEQ_BASE , XmlUtils.SECOND_PAIR , 151, new String[] {"G"}, new int[] { 1} ) ; 		
  	}
 	
 	@Test
 	public void getQualityByCycleTest() throws Exception{
  		Element root = getSummarizedRoot();		
  		
- 		checklength( root,  XmlUtils.qualBase , XmlUtils.firstOfPair, 1, new String[] {"A","("}, new int[] { 1,1 } ) ;
- 		checklength( root,  XmlUtils.qualBase , XmlUtils.firstOfPair, 143, new String[] {"-","J"}, new int[] {1, 1} ) ;
- 		checklength( root,  XmlUtils.qualBase , XmlUtils.firstOfPair, 144, new String[] {"7"}, new int[] { 1 } ) ;
- 		checklength( root,  XmlUtils.qualBase , XmlUtils.firstOfPair, 151, new String[] {"A"}, new int[] { 1 } ) ;		
-  		checklength( root,  XmlUtils.qualBase , XmlUtils.secondOfPair, 1, new String[] {"A" }, new int[] { 1} ) ;	
-		checklength( root,  XmlUtils.qualBase , XmlUtils.secondOfPair, 148, new String[] {"-" }, new int[] { 1} ) ;
-		checklength( root,  XmlUtils.qualBase , XmlUtils.secondOfPair, 151, new String[] {"7" }, new int[] { 1} ) ;
+ 		checklength( root,  XmlUtils.QUAL_BASE , XmlUtils.FIRST_PAIR, 1, new String[] {"A","("}, new int[] { 1,1 } ) ;
+ 		checklength( root,  XmlUtils.QUAL_BASE , XmlUtils.FIRST_PAIR, 143, new String[] {"-","J"}, new int[] {1, 1} ) ;
+ 		checklength( root,  XmlUtils.QUAL_BASE , XmlUtils.FIRST_PAIR, 144, new String[] {"7"}, new int[] { 1 } ) ;
+ 		checklength( root,  XmlUtils.QUAL_BASE , XmlUtils.FIRST_PAIR, 151, new String[] {"A"}, new int[] { 1 } ) ;		
+  		checklength( root,  XmlUtils.QUAL_BASE , XmlUtils.SECOND_PAIR, 1, new String[] {"A" }, new int[] { 1} ) ;	
+		checklength( root,  XmlUtils.QUAL_BASE , XmlUtils.SECOND_PAIR, 148, new String[] {"-" }, new int[] { 1} ) ;
+		checklength( root,  XmlUtils.QUAL_BASE , XmlUtils.SECOND_PAIR, 151, new String[] {"7" }, new int[] { 1} ) ;
 	}	
 
 	public static Element getSummarizedRoot() throws Exception{				

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -139,20 +139,20 @@ public class KmersSummaryTest {
 		summary.toXml(root, 2);
 				
 		//only one <sequenceMetrics>
-		List<Element> eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle);
+		List<Element> eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE);
 		assertEquals(eles.size(), 1);
-		assertEquals(eles.get(0).getAttribute(XmlUtils.sName), "2mers");
+		assertEquals(eles.get(0).getAttribute(XmlUtils.NAME), "2mers");
 		assertEquals(1, eles.get(0).getChildNodes().getLength());
 		
 		//check <variableGroup...>
 		Element ele = (Element)eles.get(0).getFirstChild();
-		assertEquals(ele.getAttribute(XmlUtils.sName), "2mers") ;
+		assertEquals(ele.getAttribute(XmlUtils.NAME), "2mers") ;
 		//base.length -3 
 		//cycle number = base.length - KmersSummary.maxKmers = 16-6 that is [1,11]
 		assertEquals(11, ele.getChildNodes().getLength());
 		for(int i = 0; i < ele.getChildNodes().getLength(); i ++) {
-			Element baseE = XmlElementUtils.getChildElement(ele, XmlUtils.baseCycleEle, i);
-			assertEquals(baseE.getAttribute(XmlUtils.Scycle), (i+1) + "");
+			Element baseE = XmlElementUtils.getChildElement(ele, XmlUtils.BASE_CYCLE_ELE, i);
+			assertEquals(baseE.getAttribute(XmlUtils.CYCLE), (i+1) + "");
 		}	
 		
 	}
@@ -175,26 +175,26 @@ public class KmersSummaryTest {
 		assertEquals( "GTT,CAG", StringUtils.join(summary.getPopularKmerString(16,  3, false, 1), ",") );
 		assertEquals( "TAA,CCT", StringUtils.join(summary.getPopularKmerString(16,  3, false, 2), ",") );
 			 
-		List<Element> tallysE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.sTally);
+		List<Element> tallysE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.TALLY);
 		assertEquals(4, tallysE.size());
 		
 		for(Element tE : tallysE) { 
-			assertTrue( tE.getAttribute(XmlUtils.sCount).equals("1") );	
+			assertTrue( tE.getAttribute(XmlUtils.COUNT).equals("1") );	
 			Element baseCycleEle = (Element) tE.getParentNode();
 			Element groupEle =  (Element) baseCycleEle.getParentNode();
 			Element metricEle = (Element) groupEle.getParentNode();
-			if( tE.getAttribute( XmlUtils.sValue ).equals("GTT") ) {								
-				assertTrue( baseCycleEle.getAttribute(XmlUtils.Scycle).equals("5") );
-				assertTrue( metricEle.getAttribute(XmlUtils.sName).equals("3mers") );	
-				assertTrue( groupEle.getAttribute(XmlUtils.sName).equals("firstReadInPair") ); 				
-			}else if(tE.getAttribute( XmlUtils.sValue ).equals("TAA")){
-				assertTrue( baseCycleEle.getAttribute(XmlUtils.Scycle).equals("3") );
-				assertTrue( metricEle.getAttribute(XmlUtils.sName).equals("3mers") ); 
-				assertTrue( groupEle.getAttribute(XmlUtils.sName).equals("secondReadInPair") ); 
-			}else if(tE.getAttribute( XmlUtils.sValue ).equals("CCT")) 
-				assertTrue( baseCycleEle.getAttribute(XmlUtils.Scycle).equals("1") );
+			if( tE.getAttribute( XmlUtils.VALUE ).equals("GTT") ) {								
+				assertTrue( baseCycleEle.getAttribute(XmlUtils.CYCLE).equals("5") );
+				assertTrue( metricEle.getAttribute(XmlUtils.NAME).equals("3mers") );	
+				assertTrue( groupEle.getAttribute(XmlUtils.NAME).equals("firstReadInPair") ); 				
+			}else if(tE.getAttribute( XmlUtils.VALUE ).equals("TAA")){
+				assertTrue( baseCycleEle.getAttribute(XmlUtils.CYCLE).equals("3") );
+				assertTrue( metricEle.getAttribute(XmlUtils.NAME).equals("3mers") ); 
+				assertTrue( groupEle.getAttribute(XmlUtils.NAME).equals("secondReadInPair") ); 
+			}else if(tE.getAttribute( XmlUtils.VALUE ).equals("CCT")) 
+				assertTrue( baseCycleEle.getAttribute(XmlUtils.CYCLE).equals("1") );
 			else
-				assertTrue( tE.getAttribute( XmlUtils.sValue ).equals("CAG"));			 
+				assertTrue( tE.getAttribute( XmlUtils.VALUE ).equals("CAG"));			 
 		}
 		
 		// kmers3

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -139,7 +139,7 @@ public class KmersSummaryTest {
 		summary.toXml(root, 2);
 				
 		//only one <sequenceMetrics>
-		List<Element> eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE);
+		List<Element> eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS);
 		assertEquals(eles.size(), 1);
 		assertEquals(eles.get(0).getAttribute(XmlUtils.NAME), "2mers");
 		assertEquals(1, eles.get(0).getChildNodes().getLength());
@@ -151,7 +151,7 @@ public class KmersSummaryTest {
 		//cycle number = base.length - KmersSummary.maxKmers = 16-6 that is [1,11]
 		assertEquals(11, ele.getChildNodes().getLength());
 		for(int i = 0; i < ele.getChildNodes().getLength(); i ++) {
-			Element baseE = XmlElementUtils.getChildElement(ele, XmlUtils.BASE_CYCLE_ELE, i);
+			Element baseE = XmlElementUtils.getChildElement(ele, XmlUtils.BASE_CYCLE, i);
 			assertEquals(baseE.getAttribute(XmlUtils.CYCLE), (i+1) + "");
 		}	
 		

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/PairSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/PairSummaryTest.java
@@ -37,7 +37,7 @@ public class PairSummaryTest {
 	public void toSummaryXmlTest() throws Exception {	
 		
 		Element root = createPairRoot(input);		
-		List<Element> pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.METRICS_ELE)	
+		List<Element> pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.SEQUENCE_METRICS)	
 				.stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals( "properPairs" )).collect(Collectors.toList());	
 		
 		//only one inward pair but overlapped
@@ -54,7 +54,7 @@ public class PairSummaryTest {
 		checkVariableGroup( ele, "Inward", new int[] {1,0,0,0,1,1,0,0,0,76 } );		
 			
 		//notProperPair
-		pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.METRICS_ELE)	
+		pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.SEQUENCE_METRICS)	
 				.stream().filter(e  -> e .getAttribute(XmlUtils.NAME).equals( "notProperPairs" )).collect(Collectors.toList());
 		ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.NAME).equals(XmlUtils.UNKNOWN_READGROUP)).findFirst().get();	
 		checkVariableGroup( ele, "F3F5", new int[] {1,0,0,0,1,1,0,0,0, 0} ); //notProperPair
@@ -64,7 +64,7 @@ public class PairSummaryTest {
 	
 	private void checkVariableGroup(Element root, String name, int[] counts ) {
 		
-		Element variableEle = XmlElementUtils.getChildElementByTagName(root, XmlUtils.VARIABLE_GROUP_ELE).stream()
+		Element variableEle = XmlElementUtils.getChildElementByTagName(root, XmlUtils.VARIABLE_GROUP).stream()
 			.filter(e -> e.getAttribute(XmlUtils.NAME).equals(name) ).findFirst().get();
 		
 		List<Element> childEles = XmlElementUtils.getChildElementByTagName(variableEle, XmlUtils.VALUE);

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/PairSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/PairSummaryTest.java
@@ -15,6 +15,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.util.XmlElementUtils;
+import org.qcmg.picard.BwaPair;
 import org.qcmg.qprofiler2.bam.BamSummarizer2;
 import org.qcmg.qprofiler2.bam.BamSummaryReport2;
 import org.qcmg.qprofiler2.util.XmlUtils;
@@ -33,285 +34,29 @@ public class PairSummaryTest {
 	}	
 	
 	@Test
-	public void zeroMinusTlen() {
-		PairSummary pairS = new PairSummary(PairSummary.Pair.Others, false );
-		SAMRecord recorda = new SAMRecord(null);	
-		recorda.setInferredInsertSize(-1000 );
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0); 
-		recorda.setInferredInsertSize(-1 );
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0); 
-		try {
-			pairS.parse(recorda);
-			fail("expect to throw exception");
-		}catch(Exception e) {}
-		
-		
-		//set tLen == 0, any second of pair
-		recorda.setInferredInsertSize( 0 );
-		for(int flag : new int[] {129,131,147, 179}) {
-			recorda.setFlags(flag);
-			assertTrue(PairSummary.getOverlapBase(recorda) == 0); 
-			pairS.parse(recorda);
-		}
-		
-		//ST-E00180:52:H5LNMCCXX:1:1116:24274:5247 113 chr1 27977105 60 5S145M = 27977205 0
-		//<-----------| F3F5 reverse firstOfPaie
-		//    <-------|
-		recorda.setFlags(113);
-		recorda.setCigarString("5S145M");
-		recorda.setAlignmentStart(27977105);
-		recorda.setMateAlignmentStart(27977205);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 27977250 - 27977205); 
-		pairS.parse(recorda);
-		
-		//ST-E00180:52:H5LNMCCXX:1:2103:1720:24691 113 chr1 27775356 39 117S33M = 27775354 0
-		//    <-------|  F5F3 reverse firstOfPaie
-		//<-----------|
-		recorda.setCigarString( "117S33M" );
-		recorda.setAlignmentStart( 27775356 );
-		recorda.setMateAlignmentStart( 27775354 );
-		assertTrue(PairSummary.getOverlapBase(recorda) == 27775389 - 27775356); 
-		pairS.parse(recorda);
-		
-		//ST-E00180:52:H5LNMCCXX:1:2101:31703:21983 65 chr1 34492938 60 95M55S = 34492938 0   
-		//F5F3 forward firstOfPaie
-		//s1 |--------------> e1			s1 |---------> e1
-		//s2 |------------> e2		or 		s2 |------------> e2
-		recorda.setFlags(65);
-		recorda.setCigarString("95M55S");
-		recorda.setAlignmentStart(34492938);
-		recorda.setMateAlignmentStart(34492938);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 95); 
-		pairS.parse(recorda);
-
-		
-		//ST-E00180:52:H5LNMCCXX:1:1205:9993:36522 97 chr1 121484553 43 149M = 121484404 0   
-		//outward firstOfPair   <-------|-------->
-		recorda.setFlags(97);
-		recorda.setCigarString("95M55S");
-		recorda.setAlignmentStart(121484553);
-		recorda.setMateAlignmentStart(121484404);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0); 
-		pairS.parse(recorda);
-		
-		assertTrue( pairS.getFirstOfPairCounts() == 4 );
-//		assertTrue( pairS.getPairCounts() == 4 );
-		assertTrue( pairS.near.get() == 1 ); //only one without overlap		
-		assertTrue( pairS.tLenOverall.get(0) == 4 ); 
-		
-		assertTrue( pairS.getoverlapCounts().get(0) == 0 );
-		assertTrue( pairS.getoverlapCounts().get(33) == 1 );
-		assertTrue( pairS.getoverlapCounts().get(45) == 1 );
-		assertTrue( pairS.getoverlapCounts().get(95) == 1 );
-		
-	}
-	
-	@Test
-	public void isOverlapF5F3() {
-		//read   : first of pair 	   |---->  or  <------|      
-		//read   : second of pair  |---->      or  	        <-----|    
-		SAMRecord recorda = new SAMRecord(null);		
-		
-		//second Of Pair with positive tlen, and both forward
-		//ST-E00180:52:H5LNMCCXX:1:2111:15616:38526 129 chr1 56131814 60 150M = 56131947 134 		
-		recorda.setFlags(129);
-		recorda.setInferredInsertSize(134 );
-		recorda.setCigarString("150M");
-		recorda.setAlignmentStart(56131814);
-		recorda.setMateAlignmentStart(56131947);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 56131964 - 56131947); 		
-						
-		//now set to first of mapped pair, both reverse 
-		recorda.setFlags(115);
-		recorda.setAlignmentStart(100);
-		recorda.setMateAlignmentStart(119);
-		//reverse mate end - reverse read end = (119+149) - (100 + 149) + 1 = 20 (just example)
-		recorda.setInferredInsertSize(20);
-		//overlap = read_ends - max_starts = 249 - 119 + 1 = 131
-		assertTrue(PairSummary.getOverlapBase(recorda) == 131);
-		 		
-		//now set to second of mapped pair, both forward 
-		recorda.setFlags(131);
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.F5F3 );
-		assertTrue(PairSummary.getOverlapBase(recorda) == 131);
-		
-		//when there is no overlap
-		recorda.setMateAlignmentStart(250);
-		recorda.setInferredInsertSize(151);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0);			
-		recorda.setMateAlignmentStart(260);
-		assertTrue(PairSummary.getOverlapBase(recorda) < 0);	
-	}
-		
-	@Test
-	public void isOverlapF3F5() {
-		//read   : first of pair    |---->        or  	   <------|      
-		//read   : second of pair        |---->   or  <-----|    
-		SAMRecord recorda = new SAMRecord(null);
-		// second of mapped pair, both forward 
-		recorda.setFlags(131);		
-		recorda.setAlignmentStart(120);
-		recorda.setMateAlignmentStart(100);
-		assertFalse( PairSummary.getPairType(recorda).equals(PairSummary.Pair.F5F3 ));
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.F3F5 );
-		
-		//only count overlap on reads with positive tlen
-		recorda.setInferredInsertSize(-20);		//100-120	
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0);
-				
-		//first pair  fully overlap with tLen == 0 since both forward orientation
-		recorda.setCigarString("75M");
-		//first of mapped pair, both forward
-		recorda.setFlags(65);
-		recorda.setAlignmentStart(7480169);
-		recorda.setMateAlignmentStart(7480169);		
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.F3F5 );
-		//same start first of pair
-		recorda.setInferredInsertSize(0);	
-		assertTrue(PairSummary.getOverlapBase(recorda) == 75); 
-		//same start second of pair
-		recorda.setFlags(179);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0); 
-		
-		//now set to second of mapped pair, both reverse 
-		//ST-E00180:52:H5LNMCCXX:1:1116:24274:5247 113 chr1 27977105 60 5S145M = 27977205 0 
-		recorda.setAlignmentStart(105);
-		recorda.setMateAlignmentStart(205);
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.F3F5 );
-		
-		//reverse mate end - reverse read end = (120+21-1) - (100 + 21-1) = 20 (just example)
-		recorda.setInferredInsertSize(20);	
-		recorda.setCigarString("121M"); //set cigar, read end is 100 = 25 -1
-		//min_end - max_starts = (105+121-1) - 205, since cigar is nothing
-		assertTrue(PairSummary.getOverlapBase(recorda) == 21); 		 
-		
-		// 105 <------------|225
-		// 		205 <-------|225		
-		recorda.setInferredInsertSize(0);
-		//second of pair overlap ignor if tLen = 0
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0); 
-		//first of pair overlap >= 0 if tLen = 0
-		recorda.setFlags(115);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 21); 
-	}
-	
-	@Test
-	public void isOverlapInward() {
-//		PairSummary pairS = new PairSummary(PairSummary.Pair.Inward, true );	
-		// |--------->    <---------|		
-		SAMRecord recorda = new SAMRecord(null);		
-		// second of mapped pair, read reverse, mate forward
-		recorda.setFlags(147);
-		recorda.setAlignmentStart(120);
-		recorda.setMateAlignmentStart(100);
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Inward );
-	
-		//100-120 when read length is 0
-		recorda.setInferredInsertSize(-20);	
-		//set overlap  = 0 sinve tLen  < 0
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0);
-		
-		// first of mapped pair, read reverse, mate forward
-		recorda.setFlags(83);
-		//inward disregards first or second
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Inward );
-		assertTrue(PairSummary.getOverlapBase(recorda) ==0);
-		 
-
-		// first of mapped pair, read forward, mate reverse
-		recorda.setFlags(99);
-		recorda.setAlignmentStart(100);
-		recorda.setMateAlignmentStart(120);
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Inward );
-		
-		//120-100 when read length is 0
-		recorda.setInferredInsertSize(20);
-		//min_ends - max_starts = 99 -120 (cigar string is nothing)
-		assertTrue(PairSummary.getOverlapBase(recorda) == -20);
-
-		//120+20-100 when read length is 20
-		recorda.setInferredInsertSize(40);
-		//min_ends - max_starts = 99 -120 (cigar string is nothing)
-		assertTrue(PairSummary.getOverlapBase(recorda) == -20);
-		//min_ends - max_starts = min(140, 125) -120 =25
-		
-		
-		// 100|--------->124
-		//       120 <----|	140			 
-		recorda.setCigarString("25M");
-		//min_ends - max_starts = 124 -120+1 (end = start + cigar.M-1)
-		assertTrue(PairSummary.getOverlapBase(recorda) == 5);
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Inward  );
-		
-		// 100|--------------------->149
-		//       120<----|139		
-		// first of mapped pair, read forward, mate reverse
-		recorda.setCigarString("50M");
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Inward );
-		//min_ends - max_starts = 140 -120 (read end = start + cigar.M-1 = 149. mateEnd2= readStart-1+tLen = 139)
-		assertTrue(PairSummary.getOverlapBase(recorda) == 20);
-		
-	}
-		
-	@Test
-	public void isOverlapOutward() {
-
-		SAMRecord recorda = new SAMRecord(null);			
-		// <---------|(mate)    |--------->(read)	
-		// first of mapped pair, read forward, mate reverse
-		recorda.setFlags(99);
-		recorda.setAlignmentStart(120);
-		recorda.setMateAlignmentStart(100);
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Outward);
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0); //tLen == 0
-		recorda.setInferredInsertSize(-10); //tLen < 0
-		assertTrue(PairSummary.getOverlapBase(recorda) == 0);		
-		
-		//100 <---------------|150 mate
-		//          120|---->124 read
-		//set mate length = 50; tlen = (100+50) - 119 = 31
-		recorda.setInferredInsertSize(31);
-		recorda.setCigarString("5M");
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Outward);
-		//min(120-1+31, 120+5-1) - max(100, 120) +1= 5
-		assertTrue(PairSummary.getOverlapBase(recorda) == 5);
-			
-		// 100<----|104(read)    120|--------->(mate)	
-		recorda.setFlags(83);
-		recorda.setAlignmentStart(100);
-		recorda.setMateAlignmentStart(120);
-		assertEquals( PairSummary.getPairType(recorda), PairSummary.Pair.Outward);
-		//since readlength = 5, tlen = 120-104 + 1
-		recorda.setInferredInsertSize(17);
-		//overlap = min_ends - max_start + 1= min(104, 120+?) - 120 + 1
-		assertTrue(PairSummary.getOverlapBase(recorda) == -15);
-		
-	}
-	
-	@Test
 	public void toSummaryXmlTest() throws Exception {	
 		
 		Element root = createPairRoot(input);		
-		List<Element> pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.metricsEle)	
-				.stream().filter(e -> e.getAttribute(XmlUtils.sName).equals( "properPairs" )).collect(Collectors.toList());	
+		List<Element> pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.METRICS_ELE)	
+				.stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals( "properPairs" )).collect(Collectors.toList());	
 		
 		//only one inward pair but overlapped
-		Element ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.sName).equals("1959N")).findFirst().get(); 		
+		Element ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.NAME).equals("1959N")).findFirst().get(); 		
 		checkVariableGroup( ele, "Inward", new int[] {1,0,0,0,1,1,1, 0, 0,175} );
 
 		//five pairs
-		ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.sName).equals("1959T")).findFirst().get();	
+		ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.NAME).equals("1959T")).findFirst().get();	
 		checkVariableGroup( ele, "F5F3", new int[] {0,0,0,1,1,1,0, 0, 0,2025} ); //tlen=11205, 2015
 		checkVariableGroup( ele, "F3F5", new int[] {0,1,1,0,1,1,1,0, 0,93} ); //paircounts only for number of firstOfpair
 		checkVariableGroup( ele, "Outward", new int[] {2,0,0,0,2,1,3,0,0,13} );
 				
-		ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.sName).equals(XmlUtils.UNKNOWN_READGROUP)).findFirst().get();	
+		ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.NAME).equals(XmlUtils.UNKNOWN_READGROUP)).findFirst().get();	
 		checkVariableGroup( ele, "Inward", new int[] {1,0,0,0,1,1,0,0,0,76 } );		
 			
 		//notProperPair
-		pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.metricsEle)	
-				.stream().filter(e  -> e .getAttribute(XmlUtils.sName).equals( "notProperPairs" )).collect(Collectors.toList());
-		ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.sName).equals(XmlUtils.UNKNOWN_READGROUP)).findFirst().get();	
+		pairEles =  XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.METRICS_ELE)	
+				.stream().filter(e  -> e .getAttribute(XmlUtils.NAME).equals( "notProperPairs" )).collect(Collectors.toList());
+		ele = pairEles.stream().filter(e -> ( (Element) e.getParentNode()).getAttribute(XmlUtils.NAME).equals(XmlUtils.UNKNOWN_READGROUP)).findFirst().get();	
 		checkVariableGroup( ele, "F3F5", new int[] {1,0,0,0,1,1,0,0,0, 0} ); //notProperPair
 		
 		
@@ -319,14 +64,14 @@ public class PairSummaryTest {
 	
 	private void checkVariableGroup(Element root, String name, int[] counts ) {
 		
-		Element variableEle = XmlElementUtils.getChildElementByTagName(root, XmlUtils.variableGroupEle).stream()
-			.filter(e -> e.getAttribute(XmlUtils.sName).equals(name) ).findFirst().get();
+		Element variableEle = XmlElementUtils.getChildElementByTagName(root, XmlUtils.VARIABLE_GROUP_ELE).stream()
+			.filter(e -> e.getAttribute(XmlUtils.NAME).equals(name) ).findFirst().get();
 		
-		List<Element> childEles = XmlElementUtils.getChildElementByTagName(variableEle, XmlUtils.sValue);
+		List<Element> childEles = XmlElementUtils.getChildElementByTagName(variableEle, XmlUtils.VALUE);
 		assertTrue( childEles.size() == 9 );
 		
 		for(Element ele : childEles) {
-			switch (ele.getAttribute(XmlUtils.sName)) {
+			switch (ele.getAttribute(XmlUtils.NAME)) {
 				case "overlappedPairs": assertTrue( ele.getTextContent().equals(counts[0] + "") ); break;
 				case  "tlenUnder1500Pairs" : assertTrue( ele.getTextContent().equals(counts[1] + "") ); break;
 				case  "tlenOver10000Pairs" : assertTrue( ele.getTextContent().equals(counts[2] + "") ); break;
@@ -341,6 +86,79 @@ public class PairSummaryTest {
 		}	
 	}
 	
+	@Test
+	public void zeroMinusTlen() {
+		PairSummary pairS = new PairSummary(BwaPair.Pair.Others, false );
+		SAMRecord recorda = new SAMRecord(null);	
+		recorda.setInferredInsertSize(-1000 );
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0); 
+		recorda.setInferredInsertSize(-1 );
+		assertTrue(BwaPair.getOverlapBase(recorda) == 0); 
+		try {
+			pairS.parse(recorda);
+			fail("expect to throw exception");
+		}catch(Exception e) {}
+		
+		
+		//set tLen == 0, any second of pair
+		recorda.setInferredInsertSize( 0 );
+		for(int flag : new int[] {129,131,147, 179}) {
+			recorda.setFlags(flag);
+			assertTrue(BwaPair.getOverlapBase(recorda) == 0); 
+			pairS.parse(recorda);
+		}
+		
+		//ST-E00180:52:H5LNMCCXX:1:1116:24274:5247 113 chr1 27977105 60 5S145M = 27977205 0
+		//<-----------| F3F5 reverse firstOfPaie
+		//    <-------|
+		recorda.setFlags(113);
+		recorda.setCigarString("5S145M");
+		recorda.setAlignmentStart(27977105);
+		recorda.setMateAlignmentStart(27977205);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 27977250 - 27977205); 
+		pairS.parse(recorda);
+		
+		//ST-E00180:52:H5LNMCCXX:1:2103:1720:24691 113 chr1 27775356 39 117S33M = 27775354 0
+		//    <-------|  F5F3 reverse firstOfPaie
+		//<-----------|
+		recorda.setCigarString( "117S33M" );
+		recorda.setAlignmentStart( 27775356 );
+		recorda.setMateAlignmentStart( 27775354 );
+		assertTrue(BwaPair.getOverlapBase(recorda) == 27775389 - 27775356); 
+		pairS.parse(recorda);
+		
+		//ST-E00180:52:H5LNMCCXX:1:2101:31703:21983 65 chr1 34492938 60 95M55S = 34492938 0   
+		//F5F3 forward firstOfPaie
+		//s1 |--------------> e1			s1 |---------> e1
+		//s2 |------------> e2		or 		s2 |------------> e2
+		recorda.setFlags(65);
+		recorda.setCigarString("95M55S");
+		recorda.setAlignmentStart(34492938);
+		recorda.setMateAlignmentStart(34492938);
+		assertTrue(BwaPair.getOverlapBase(recorda) == 95); 
+		pairS.parse(recorda);
+	
+		
+		//ST-E00180:52:H5LNMCCXX:1:1205:9993:36522 97 chr1 121484553 43 149M = 121484404 0   
+		//outward firstOfPair   <---mate----|----read---->
+		recorda.setFlags(97);
+		recorda.setCigarString("95M55S");		
+		recorda.setAlignmentStart(121484553);
+		recorda.setMateAlignmentStart(121484404);		
+		assertTrue(BwaPair.getOverlapBase(recorda) == 1); 
+		pairS.parse(recorda);
+		
+		assertTrue( pairS.getFirstOfPairCounts() == 4 );
+		assertTrue( pairS.near.get() == 0 ); //only one without overlap		
+		assertTrue( pairS.tLenOverall.get(0) == 4 ); 
+		
+		assertTrue( pairS.getoverlapCounts().get(0) == 0 );
+		assertTrue( pairS.getoverlapCounts().get(33) == 1 );
+		assertTrue( pairS.getoverlapCounts().get(45) == 1 );
+		assertTrue( pairS.getoverlapCounts().get(95) == 1 );
+		
+	}
+
 	public static Element createPairRoot(File input) throws Exception {
 		createPairInputFile(input);
 		BamSummarizer2 bs = new BamSummarizer2();

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadGroupSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadGroupSummaryTest.java
@@ -120,7 +120,7 @@ public class ReadGroupSummaryTest {
 	 * @param ele:<sequenceMetrics name="reads"..>
 	 */
 	private void checktLen(Element parent, int pairCount, int max, int mean, int mode, int median) {
-		Element ele = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+		Element ele = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP)
 		.stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals("tLen")).findFirst().get() ;	
 		assertTrue( checkChildValue( ele, ReadGroupSummary.MAX, max+"" )); 	
 		assertTrue( checkChildValue( ele, ReadGroupSummary.MEAN, mean +"")); 	
@@ -135,7 +135,7 @@ public class ReadGroupSummaryTest {
 	 * @param counts: array of {totalReads, supplementaryReads, secondaryReads, failedReads}
 	 */
 	private void checkDiscardReads(Element parent, int supplementary, int secondary, int failedVendor) {		
-		Element ele1 = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+		Element ele1 = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP)
 				   .stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("discardedReads")).findFirst().get() ;				
 		assertTrue( checkChildValue(ele1,"supplementaryAlignmentCount", String.valueOf(supplementary)));
 		assertTrue( checkChildValue(ele1,"secondaryAlignmentCount", String.valueOf(secondary)));
@@ -151,7 +151,7 @@ public class ReadGroupSummaryTest {
 	 * @return
 	 */
 	private Element checkBadReadStats(Element parent, String name, int reads, int base, String percent ){		    
-		   Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+		   Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP)
 				   .stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(name)).findFirst().get() ;		   
 			assertTrue( checkChildValue(groupE,"readCount", String.valueOf(reads)));
 			assertTrue( checkChildValue(groupE,"basesLostCount", String.valueOf(base)));			 		
@@ -168,7 +168,7 @@ public class ReadGroupSummaryTest {
 	 */
 	private void checkCountedReadStats(Element parent, String nodeName, int[] counts, String percent ) {
 		//check readCount		 
-		Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+		Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP)
 			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(nodeName)).findFirst().get() ;		   
 		assertTrue( checkChildValue(groupE, ReadGroupSummary.MIN, String.valueOf(counts[1] )));
 		assertTrue( checkChildValue(groupE, ReadGroupSummary.MAX, String.valueOf(counts[2] )));
@@ -223,7 +223,7 @@ public class ReadGroupSummaryTest {
 		assertTrue(rgSumm.getReadCount() == 2);
 		
 		//<sequenceMetrics name="baseLost">
-		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkBadReadStats(root1, "duplicateReads", 0, 0, "0.00");
 		checkBadReadStats(root1, "unmappedReads", 0, 0, "0.00" );
@@ -235,18 +235,18 @@ public class ReadGroupSummaryTest {
 		
 		
 		//<sequenceMetrics name="reads" readCount="2">					
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;		
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("2"));
 		checkDiscardReads(root1, 0,0,0);
 		
 		//check readCount
-		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		   					
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MAX, "50" )); 	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MEAN, "43" )); 
 		
-		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.UNPAIRED_READ, "0" ));
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.READ_COUNT, "2" )); 
@@ -267,7 +267,7 @@ public class ReadGroupSummaryTest {
 		assertTrue(rgSumm.getReadCount() == 1); //counted reads is  1	
 		
 		//<sequenceMetrics name="baseLost">
-		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkBadReadStats(root1, "duplicateReads", 0, 0, "0.00");
 		checkBadReadStats(root1, "unmappedReads", 0, 0, "0.00" );
@@ -278,19 +278,19 @@ public class ReadGroupSummaryTest {
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_OVERLAP, new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 				
 		//<sequenceMetrics name="reads" readCount="2">					
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;	
 		checktLen(root1, 0, 0,  0, 0,0);
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("1"));
 		checkDiscardReads(root1, 0,0,0);
 		
 		//check readCount
-		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		  		
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MAX, "75" )); 	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MEAN, "75" )); 	
 		
-		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;			
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.READ_COUNT, "1" )); 
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.UNPAIRED_READ, "1" ));
@@ -312,7 +312,7 @@ public class ReadGroupSummaryTest {
 		assertTrue(rgSumm.getReadCount() == 6); //counted reads is 9-1-1-1 =6			
 				
 		//<sequenceMetrics name="baseLost">
-		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkBadReadStats(root1, "duplicateReads", 2, 80, "33.33"); 
 		checkBadReadStats(root1, "unmappedReads", 1, 40, "16.67" );
@@ -323,19 +323,19 @@ public class ReadGroupSummaryTest {
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_HARDCLIP, new int[] {3,3,8 ,5 ,3,5,16}, "6.67" );			
 				
 		//<sequenceMetrics name="reads" readCount="2">					
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;	
 		checktLen(root1,2, 93,  59, 26,93);
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("9"));
 		checkDiscardReads(root1, 1,1,1);
 		
 		//check readCount
-		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		   					
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MAX, "40" )); 	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MEAN, "39" )); 
 		
-		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;		
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.READ_COUNT, "6" )); 
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.UNPAIRED_READ, "0" ));
@@ -356,7 +356,7 @@ public class ReadGroupSummaryTest {
 		sr.toXml(root);	
 
 		root = XmlElementUtils.getOffspringElementByTagName( root, "bamSummary" ).get(0);
-		Element root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.METRICS_ELE )		
+		Element root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.SEQUENCE_METRICS )		
 		.stream().filter( ele -> ele.getAttribute(XmlUtils.NAME ).equals( XmlUtils.ALL_BASE_LOST  )).findFirst().get() ;	
 		assertTrue( checkChildValue( root1, ReadGroupSummary.READ_COUNT, "9" ));
 		assertTrue( checkChildValue( root1, ReadGroupSummary.BASE_COUNT , "415" ));	
@@ -369,7 +369,7 @@ public class ReadGroupSummaryTest {
 		assertTrue( checkChildValue( root1, StringUtils.getJoinedString( ReadGroupSummary.NODE_HARDCLIP, ReadGroupSummary.BASE_LOST_PERCENT, "_"), "3.86" ));  //16/415
 		assertTrue( checkChildValue( root1, StringUtils.getJoinedString( ReadGroupSummary.NODE_OVERLAP , ReadGroupSummary.BASE_LOST_PERCENT, "_"), "21.20" ));  //88/415	   		
 			
-		root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.METRICS_ELE )		
+		root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.SEQUENCE_METRICS )		
 				.stream().filter( ele -> ele.getAttribute(XmlUtils.NAME ).equals( XmlUtils.OVERALL  )).findFirst().get() ;
 		assertTrue( checkChildValue( root1, "Number of cycles with greater than 1% mismatches", "0" ));  
 		assertTrue( checkChildValue( root1, "Average length of first-of-pair reads", "36" )); // (37+35+37)/3
@@ -402,21 +402,21 @@ public class ReadGroupSummaryTest {
 		rgSumm.readSummary2Xml(root);
 		
 		//<sequenceMetrics name="basesLost">
-		Element	root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		Element	root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 						.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_SOFTCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_HARDCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_TRIM , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		
 		//<sequenceMetrics name="reads"
-		root1  = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		root1  = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;	
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("4"));
 		checktLen(root1,0, 0,  0, 0,0);		
 		checkDiscardReads(root1, 0,0,0);
 		
 		//<variableGroup name="countedReads">
-		root1 = XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+		root1 = XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;	
 		assertTrue( checkChildValue( root1, ReadGroupSummary.READ_COUNT, "4" )); 
 		assertTrue( checkChildValue( root1, ReadGroupSummary.UNPAIRED_READ, "0" ));
@@ -444,7 +444,7 @@ public class ReadGroupSummaryTest {
 		Element root = XmlElementUtils.createRootElement("root",null);
 		rgSumm.readSummary2Xml(root);
 		
-		Element	root1 = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.VARIABLE_GROUP_ELE)
+		Element	root1 = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.VARIABLE_GROUP)
 				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;
 		assertTrue( checkChildValue( root1, ReadGroupSummary.READ_COUNT, "3" )); 
 		assertTrue( checkChildValue( root1, ReadGroupSummary.UNPAIRED_READ, "1" ));
@@ -454,7 +454,7 @@ public class ReadGroupSummaryTest {
 		
 		
 		//<sequenceMetrics name="basesLost">
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS)		
 					.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_SOFTCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_HARDCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadGroupSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadGroupSummaryTest.java
@@ -120,8 +120,8 @@ public class ReadGroupSummaryTest {
 	 * @param ele:<sequenceMetrics name="reads"..>
 	 */
 	private void checktLen(Element parent, int pairCount, int max, int mean, int mode, int median) {
-		Element ele = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.variableGroupEle)
-		.stream().filter(e -> e.getAttribute(XmlUtils.sName).equals("tLen")).findFirst().get() ;	
+		Element ele = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+		.stream().filter(e -> e.getAttribute(XmlUtils.NAME).equals("tLen")).findFirst().get() ;	
 		assertTrue( checkChildValue( ele, ReadGroupSummary.MAX, max+"" )); 	
 		assertTrue( checkChildValue( ele, ReadGroupSummary.MEAN, mean +"")); 	
 		assertTrue( checkChildValue( ele, ReadGroupSummary.MODE, mode+"" )); 	
@@ -135,8 +135,8 @@ public class ReadGroupSummaryTest {
 	 * @param counts: array of {totalReads, supplementaryReads, secondaryReads, failedReads}
 	 */
 	private void checkDiscardReads(Element parent, int supplementary, int secondary, int failedVendor) {		
-		Element ele1 = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.variableGroupEle)
-				   .stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals("discardedReads")).findFirst().get() ;				
+		Element ele1 = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+				   .stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("discardedReads")).findFirst().get() ;				
 		assertTrue( checkChildValue(ele1,"supplementaryAlignmentCount", String.valueOf(supplementary)));
 		assertTrue( checkChildValue(ele1,"secondaryAlignmentCount", String.valueOf(secondary)));
 		assertTrue( checkChildValue(ele1,"failedVendorQualityCount", String.valueOf(failedVendor)));
@@ -151,8 +151,8 @@ public class ReadGroupSummaryTest {
 	 * @return
 	 */
 	private Element checkBadReadStats(Element parent, String name, int reads, int base, String percent ){		    
-		   Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.variableGroupEle)
-				   .stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals(name)).findFirst().get() ;		   
+		   Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+				   .stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(name)).findFirst().get() ;		   
 			assertTrue( checkChildValue(groupE,"readCount", String.valueOf(reads)));
 			assertTrue( checkChildValue(groupE,"basesLostCount", String.valueOf(base)));			 		
 			assertTrue( checkChildValue(groupE,"basesLostPercent",percent));
@@ -168,8 +168,8 @@ public class ReadGroupSummaryTest {
 	 */
 	private void checkCountedReadStats(Element parent, String nodeName, int[] counts, String percent ) {
 		//check readCount		 
-		Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.variableGroupEle)
-			.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals(nodeName)).findFirst().get() ;		   
+		Element groupE =  XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VARIABLE_GROUP_ELE)
+			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(nodeName)).findFirst().get() ;		   
 		assertTrue( checkChildValue(groupE, ReadGroupSummary.MIN, String.valueOf(counts[1] )));
 		assertTrue( checkChildValue(groupE, ReadGroupSummary.MAX, String.valueOf(counts[2] )));
 		assertTrue( checkChildValue(groupE, ReadGroupSummary.MEAN, String.valueOf(counts[3] )));
@@ -181,8 +181,8 @@ public class ReadGroupSummaryTest {
 	}
 			
 	public static boolean checkChildValue(Element parent,String name, String value) {
-		 List<Element> eles = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.sValue);	
-		 Element ele = eles.stream().filter( e -> e.getAttribute(XmlUtils.sName).equals(name)).findFirst().get() ;		 
+		 List<Element> eles = XmlElementUtils.getChildElementByTagName(parent, XmlUtils.VALUE);	
+		 Element ele = eles.stream().filter( e -> e.getAttribute(XmlUtils.NAME).equals(name)).findFirst().get() ;		 
 		 return ele.getTextContent().equals(value);		
 	}
 
@@ -223,8 +223,8 @@ public class ReadGroupSummaryTest {
 		assertTrue(rgSumm.getReadCount() == 2);
 		
 		//<sequenceMetrics name="baseLost">
-		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "basesLost" )).findFirst().get() ;	
+		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkBadReadStats(root1, "duplicateReads", 0, 0, "0.00");
 		checkBadReadStats(root1, "unmappedReads", 0, 0, "0.00" );
 		checkBadReadStats(root1, ReadGroupSummary.NODE_NOT_PROPER_PAIR, 0, 0, "0.00" );
@@ -235,19 +235,19 @@ public class ReadGroupSummaryTest {
 		
 		
 		//<sequenceMetrics name="reads" readCount="2">					
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-			.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "reads" )).findFirst().get() ;		
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;		
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("2"));
 		checkDiscardReads(root1, 0,0,0);
 		
 		//check readCount
-		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		   					
+		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		   					
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MAX, "50" )); 	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MEAN, "43" )); 
 		
-		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals("countedReads")).findFirst().get() ;	
+		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.UNPAIRED_READ, "0" ));
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.READ_COUNT, "2" )); 
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.BASE_LOST_COUNT, "80" ));
@@ -267,8 +267,8 @@ public class ReadGroupSummaryTest {
 		assertTrue(rgSumm.getReadCount() == 1); //counted reads is  1	
 		
 		//<sequenceMetrics name="baseLost">
-		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "basesLost" )).findFirst().get() ;	
+		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkBadReadStats(root1, "duplicateReads", 0, 0, "0.00");
 		checkBadReadStats(root1, "unmappedReads", 0, 0, "0.00" );
 		checkBadReadStats(root1, "trimmedBases", 0, 0, "0.00" );
@@ -278,20 +278,20 @@ public class ReadGroupSummaryTest {
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_OVERLAP, new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 				
 		//<sequenceMetrics name="reads" readCount="2">					
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-			.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "reads" )).findFirst().get() ;	
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;	
 		checktLen(root1, 0, 0,  0, 0,0);
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("1"));
 		checkDiscardReads(root1, 0,0,0);
 		
 		//check readCount
-		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		  		
+		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		  		
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MAX, "75" )); 	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MEAN, "75" )); 	
 		
-		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals("countedReads")).findFirst().get() ;			
+		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;			
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.READ_COUNT, "1" )); 
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.UNPAIRED_READ, "1" ));
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.BASE_LOST_COUNT, "0" ));
@@ -312,8 +312,8 @@ public class ReadGroupSummaryTest {
 		assertTrue(rgSumm.getReadCount() == 6); //counted reads is 9-1-1-1 =6			
 				
 		//<sequenceMetrics name="baseLost">
-		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "basesLost" )).findFirst().get() ;	
+		Element root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkBadReadStats(root1, "duplicateReads", 2, 80, "33.33"); 
 		checkBadReadStats(root1, "unmappedReads", 1, 40, "16.67" );
 		checkBadReadStats(root1, "trimmedBases", 0, 0, "0.00" );
@@ -323,20 +323,20 @@ public class ReadGroupSummaryTest {
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_HARDCLIP, new int[] {3,3,8 ,5 ,3,5,16}, "6.67" );			
 				
 		//<sequenceMetrics name="reads" readCount="2">					
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-			.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "reads" )).findFirst().get() ;	
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+			.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;	
 		checktLen(root1,2, 93,  59, 26,93);
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("9"));
 		checkDiscardReads(root1, 1,1,1);
 		
 		//check readCount
-		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		   					
+		Element groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals(ReadGroupSummary.NODE_READ_LENGTH)).findFirst().get() ;		   					
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MAX, "40" )); 	
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.MEAN, "39" )); 
 		
-		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals("countedReads")).findFirst().get() ;		
+		groupE =  XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;		
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.READ_COUNT, "6" )); 
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.UNPAIRED_READ, "0" ));
 		assertTrue( checkChildValue( groupE, ReadGroupSummary.BASE_LOST_COUNT, "162" ));
@@ -356,8 +356,8 @@ public class ReadGroupSummaryTest {
 		sr.toXml(root);	
 
 		root = XmlElementUtils.getOffspringElementByTagName( root, "bamSummary" ).get(0);
-		Element root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.metricsEle )		
-		.stream().filter( ele -> ele.getAttribute(XmlUtils.sName ).equals( "summary2" )).findFirst().get() ;	
+		Element root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.METRICS_ELE )		
+		.stream().filter( ele -> ele.getAttribute(XmlUtils.NAME ).equals( XmlUtils.ALL_BASE_LOST  )).findFirst().get() ;	
 		assertTrue( checkChildValue( root1, ReadGroupSummary.READ_COUNT, "9" ));
 		assertTrue( checkChildValue( root1, ReadGroupSummary.BASE_COUNT , "415" ));	
 		//duplicate 80/415=19.28
@@ -369,13 +369,13 @@ public class ReadGroupSummaryTest {
 		assertTrue( checkChildValue( root1, StringUtils.getJoinedString( ReadGroupSummary.NODE_HARDCLIP, ReadGroupSummary.BASE_LOST_PERCENT, "_"), "3.86" ));  //16/415
 		assertTrue( checkChildValue( root1, StringUtils.getJoinedString( ReadGroupSummary.NODE_OVERLAP , ReadGroupSummary.BASE_LOST_PERCENT, "_"), "21.20" ));  //88/415	   		
 			
-		root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.metricsEle )		
-				.stream().filter( ele -> ele.getAttribute(XmlUtils.sName ).equals( "summary1" )).findFirst().get() ;
+		root1 = XmlElementUtils.getChildElementByTagName( root, XmlUtils.METRICS_ELE )		
+				.stream().filter( ele -> ele.getAttribute(XmlUtils.NAME ).equals( XmlUtils.OVERALL  )).findFirst().get() ;
 		assertTrue( checkChildValue( root1, "Number of cycles with greater than 1% mismatches", "0" ));  
 		assertTrue( checkChildValue( root1, "Average length of first-of-pair reads", "36" )); // (37+35+37)/3
 		assertTrue( checkChildValue( root1, "Average length of second-of-pair reads", "41" )); // (32+50)/2
 		assertTrue( checkChildValue( root1, "Discarded reads (FailedVendorQuality, secondary, supplementary)", "3" ));  	
-		assertTrue( checkChildValue( root1, "Total reads including discarded reads", "12" )); // 
+		assertTrue( checkChildValue( root1, "Total reads including discarded reads", "12" )); //
 	}				
 
 	@Test
@@ -402,22 +402,22 @@ public class ReadGroupSummaryTest {
 		rgSumm.readSummary2Xml(root);
 		
 		//<sequenceMetrics name="basesLost">
-		Element	root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-						.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "basesLost" )).findFirst().get() ;	
+		Element	root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+						.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_SOFTCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_HARDCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_TRIM , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		
 		//<sequenceMetrics name="reads"
-		root1  = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "reads" )).findFirst().get() ;	
+		root1  = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "reads" )).findFirst().get() ;	
 		assertTrue( root1.getAttribute(ReadGroupSummary.READ_COUNT).equals("4"));
 		checktLen(root1,0, 0,  0, 0,0);		
 		checkDiscardReads(root1, 0,0,0);
 		
 		//<variableGroup name="countedReads">
-		root1 = XmlElementUtils.getChildElementByTagName(root1, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals("countedReads")).findFirst().get() ;	
+		root1 = XmlElementUtils.getChildElementByTagName(root1, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;	
 		assertTrue( checkChildValue( root1, ReadGroupSummary.READ_COUNT, "4" )); 
 		assertTrue( checkChildValue( root1, ReadGroupSummary.UNPAIRED_READ, "0" ));
 		assertTrue( checkChildValue( root1, ReadGroupSummary.BASE_LOST_PERCENT, "100.00" ));   
@@ -444,8 +444,8 @@ public class ReadGroupSummaryTest {
 		Element root = XmlElementUtils.createRootElement("root",null);
 		rgSumm.readSummary2Xml(root);
 		
-		Element	root1 = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.variableGroupEle)
-				.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals("countedReads")).findFirst().get() ;
+		Element	root1 = XmlElementUtils.getOffspringElementByTagName( root, XmlUtils.VARIABLE_GROUP_ELE)
+				.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals("countedReads")).findFirst().get() ;
 		assertTrue( checkChildValue( root1, ReadGroupSummary.READ_COUNT, "3" )); 
 		assertTrue( checkChildValue( root1, ReadGroupSummary.UNPAIRED_READ, "1" ));
 		assertTrue( checkChildValue( root1, ReadGroupSummary.BASE_LOST_PERCENT, "100.00" ));   
@@ -454,8 +454,8 @@ public class ReadGroupSummaryTest {
 		
 		
 		//<sequenceMetrics name="basesLost">
-		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.metricsEle)		
-					.stream().filter(ele -> ele.getAttribute(XmlUtils.sName).equals( "basesLost" )).findFirst().get() ;	
+		root1 = XmlElementUtils.getChildElementByTagName(root, XmlUtils.METRICS_ELE)		
+					.stream().filter(ele -> ele.getAttribute(XmlUtils.NAME).equals( "basesLost" )).findFirst().get() ;	
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_SOFTCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_HARDCLIP , new int[] {0, 0, 0, 0, 0,0,0}, "0.00");
 		checkCountedReadStats(root1, ReadGroupSummary.NODE_TRIM , new int[] {1, 7,7, 7, 7,7,7}, "33.33");		

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/SampleSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/SampleSummaryTest.java
@@ -83,28 +83,28 @@ public class SampleSummaryTest {
 		for(VcfRecord re: records) summary.parseRecord( re, 1 );
 		summary.toXML( root,null, null );  
 		if(records.size() == 0){			
-			assertEquals( 0, XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.sValue).size());			 
+			assertEquals( 0, XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VALUE).size());			 
 			return; 
 		}
 			
 			
 		//get <SNP TiTvRatio="0.00" Transitions="0" Transversions="1">
-		Element subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.sValue).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sName).equals(SampleSummary.tiTvRatio)).findFirst().get();								 
+		Element subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VALUE).stream()
+				.filter( e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.tiTvRatio)).findFirst().get();								 
 		assertEquals( ratio, subE.getTextContent());
 		
 		
 		if(ti != null) {
-			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.variableGroupEle).stream()
-					.filter( e -> e.getAttribute(XmlUtils.sName).equals(SampleSummary.transitions)).findFirst().get();
-			assertEquals(ti, XmlElementUtils.getChildElement(subE, XmlUtils.sTally, 0).getAttribute(XmlUtils.sCount));
+			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP_ELE).stream()
+					.filter( e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transitions)).findFirst().get();
+			assertEquals(ti, XmlElementUtils.getChildElement(subE, XmlUtils.TALLY, 0).getAttribute(XmlUtils.COUNT));
 			
 		}
 		
 		if(tv != null) {
-			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.variableGroupEle).stream()
-					.filter( e -> e.getAttribute(XmlUtils.sName).equals(SampleSummary.transversions)).findFirst().get();
-			assertEquals(tv,  XmlElementUtils.getChildElement(subE, XmlUtils.sTally, 0).getAttribute(XmlUtils.sCount));
+			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP_ELE).stream()
+					.filter( e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transversions)).findFirst().get();
+			assertEquals(tv,  XmlElementUtils.getChildElement(subE, XmlUtils.TALLY, 0).getAttribute(XmlUtils.COUNT));
 			
 		}
 	

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/SampleSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/SampleSummaryTest.java
@@ -95,14 +95,14 @@ public class SampleSummaryTest {
 		
 		
 		if(ti != null) {
-			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP_ELE).stream()
+			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP).stream()
 					.filter( e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transitions)).findFirst().get();
 			assertEquals(ti, XmlElementUtils.getChildElement(subE, XmlUtils.TALLY, 0).getAttribute(XmlUtils.COUNT));
 			
 		}
 		
 		if(tv != null) {
-			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP_ELE).stream()
+			subE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP).stream()
 					.filter( e -> e.getAttribute(XmlUtils.NAME).equals(SampleSummary.transversions)).findFirst().get();
 			assertEquals(tv,  XmlElementUtils.getChildElement(subE, XmlUtils.TALLY, 0).getAttribute(XmlUtils.COUNT));
 			

--- a/qprofiler2/test/org/qcmg/qprofiler2/util/FlagUtilTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/util/FlagUtilTest.java
@@ -115,7 +115,7 @@ public class FlagUtilTest {
 		XmlUtils.outputTallyGroup( root , "FLAG", flagBinaryCount, true, true);	
 		
 		//check output
-		List<Element> tallys =  XmlElementUtils.getChildElementByTagName(XmlElementUtils.getChildElement( root, XmlUtils.VARIABLE_GROUP_ELE,0), XmlUtils.TALLY );
+		List<Element> tallys =  XmlElementUtils.getChildElementByTagName(XmlElementUtils.getChildElement( root, XmlUtils.VARIABLE_GROUP,0), XmlUtils.TALLY );
 		assertEquals( 2, tallys.size() );
 		
 		assertEquals( 1, tallys.stream().filter( e -> e.getAttribute(XmlUtils.COUNT).equals("1")  &&  e.getAttribute(XmlUtils.VALUE).equals("000001100011, pPR1")).count() );

--- a/qprofiler2/test/org/qcmg/qprofiler2/util/FlagUtilTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/util/FlagUtilTest.java
@@ -112,14 +112,14 @@ public class FlagUtilTest {
 				String flagString = FlagUtil.getFlagString(i);
 				flagBinaryCount.put(flagString, new AtomicLong(flagIntegerCount.get(i)));
 			}				
-		XmlUtils.outputTallyGroup( root , "FLAG", flagBinaryCount, true);	
+		XmlUtils.outputTallyGroup( root , "FLAG", flagBinaryCount, true, true);	
 		
 		//check output
-		List<Element> tallys =  XmlElementUtils.getChildElementByTagName(XmlElementUtils.getChildElement( root, XmlUtils.variableGroupEle,0), XmlUtils.sTally );
+		List<Element> tallys =  XmlElementUtils.getChildElementByTagName(XmlElementUtils.getChildElement( root, XmlUtils.VARIABLE_GROUP_ELE,0), XmlUtils.TALLY );
 		assertEquals( 2, tallys.size() );
 		
-		assertEquals( 1, tallys.stream().filter( e -> e.getAttribute(XmlUtils.sCount).equals("1")  &&  e.getAttribute(XmlUtils.sValue).equals("000001100011, pPR1")).count() );
-		assertEquals( 1, tallys.stream().filter( e -> e.getAttribute(XmlUtils.sCount).equals("2")  &&  e.getAttribute(XmlUtils.sValue).equals("000010010011, pPr2")).count() );
+		assertEquals( 1, tallys.stream().filter( e -> e.getAttribute(XmlUtils.COUNT).equals("1")  &&  e.getAttribute(XmlUtils.VALUE).equals("000001100011, pPR1")).count() );
+		assertEquals( 1, tallys.stream().filter( e -> e.getAttribute(XmlUtils.COUNT).equals("2")  &&  e.getAttribute(XmlUtils.VALUE).equals("000010010011, pPr2")).count() );
 	}
 
 }

--- a/qprofiler2/test/org/qcmg/qprofiler2/util/XmlUtilsTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/util/XmlUtilsTest.java
@@ -57,21 +57,21 @@ public class XmlUtilsTest {
 		Element root = XmlElementUtils.createRootElement( "root", null );
 		XmlUtils.outputTallyGroupWithSize(root, "test", map, limit);
 		
-		Element ele = XmlElementUtils.getChildElement(root, XmlUtils.variableGroupEle,0);
-		assertTrue(ele.getAttribute(XmlUtils.sCount).equals("31"));//[1..20][5..15]
-		assertTrue(ele.getAttribute(XmlUtils.sTallyCount).equals(limit+"+"));
+		Element ele = XmlElementUtils.getChildElement(root, XmlUtils.VARIABLE_GROUP_ELE,0);
+		assertTrue(ele.getAttribute(XmlUtils.COUNT).equals("31"));//[1..20][5..15]
+		assertTrue(ele.getAttribute(XmlUtils.TALLY_COUNT).equals(limit+"+"));
 					
 		int[] counts = new int[] {1,1,1,1,2,2,2,2,2,2};
 		int[] values = new int[] {1,2,3,4,5,6,7,8,9,10};
-		for(Element e : XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.sTally)) {
+		for(Element e : XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.TALLY)) {
 			boolean isFind = false;		 
-			if(e.getAttribute(XmlUtils.sValue).equals(XmlUtils.OTHER)){
-					assertTrue(e.getAttribute(XmlUtils.sCount).equals("15"));
+			if(e.getAttribute(XmlUtils.VALUE).equals(XmlUtils.OTHER)){
+					assertTrue(e.getAttribute(XmlUtils.COUNT).equals("15"));
 					isFind = true;
 			}else {
 				for(int i = 0; i<=10; i++) {		 
-					if(e.getAttribute(XmlUtils.sValue).equals(values[i] + "")) {
-						assertTrue(e.getAttribute(XmlUtils.sCount).equals(counts[i]+""));
+					if(e.getAttribute(XmlUtils.VALUE).equals(values[i] + "")) {
+						assertTrue(e.getAttribute(XmlUtils.COUNT).equals(counts[i]+""));
 						isFind = true;
 						break;
 					}

--- a/qprofiler2/test/org/qcmg/qprofiler2/util/XmlUtilsTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/util/XmlUtilsTest.java
@@ -57,7 +57,7 @@ public class XmlUtilsTest {
 		Element root = XmlElementUtils.createRootElement( "root", null );
 		XmlUtils.outputTallyGroupWithSize(root, "test", map, limit);
 		
-		Element ele = XmlElementUtils.getChildElement(root, XmlUtils.VARIABLE_GROUP_ELE,0);
+		Element ele = XmlElementUtils.getChildElement(root, XmlUtils.VARIABLE_GROUP,0);
 		assertTrue(ele.getAttribute(XmlUtils.COUNT).equals("31"));//[1..20][5..15]
 		assertTrue(ele.getAttribute(XmlUtils.TALLY_COUNT).equals(limit+"+"));
 					

--- a/qprofiler2/test/org/qcmg/qprofiler2/vcf/VcfSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/vcf/VcfSummaryReportTest.java
@@ -123,7 +123,7 @@ public class VcfSummaryReportTest {
 				//only allow one sequenceMetric under report
 				assertTrue(node.getChildNodes().getLength() > 0 );				
 				Element cnode = (Element) node.getChildNodes().item(0);
-				assertEquals(XmlUtils.METRICS_ELE, cnode.getNodeName() );
+				assertEquals(XmlUtils.SEQUENCE_METRICS, cnode.getNodeName() );
 				if(cnode.getAttribute(XmlUtils.NAME).equals(SVTYPE.SNP.toVariantType()))  
 					assertEquals( 2, XmlElementUtils.getChildElementByTagName(cnode, XmlUtils.VALUE).size() );					
 				 else  
@@ -131,7 +131,7 @@ public class VcfSummaryReportTest {
 			}
 			List<Element> eles = new ArrayList<>();		
 			
- 			XmlElementUtils.getOffspringElementByTagName((Element)child, XmlUtils.VARIABLE_GROUP_ELE).stream() 
+ 			XmlElementUtils.getOffspringElementByTagName((Element)child, XmlUtils.VARIABLE_GROUP).stream() 
 				.filter( e -> e.getAttribute( XmlUtils.NAME ).equals( SampleSummary.genotype ))
 				.forEach( e1 ->     eles.addAll(XmlElementUtils.getChildElementByTagName(e1, XmlUtils.TALLY)) );
 					
@@ -377,9 +377,9 @@ public class VcfSummaryReportTest {
 			 					
 		for(int i = 0; i < 3; i ++){
 			Element e = (Element) ele.getChildNodes().item(i);
-			assertEquals(XmlUtils.METRICS_ELE, e.getNodeName() );						
-			assertEquals(1, XmlElementUtils.getChildElementByTagName( e, XmlUtils.VARIABLE_GROUP_ELE ).size());
-			Element e1 = XmlElementUtils.getChildElementByTagName( e, XmlUtils.VARIABLE_GROUP_ELE ).get(0);
+			assertEquals(XmlUtils.SEQUENCE_METRICS, e.getNodeName() );						
+			assertEquals(1, XmlElementUtils.getChildElementByTagName( e, XmlUtils.VARIABLE_GROUP ).size());
+			Element e1 = XmlElementUtils.getChildElementByTagName( e, XmlUtils.VARIABLE_GROUP ).get(0);
 			assertEquals(1, XmlElementUtils.getChildElementByTagName(e1, XmlUtils.TALLY).size());
 			e1 = XmlElementUtils.getChildElement(e1,  XmlUtils.TALLY, 0);
 			assertEquals(".", e1.getAttribute(XmlUtils.VALUE));

--- a/qprofiler2/test/org/qcmg/qprofiler2/vcf/VcfSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/vcf/VcfSummaryReportTest.java
@@ -179,8 +179,8 @@ public class VcfSummaryReportTest {
 		
 		// ariantAltFrequencyPercent only from 1/1:5,30,1:36:PASS:.
 		// 31/36 = 86%
-		assertEquals( 1 , XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.COLSED_BIN ).size() );
-		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.COLSED_BIN ).stream()
+		assertEquals( 1 , XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.CLOSED_BIN ).size() );
+		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.CLOSED_BIN ).stream()
 				.filter( e -> e.getAttribute(XmlUtils.START).equals("85")  && e.getAttribute(XmlUtils.COUNT).equals("10")).count();			
 //				.filter( e -> e.getAttribute(XmlUtils.Sstart).equals("85") && e.getAttribute(XmlUtils.Send).equals("90") && e.getAttribute(XmlUtils.Scount).equals("10")).count();			
 		assertEquals( 1 , no );
@@ -212,11 +212,11 @@ public class VcfSummaryReportTest {
 								
 		//titv will be done on sampleSummayTest		
 		//ariantAltFrequencyPercent
-		assertEquals( 2 , XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.COLSED_BIN ).size() );
-		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.COLSED_BIN ).stream()
+		assertEquals( 2 , XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.CLOSED_BIN ).size() );
+		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.CLOSED_BIN ).stream()
 				.filter( e -> e.getAttribute(XmlUtils.START).equals("45")  && e.getAttribute(XmlUtils.COUNT).equals("10")).count();			
 		assertEquals( 1 , no );	
-		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.COLSED_BIN ).stream()
+		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.CLOSED_BIN ).stream()
 				.filter( e -> e.getAttribute(XmlUtils.START).equals("95")  && e.getAttribute(XmlUtils.COUNT).equals("10")).count();			
 		assertEquals( 1 , no );			
 	}

--- a/qprofiler2/test/org/qcmg/qprofiler2/vcf/VcfSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/vcf/VcfSummaryReportTest.java
@@ -63,7 +63,7 @@ public class VcfSummaryReportTest {
 				for(int j = 0; j < 12; j ++) {
 					Element recordEle = (Element) headersEle.getChildNodes().item(j);
 					assertEquals( "record" , recordEle .getNodeName() );
-					String key = recordEle.getAttribute(XmlUtils.sName);
+					String key = recordEle.getAttribute(XmlUtils.NAME);
 					if(header.getRecords(key).size() == 1)
 						assertEquals( recordEle.getTextContent() , header.getRecords(key).get(0).toString() );
 					else
@@ -75,7 +75,7 @@ public class VcfSummaryReportTest {
 			else if( headersEle.getAttribute( "FIELD" ).equals( "qPG" ) ) {
 				mark[2] = 1;
 				for( Element ele : XmlElementUtils.getChildElementByTagName( headersEle, "record") )
-					assertEquals( ele.getTextContent(), header.getIDRecord("qPG", ele.getAttribute(XmlUtils.sName)).toString() );					
+					assertEquals( ele.getTextContent(), header.getIDRecord("qPG", ele.getAttribute(XmlUtils.NAME)).toString() );					
 			}else if( headersEle.getAttribute( "FIELD" ).equals( "FILTER" ) ) {
 				mark[3] = 1;
 				assertEquals( 1, headersEle.getChildNodes().getLength() );
@@ -123,25 +123,25 @@ public class VcfSummaryReportTest {
 				//only allow one sequenceMetric under report
 				assertTrue(node.getChildNodes().getLength() > 0 );				
 				Element cnode = (Element) node.getChildNodes().item(0);
-				assertEquals(XmlUtils.metricsEle, cnode.getNodeName() );
-				if(cnode.getAttribute(XmlUtils.sName).equals(SVTYPE.SNP.toVariantType()))  
-					assertEquals( 2, XmlElementUtils.getChildElementByTagName(cnode, XmlUtils.sValue).size() );					
+				assertEquals(XmlUtils.METRICS_ELE, cnode.getNodeName() );
+				if(cnode.getAttribute(XmlUtils.NAME).equals(SVTYPE.SNP.toVariantType()))  
+					assertEquals( 2, XmlElementUtils.getChildElementByTagName(cnode, XmlUtils.VALUE).size() );					
 				 else  
-					assertEquals( 1,  XmlElementUtils.getChildElementByTagName(cnode, XmlUtils.sValue).size() );				
+					assertEquals( 1,  XmlElementUtils.getChildElementByTagName(cnode, XmlUtils.VALUE).size() );				
 			}
 			List<Element> eles = new ArrayList<>();		
 			
- 			XmlElementUtils.getOffspringElementByTagName((Element)child, XmlUtils.variableGroupEle).stream() 
-				.filter( e -> e.getAttribute( XmlUtils.sName ).equals( SampleSummary.genotype ))
-				.forEach( e1 ->     eles.addAll(XmlElementUtils.getChildElementByTagName(e1, XmlUtils.sTally)) );
+ 			XmlElementUtils.getOffspringElementByTagName((Element)child, XmlUtils.VARIABLE_GROUP_ELE).stream() 
+				.filter( e -> e.getAttribute( XmlUtils.NAME ).equals( SampleSummary.genotype ))
+				.forEach( e1 ->     eles.addAll(XmlElementUtils.getChildElementByTagName(e1, XmlUtils.TALLY)) );
 					
 			List<Integer> counts = new ArrayList<>();
 			
-			eles.stream().forEach(e -> 	counts.add(Integer.parseInt(e.getAttribute(XmlUtils.sCount))) );			 			
+			eles.stream().forEach(e -> 	counts.add(Integer.parseInt(e.getAttribute(XmlUtils.COUNT))) );			 			
 		    assertEquals( 40, counts.stream().mapToInt(i -> i.intValue()).sum() );
 						
 			// assertTrue( counts == 40*2 );			
-			String sample = child.getAttributes().getNamedItem( XmlUtils.sName).getNodeValue();
+			String sample = child.getAttributes().getNamedItem( XmlUtils.NAME).getNodeValue();
 			if( sample.equals(lastSample) || sample.equals( "control2" ) )  checkLastSampleColumn(child);	
 			else if( sample.equals("test1"))
 					checkTest1(child);
@@ -167,21 +167,21 @@ public class VcfSummaryReportTest {
 		assertEquals( "PASS:." , ele.getAttribute("values"));
 				
 		//check genotype
-		long no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.sTally ).stream()
-			.filter( e -> e.getAttribute(XmlUtils.sValue).equals("0/0") && e.getAttribute(XmlUtils.sCount).equals("10")).count();		
+		long no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.TALLY ).stream()
+			.filter( e -> e.getAttribute(XmlUtils.VALUE).equals("0/0") && e.getAttribute(XmlUtils.COUNT).equals("10")).count();		
 		assertEquals( 1 , no );
-		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.sTally ).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sValue).equals("1/1") && e.getAttribute(XmlUtils.sCount).equals("10")).count();	
+		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.TALLY ).stream()
+				.filter( e -> e.getAttribute(XmlUtils.VALUE).equals("1/1") && e.getAttribute(XmlUtils.COUNT).equals("10")).count();	
 		assertEquals( 2 , no );
-		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.sTally ).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sValue).equals("0/1") && e.getAttribute(XmlUtils.sCount).equals("10")).count();	
+		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.TALLY ).stream()
+				.filter( e -> e.getAttribute(XmlUtils.VALUE).equals("0/1") && e.getAttribute(XmlUtils.COUNT).equals("10")).count();	
 		assertEquals( 1 , no );
 		
 		// ariantAltFrequencyPercent only from 1/1:5,30,1:36:PASS:.
 		// 31/36 = 86%
-		assertEquals( 1 , XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.sBin ).size() );
-		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.sBin ).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sStart).equals("85")  && e.getAttribute(XmlUtils.sCount).equals("10")).count();			
+		assertEquals( 1 , XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.COLSED_BIN ).size() );
+		no = XmlElementUtils.getOffspringElementByTagName( ele,  XmlUtils.COLSED_BIN ).stream()
+				.filter( e -> e.getAttribute(XmlUtils.START).equals("85")  && e.getAttribute(XmlUtils.COUNT).equals("10")).count();			
 //				.filter( e -> e.getAttribute(XmlUtils.Sstart).equals("85") && e.getAttribute(XmlUtils.Send).equals("90") && e.getAttribute(XmlUtils.Scount).equals("10")).count();			
 		assertEquals( 1 , no );
 				
@@ -200,24 +200,24 @@ public class VcfSummaryReportTest {
 		assertEquals( 1, XmlElementUtils.getOffspringElementByTagName( (Element) child,  "report" ).stream()
 				.filter( e -> e.getAttribute("values").equals(value) ).count() );		
 		//check genotype
-		long no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.sTally ).stream()
-			.filter( e -> e.getAttribute(XmlUtils.sValue).equals("0/1") && e.getAttribute(XmlUtils.sCount).equals("10")).count();		
+		long no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.TALLY ).stream()
+			.filter( e -> e.getAttribute(XmlUtils.VALUE).equals("0/1") && e.getAttribute(XmlUtils.COUNT).equals("10")).count();		
 		assertEquals( 1 , no );
-		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.sTally ).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sValue).equals("1/2") && e.getAttribute(XmlUtils.sCount).equals("10")).count();	
+		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.TALLY ).stream()
+				.filter( e -> e.getAttribute(XmlUtils.VALUE).equals("1/2") && e.getAttribute(XmlUtils.COUNT).equals("10")).count();	
 		assertEquals( 2 , no );
-		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.sTally ).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sValue).equals("0/2") && e.getAttribute(XmlUtils.sCount).equals("10")).count();	
+		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.TALLY ).stream()
+				.filter( e -> e.getAttribute(XmlUtils.VALUE).equals("0/2") && e.getAttribute(XmlUtils.COUNT).equals("10")).count();	
 		assertEquals( 1 , no );
 								
 		//titv will be done on sampleSummayTest		
 		//ariantAltFrequencyPercent
-		assertEquals( 2 , XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.sBin ).size() );
-		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.sBin ).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sStart).equals("45")  && e.getAttribute(XmlUtils.sCount).equals("10")).count();			
+		assertEquals( 2 , XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.COLSED_BIN ).size() );
+		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.COLSED_BIN ).stream()
+				.filter( e -> e.getAttribute(XmlUtils.START).equals("45")  && e.getAttribute(XmlUtils.COUNT).equals("10")).count();			
 		assertEquals( 1 , no );	
-		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.sBin ).stream()
-				.filter( e -> e.getAttribute(XmlUtils.sStart).equals("95")  && e.getAttribute(XmlUtils.sCount).equals("10")).count();			
+		no = XmlElementUtils.getOffspringElementByTagName( (Element) child,  XmlUtils.COLSED_BIN ).stream()
+				.filter( e -> e.getAttribute(XmlUtils.START).equals("95")  && e.getAttribute(XmlUtils.COUNT).equals("10")).count();			
 		assertEquals( 1 , no );			
 	}
 
@@ -239,7 +239,7 @@ public class VcfSummaryReportTest {
 				sr.toXml(root);				
 				List<Element> samples = XmlElementUtils.getOffspringElementByTagName(root, "sample");
 				assertEquals(4, samples.size());
-				assertEquals(1, samples.stream().filter( e -> e.getAttribute(XmlUtils.sName).equals(lastSample)).count()) ;	
+				assertEquals(1, samples.stream().filter( e -> e.getAttribute(XmlUtils.NAME).equals(lastSample)).count()) ;	
 				assertEquals(4, XmlElementUtils.getOffspringElementByTagName(root, "report").size());
 				XmlElementUtils.getOffspringElementByTagName(root, "report").forEach(e -> assertEquals( 0, e.getAttributes().getLength()) );				 
 			} catch (Exception e) { fail("unexpected error"); }
@@ -252,9 +252,9 @@ public class VcfSummaryReportTest {
 				sr.toXml(root);				
 				List<Element> samples = XmlElementUtils.getOffspringElementByTagName(root, "sample");
 				assertEquals(4, samples.size());
-				assertEquals(1, samples.stream().filter( e -> e.getAttribute(XmlUtils.sName).equals(lastSample)).count()) ;	
+				assertEquals(1, samples.stream().filter( e -> e.getAttribute(XmlUtils.NAME).equals(lastSample)).count()) ;	
 				assertEquals(6, XmlElementUtils.getOffspringElementByTagName(root, "report").size());				
-				Element child =  samples.stream().filter( e -> e.getAttribute(XmlUtils.sName).equals("test1")).findFirst().get();
+				Element child =  samples.stream().filter( e -> e.getAttribute(XmlUtils.NAME).equals("test1")).findFirst().get();
 				checkTest1(child);							 
 			} catch (Exception e) { fail("unexpected error"); }
 			
@@ -369,25 +369,25 @@ public class VcfSummaryReportTest {
 		
 		//check SNV, there is no gt so no titv
 		Element snvE = (Element) ele.getFirstChild();		
-		for( Element e : XmlElementUtils.getChildElementByTagName(snvE, XmlUtils.sValue) )
-			if(e.getAttribute(XmlUtils.sName).equals("inDBSNP"))  
+		for( Element e : XmlElementUtils.getChildElementByTagName(snvE, XmlUtils.VALUE) )
+			if(e.getAttribute(XmlUtils.NAME).equals("inDBSNP"))  
 				assertEquals("20", e.getTextContent() );  //dbsnp always same for all sample
-			else if(e.getAttribute(XmlUtils.sName).equals("TiTvRatio"))  
+			else if(e.getAttribute(XmlUtils.NAME).equals("TiTvRatio"))  
 				assertEquals("0.00", e.getTextContent() );
 			 					
 		for(int i = 0; i < 3; i ++){
 			Element e = (Element) ele.getChildNodes().item(i);
-			assertEquals(XmlUtils.metricsEle, e.getNodeName() );						
-			assertEquals(1, XmlElementUtils.getChildElementByTagName( e, XmlUtils.variableGroupEle ).size());
-			Element e1 = XmlElementUtils.getChildElementByTagName( e, XmlUtils.variableGroupEle ).get(0);
-			assertEquals(1, XmlElementUtils.getChildElementByTagName(e1, XmlUtils.sTally).size());
-			e1 = XmlElementUtils.getChildElement(e1,  XmlUtils.sTally, 0);
-			assertEquals(".", e1.getAttribute(XmlUtils.sValue));
+			assertEquals(XmlUtils.METRICS_ELE, e.getNodeName() );						
+			assertEquals(1, XmlElementUtils.getChildElementByTagName( e, XmlUtils.VARIABLE_GROUP_ELE ).size());
+			Element e1 = XmlElementUtils.getChildElementByTagName( e, XmlUtils.VARIABLE_GROUP_ELE ).get(0);
+			assertEquals(1, XmlElementUtils.getChildElementByTagName(e1, XmlUtils.TALLY).size());
+			e1 = XmlElementUtils.getChildElement(e1,  XmlUtils.TALLY, 0);
+			assertEquals(".", e1.getAttribute(XmlUtils.VALUE));
 			
-			if( e.getAttribute( XmlUtils.sName).equals(SVTYPE.SNP.toVariantType() )  ) 				
-				assertEquals("20",  e1.getAttribute( XmlUtils.sCount));
+			if( e.getAttribute( XmlUtils.NAME).equals(SVTYPE.SNP.toVariantType() )  ) 				
+				assertEquals("20",  e1.getAttribute( XmlUtils.COUNT));
 			else 				
-				assertEquals("10",  e1.getAttribute( XmlUtils.sCount));
+				assertEquals("10",  e1.getAttribute( XmlUtils.COUNT));
 			
 		}
 		


### PR DESCRIPTION
1. move pair algorithm from qProfiler2 to qPicard.  
2. Add one more condition "overlap==0, mate.start > read.end" to overlap algorithm. 
3. minor change summary node name and make it consistent to NSGCheck
3. remove comments from xml output
4. remove duplicated counts from cigar and summary section to avoid confusion. 