### PR TITLE
change to getFullChromosome so that if supplied ref is chrM, that is …

### DIFF
--- a/qcommon/src/org/qcmg/common/util/IndelUtils.java
+++ b/qcommon/src/org/qcmg/common/util/IndelUtils.java
@@ -193,16 +193,11 @@ public class IndelUtils {
 	public static String getFullChromosome(String ref) {
 		if (ref == null ) return null; //stop exception
 		
-		//convert chrMT first 
-		if (ref.equals("chrM") || ref.equals("M") || ref.equals("MT")) {	
-           		 return "chrMT";	
-       		 }
-		
         if (ref.startsWith(Constants.CHR)) {
         	return ref;
         }
 		
-		if (ref.equals("X") || ref.equals("Y") ) {
+		if (ref.equals("X") || ref.equals("Y") || ref.equals("M") || ref.equals("MT")) {
 			return "chr" + ref;
 		}
 		

--- a/qcommon/src/org/qcmg/common/util/IndelUtils.java
+++ b/qcommon/src/org/qcmg/common/util/IndelUtils.java
@@ -193,11 +193,16 @@ public class IndelUtils {
 	public static String getFullChromosome(String ref) {
 		if (ref == null ) return null; //stop exception
 		
+		//convert chrMT first 
+		if (ref.equals("chrM") || ref.equals("M") || ref.equals("MT")) {	
+           		 return "chrMT";	
+       		 }
+		
         if (ref.startsWith(Constants.CHR)) {
         	return ref;
         }
 		
-		if (ref.equals("X") || ref.equals("Y") || ref.equals("M") || ref.equals("MT")) {
+		if (ref.equals("X") || ref.equals("Y") ) {
 			return "chr" + ref;
 		}
 		

--- a/qcommon/src/org/qcmg/common/util/IndelUtils.java
+++ b/qcommon/src/org/qcmg/common/util/IndelUtils.java
@@ -180,37 +180,39 @@ public class IndelUtils {
 	}
 	
 	/**
+	 * Takes a string representation of a contig and updates it if necessary (ie. if ref is equal to X,Y,M,MT, or an integer less than 23 and greater than 0).
+	 *  
+	 *  It used to be the case that is the supplied ref was equal to "chrM", the returned value would be "chrMT". 
+	 *  This was useful when different versions of the human genome (ie. GRCh37/b37 and Hg19) had different values for the mitochondrial genome.
+	 *  
+	 *  With the adoption of GRCh38, which uses "chrM", this feature was removed
 	 * 
 	 * @param ref
 	 * @return
 	 */
 	public static String getFullChromosome(String ref) {
-		if(ref == null ) return null; //stop exception
+		if (ref == null ) return null; //stop exception
 		
-		/*
-		 * Deal with MT special case first
-		 */
-        if (ref.equals("chrM") || ref.equals("M") || ref.equals("MT")) {
-            return "chrMT";
-        }
-        
         if (ref.startsWith(Constants.CHR)) {
-        		return ref;
-        	}
+        	return ref;
+        }
 		
-		if (ref.equals("X") || ref.equals("Y")) {
+		if (ref.equals("X") || ref.equals("Y") || ref.equals("M") || ref.equals("MT")) {
 			return "chr" + ref;
 		}
 		
 		/*
 		 * If ref is an integer less than 23, slap "chr" in front of it
 		 */
-		try {
-			if (Integer.parseInt(ref) < 23) {
-				return Constants.CHR + ref;
+		if (Character.isDigit(ref.charAt(0))) {
+			try {
+				int refInt = Integer.parseInt(ref);
+				if (refInt < 23 && refInt > 0) {
+					return Constants.CHR + ref;
+				}
+			} catch (NumberFormatException nfe) {
+				// don't do anything here - will return the original reference
 			}
-		} catch (NumberFormatException nfe) {
-			// don't do anything here - will return the original reference
 		}
 		
 		return ref;

--- a/qcommon/test/org/qcmg/common/util/IndelUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/IndelUtilsTest.java
@@ -198,7 +198,7 @@ public class IndelUtilsTest {
 		
 		assertEquals("chr10", IndelUtils.getFullChromosome("10"));
 		assertEquals("chr10", IndelUtils.getFullChromosome("chr10"));
-		assertEquals("chrMT", IndelUtils.getFullChromosome("M"));
+		assertEquals("chrM", IndelUtils.getFullChromosome("M"));
 		assertEquals("chrMT", IndelUtils.getFullChromosome("MT"));
 		assertEquals("GL12345", IndelUtils.getFullChromosome("GL12345"));
 	}
@@ -214,10 +214,10 @@ public class IndelUtilsTest {
 		assertEquals("chr1", IndelUtils.getFullChromosome("1"));
 		assertEquals("chrY", IndelUtils.getFullChromosome("Y"));
 		assertEquals("chrX", IndelUtils.getFullChromosome("X"));
-		assertEquals("chrMT", IndelUtils.getFullChromosome("M"));
+		assertEquals("chrM", IndelUtils.getFullChromosome("M"));
 		assertEquals("chrMT", IndelUtils.getFullChromosome("MT"));
 		assertEquals("chrMT", IndelUtils.getFullChromosome("chrMT"));
-		assertEquals("chrMT", IndelUtils.getFullChromosome("chrM"));
+		assertEquals("chrM", IndelUtils.getFullChromosome("chrM"));
 		assertEquals("MTT", IndelUtils.getFullChromosome("MTT"));
 		assertEquals("GL123", IndelUtils.getFullChromosome("GL123"));
 		assertEquals("chr10", IndelUtils.getFullChromosome("chr10"));


### PR DESCRIPTION
…what will be returned rather than chrMT

This change will allow `qannotate` to be run against `GRCh38`