### PR TITLE
multi-thread bug fix

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizer2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizer2.java
@@ -15,6 +15,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 
 import htsjdk.samtools.SamReader;
@@ -57,8 +58,9 @@ public class BamSummarizer2 implements Summarizer {
 		SAMSequenceDictionary samSeqDict  = header.getSequenceDictionary();
 		//String bamHeader = reader.getFileHeader().getTextHeader();
 		List<SAMProgramRecord> pgLines = header.getProgramRecords();
-		List<String> readGroupIds = header.getReadGroups().stream().map( it -> it.getId()  ).collect(toList()); 
-							
+		List<String> readGroupIds = header.getReadGroups().stream().map( it -> it.getId()  ).collect(toList()); 		
+		readGroupIds.sort(Comparator.comparing( String::toString ) );//Natural order  
+		
 		BamSummaryReport2 bamSummaryReport = new BamSummaryReport2( maxRecords, isFullBamHeader );									
 		bamSummaryReport.setBamHeader(header, isFullBamHeader);		
 		bamSummaryReport.setSamSequenceDictionary(samSeqDict);

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/TagSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/TagSummaryReport2.java
@@ -84,27 +84,28 @@ public class TagSummaryReport2 {
 	
 	public void toXml(Element parent){
 				
-		//"tags:MD:Z" mismatchbycycle		
-		Element ele = XmlUtils.createMetricsNode(parent, "tags:MD:Z", 
-				new Pair<String, Number>(ReadGroupSummary.READ_COUNT, mdTagCounts.get()));
-		for(int order = 0; order < 3; order ++) { 
-			tagMDMismatchByCycle[order].toXml( ele, BamSummaryReport2.sourceName[order] );
+		//"tags:MD:Z" mismatchbycycle
+		if( mdTagCounts.get() > 0) {
+			Element ele = XmlUtils.createMetricsNode(parent, "tags:MD:Z", 
+					new Pair<String, Number>(ReadGroupSummary.READ_COUNT, mdTagCounts.get()));
+			for(int order = 0; order < 3; order ++) { 
+				tagMDMismatchByCycle[order].toXml( ele, BamSummaryReport2.sourceName[order] );
+			}
+					
+			for(String strand : new String[]{ "ForwardStrand", "ReverseStrand" }){				
+				for(int order = 0; order < 3; order ++) {				
+					Map<String, AtomicLong> mdRefAltLengthsString = new HashMap<>();
+					QCMGAtomicLongArray mdRefAltLengths = (strand.contains("Forward"))? mdRefAltLengthsForward[order] : mdRefAltLengthsReverse[order];				
+					for (int m = 0 ; m < mdRefAltLengths.length() ; m++) {
+						long l = mdRefAltLengths.get(m);
+						if (l <= 0)  continue;
+						mdRefAltLengthsString.put(CycleSummaryUtils.getStringFromInt(m), new AtomicLong(l));					 
+					}
+					String name = BamSummaryReport2.sourceName[order] + strand; 				
+					XmlUtils.outputTallyGroup(ele,  name, mdRefAltLengthsString, true, true);				
+				}		
+			}			
 		}
-				
-		for(String strand : new String[]{ "ForwardStrand", "ReverseStrand" }){				
-			for(int order = 0; order < 3; order ++) {				
-				Map<String, AtomicLong> mdRefAltLengthsString = new HashMap<>();
-				QCMGAtomicLongArray mdRefAltLengths = (strand.contains("Forward"))? mdRefAltLengthsForward[order] : mdRefAltLengthsReverse[order];				
-				for (int m = 0 ; m < mdRefAltLengths.length() ; m++) {
-					long l = mdRefAltLengths.get(m);
-					if (l <= 0)  continue;
-					mdRefAltLengthsString.put(CycleSummaryUtils.getStringFromInt(m), new AtomicLong(l));					 
-				}
-				String name = BamSummaryReport2.sourceName[order] + strand; 
-				
-				XmlUtils.outputTallyGroup(ele,  name, mdRefAltLengthsString, true, true);				
-			}		
-		}			
 		
 		// additional tags includes RG
 		for (Entry<String,  ConcurrentSkipListMap<String, AtomicLong>> entry : additionalTags.entrySet()) {			

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/PositionSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/PositionSummary.java
@@ -42,10 +42,9 @@ public class PositionSummary {
 	 * @param position sets the first position value of this summary record to position
 	 * 
 	 */	
-	public PositionSummary(List<String> rgs) {
+	public PositionSummary(List<String> rgs) {		
+		//Natural order should only do once inside BamSummarizer2::createReport
 		readGroupIds = rgs; 
-		//Natural order
-		readGroupIds.sort(Comparator.comparing( String::toString ) );
 		
 		min = new AtomicInteger(512*BUCKET_SIZE);
 		max = new AtomicInteger(0); 

--- a/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportMetricsTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportMetricsTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.ArrayList;
@@ -49,10 +50,7 @@ public class BamSummaryReportMetricsTest {
 		BamSummarizer2 bs = new BamSummarizer2();
 		//BamSummarizer2 bs = new BamSummarizer2( 200, null, true);
 		BamSummaryReport2 sr = (BamSummaryReport2) bs.summarize(input.getAbsolutePath()); 		
-		sr.toXml(root);	
-		
-		//debug
-		//XmlElementUtils.asXmlText(root, "/users/christix/Documents/Eclipse/gitHub/qprofiler_jun2019/adamajava/qprofiler2/qprofiler1.xml");		
+		sr.toXml(root);			
 	}
 	
 	/**
@@ -286,7 +284,7 @@ public class BamSummaryReportMetricsTest {
 	
 	
 	@Test
-	public void speedTest() {
+	public void speedTest() throws IOException {
 		List<String> myList  = new ArrayList<>();
 		
 		for(int i = 0; i < 101; i ++) {
@@ -303,7 +301,7 @@ public class BamSummaryReportMetricsTest {
 		
 		int freq = 10000;
 		String str; 
-		QLogger logger = QLoggerFactory.getLogger(QProfiler2.class, "my.log", "DEBUG");
+		QLogger logger = QLoggerFactory.getLogger(QProfiler2.class, testFolder.newFile("my.log").getAbsolutePath(), "DEBUG");
 		long start = System.currentTimeMillis();		
 		for(int i = 0; i < freq; i ++) {
 			str = myList.get(i%100);


### PR DESCRIPTION
1. sort readgroupId list once rather than sorting for each new reference name. 
2. stop outputting tag:MD:Z, if  there are no reads containing MD tag