### PR TITLE
moved vcf header filter descriptions from qsnp to qannotate

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/modes/GermlineMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/GermlineMode.java
@@ -50,6 +50,7 @@ public class GermlineMode extends AbstractMode{
 		loadVcfRecordsFromFile(new File( options.getInputFileName())   );
 		addAnnotation(options.getDatabaseFileName() );
 		header.addInfo(VcfHeaderUtils.INFO_GERMLINE, ".", "String",VcfHeaderUtils.INFO_GERMLINE_DESC);
+//		header.addFilter(VcfHeaderUtils.FILTER_GERMLINE,"Mutation is a germline variant in another patient");
 		reheader(options.getCommandLine(),options.getInputFileName())	;	
 		writeVCF(new File(options.getOutputFileName()) );	
 	}
@@ -72,7 +73,7 @@ public class GermlineMode extends AbstractMode{
 	void addAnnotation(String dbGermlineFile) throws IOException {
  		
  		/*
- 		 *  remove all exsiting GERM annotation
+ 		 *  remove all existing GERM annotation
  		 */
  		for (List<VcfRecord> vcfs : positionRecordMap.values()) {
  			for(VcfRecord vcf : vcfs ) {

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -1504,7 +1504,7 @@ public class VcfUtils {
 	 * @param minCoverage
 	 * @return
 	 */
-	public static boolean mutationInNorma(int altCount, int totalReadCount, float percentage, int maxCoverage) {
+	public static boolean mutationInNormal(int altCount, int totalReadCount, float percentage, int maxCoverage) {
 		if (altCount == 0) {
 			return false;
 		}
@@ -1520,7 +1520,7 @@ public class VcfUtils {
 		float passingCount = totalReadCount > 0 ? (((float)totalReadCount / 100) * percentage) : 0;
 		return altCount >= passingCount;
 	}
-	public static boolean mutationInNorma(int altCount, int totalReadCount, int percentage, int maxCoverage) {
-		return mutationInNorma(altCount, totalReadCount, (float) percentage, maxCoverage);
+	public static boolean mutationInNormal(int altCount, int totalReadCount, int percentage, int maxCoverage) {
+		return mutationInNormal(altCount, totalReadCount, (float) percentage, maxCoverage);
 	}
 }

--- a/qcommon/src/org/qcmg/common/vcf/header/VcfHeaderUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/header/VcfHeaderUtils.java
@@ -71,7 +71,7 @@ public class VcfHeaderUtils {
 			+ "and the repeat frequence is more than 10 (or more than six for homoplymers repeat), "
 			+ ", or less than 20% of informative reads are strong supporting in case of indel variant";
 	public static final String FILTER_END_OF_READ = "5BP";
-	public static final String FILTER_END_OF_READ_DESC = "Bases that fall within 5bp of the start or finish of the (filtered) read.";
+	public static final String FILTER_END_OF_READ_DESC = "There are fewer than 5 reads supporting the mutation where the mutation is in the middle of the read (ie. not 5bp from the start or end of the read) OR there are 5 or more reads supporting the mutation where the mutation is in the middle of the read, BUT they are all on the same strand";
 
 	//INFO FIELDS
 	public static final String INFO_MUTATION = "MU";

--- a/qcommon/test/org/qcmg/common/vcf/VcfFileMetaTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfFileMetaTest.java
@@ -118,6 +118,29 @@ public class VcfFileMetaTest {
 		VcfFileMeta meta = new VcfFileMeta(header);
 		assertEquals(ContentType.SINGLE_CALLER_SINGLE_SAMPLE, meta.getType());
 	}
+	@Test
+	public void ctorRealLifeFail2() {
+		VcfHeader header = new VcfHeader();
+		header.addOrReplace("##fileformat=VCFv4.2");
+		header.addOrReplace("##fileDate=20181008");
+		header.addOrReplace("##reference=file:///mnt/lustre/reference/genomes/GRCh37_ICGC_standard_v2/indexes/GATK_3.3-0/GRCh37_ICGC_standard_v2.fa");
+		header.addOrReplace("##qDonorId=02.006.0452");
+		header.addOrReplace("##qControlSample=020060452BP");
+		header.addOrReplace("##qTestSample=020060452FFPE");
+		header.addOrReplace("##qINPUT_GATK_TEST=/mnt/lustre/working/genomeinfo/analysis/7/2/72dde0d0-b795-44d2-956f-3b948389c677/72dde0d0-b795-44d2-956f-3b948389c677.vcf");
+		header.addOrReplace("##qINPUT_GATK_CONTROL=/mnt/lustre/working/genomeinfo/analysis/6/7/67db1323-1761-46e2-9f2a-6ec66c0cb229/67db1323-1761-46e2-9f2a-6ec66c0cb229.vcf");
+		header.addOrReplace("##qControlBam=/mnt/lustre/working/genomeinfo/sample/a/f/af146d8c-0a17-4a24-8953-38fb82b06987/aligned_read_group_set/a264340d-07bf-433b-b871-5a1051b040ae.bam");
+		header.addOrReplace("##qControlBamUUID=a264340d-07bf-433b-b871-5a1051b040ae");
+		header.addOrReplace("##qTestBam=/mnt/lustre/working/genomeinfo/sample/8/0/807cf4b0-4f64-4c75-8367-8edf5887b470/aligned_read_group_set/e3125365-7708-4e97-bee8-ba93337daedd.bam");
+		header.addOrReplace("##qTestBamUUID=e3125365-7708-4e97-bee8-ba93337daedd");
+		header.addOrReplace("##qAnalysisId=cf1c66f2-f2cd-4e90-8df0-34719d230c6e");
+		header.addOrReplace("##qUUID=405ee63d-a2ae-4ad5-a302-e5d523f3fb77");
+		header.addOrReplace("##qSource=qannotate-2.0.1 (2566)");
+		header.addOrReplace("##qINPUT=405ee63d-a2ae-4ad5-a302-e5d523f3fb77:/mnt/lustre/working/genomeinfo/analysis/c/f/cf1c66f2-f2cd-4e90-8df0-34719d230c6e/cf1c66f2-f2cd-4e90-8df0-34719d230c6e.vcf.conf");
+		header.addOrReplace("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t020060452BP\t020060452FFPE");
+		VcfFileMeta meta = new VcfFileMeta(header);
+		assertEquals(ContentType.SINGLE_CALLER_MULTIPLE_SAMPLES, meta.getType());
+	}
 	
 	@Test
 	public void ctorSingleSampleSingleCaller() {

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -1251,13 +1251,13 @@ public class VcfUtilsTest {
 	@Test
 	public void minWithAM() {
 		//static boolean mutationInNorma(int altCount, int totalReadCount, int percentage, int minCoverage) {
-		assertEquals(true, VcfUtils.mutationInNorma(1, 10, 5, 0));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 20, 5, 0));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 30, 5, 0));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 30, 5, 1));
-		assertEquals(false, VcfUtils.mutationInNorma(1, 30, 5, 2));
-		assertEquals(false, VcfUtils.mutationInNorma(1, 30, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 300, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 10, 5, 0));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 20, 5, 0));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 30, 5, 0));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 30, 5, 1));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 30, 5, 2));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 30, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 300, 5, 3));
 	}
 	
 	@Test
@@ -1295,31 +1295,31 @@ public class VcfUtilsTest {
 	
 	@Test
 	public void min() {
-		assertEquals(false, VcfUtils.mutationInNorma(0, 0, 0, 0));
-		assertEquals(false, VcfUtils.mutationInNorma(0, 10, 1, 2));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 10, 1, 2));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 1, 2));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 1, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 25, 2));
-		assertEquals(false, VcfUtils.mutationInNorma(2, 10, 25, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(0, 0, 0, 0));
+		assertEquals(false, VcfUtils.mutationInNormal(0, 10, 1, 2));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 10, 1, 2));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 1, 2));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 1, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 25, 2));
+		assertEquals(false, VcfUtils.mutationInNormal(2, 10, 25, 3));
 		
 		
-		assertEquals(false, VcfUtils.mutationInNorma(1, 24, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 63, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 79, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 99, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 24, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 63, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 79, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 99, 5, 3));
 		
-		assertEquals(false, VcfUtils.mutationInNorma(1, 30, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 10, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 10, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 10, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 30, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 10, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 10, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 10, 5, 3));
 		
-		assertEquals(false, VcfUtils.mutationInNorma(1, 100, 5, 3));
-		assertEquals(false, VcfUtils.mutationInNorma(2, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(5, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(6, 100, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 100, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(2, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(5, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(6, 100, 5, 3));
 	}
 }

--- a/qsnp/src/org/qcmg/snp/Pipeline.java
+++ b/qsnp/src/org/qcmg/snp/Pipeline.java
@@ -101,8 +101,6 @@ public abstract class Pipeline {
 			VcfHeaderUtils.FORMAT_NOVEL_STARTS + Constants.COLON + 
 			VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND;
 	
-//	static final String ILLUMINA_MOTIF = "GGT";
-	
 	/**
 	 * used to buffer the accumulation arrays in case reads go over ends of contigs 
 	 */
@@ -418,15 +416,6 @@ public abstract class Pipeline {
 		
 		header.addInfo(VcfHeaderUtils.INFO_FLANKING_SEQUENCE, "1", "String","Flanking sequence either side of variant");														
 		header.addInfo(VcfHeaderUtils.INFO_SOMATIC, "0", "Flag",VcfHeaderUtils.INFO_SOMATIC_DESC);														
-		header.addFilter(VcfHeaderUtils.FILTER_COVERAGE, VcfHeaderUtils.FILTER_COVERAGE_DESC);
-		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL,"Mutation also found in pileup of normal");  
-		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL,"Mutation also found in pileup of (unfiltered) normal");  
-		header.addFilter(VcfHeaderUtils.FILTER_GERMLINE,"Mutation is a germline variant in another patient");  
-		header.addFilter(VcfHeaderUtils.FILTER_NOVEL_STARTS,"Less than 4 novel starts not considering read pair");  
-		header.addFilter(VcfHeaderUtils.FILTER_MUTANT_READS,"Less than 5 mutant reads"); 
-		header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_ALT,"Alternate allele on only one strand (or percentage alternate allele on other strand is less than " + sBiasAltPercentage + "%)"); 
-		header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_COV,"Sequence coverage on only one strand (or percentage coverage on other strand is less than " + sBiasCovPercentage + "%)"); 
-	
 		header.addFormat(VcfHeaderUtils.FORMAT_GENOTYPE, "1", "String" ,"Genotype");
 		header.addFormat(VcfHeaderUtils.FORMAT_END_OF_READ, ".", "String",VcfHeaderUtils.FORMAT_END_OF_READ_DESC);
 		header.addFormat(VcfHeaderUtils.FORMAT_FILTER, ".", "String","Filters that apply to this sample");
@@ -436,7 +425,6 @@ public abstract class Pipeline {
 		header.addFormat(VcfHeaderUtils.FORMAT_FF, ".", "String",VcfHeaderUtils.FORMAT_FF_DESC);
 		header.addFormat(VcfHeaderUtils.FORMAT_READ_DEPTH, "1", "Integer","Approximate read depth (reads with MQ=255 or with bad mates are filtered)");
 		header.addFormat(VcfHeaderUtils.FORMAT_GENOTYPE_QUALITY, "1", "Integer","Genotype Quality");
-		header.addFormat(VcfHeaderUtils.FORMAT_MUTANT_READS,  ".", "Integer","Number of mutant/variant reads");
 		header.addFormat(VcfHeaderUtils.FORMAT_NOVEL_STARTS, ".", "Integer","Number of novel starts not considering read pair");		
 		header.addFormat(VcfHeaderUtils.FORMAT_QL, "1", "Float",VcfHeaderUtils.FORMAT_QL_DESC);		
 			


### PR DESCRIPTION
Vcf header entries for filters applied by `qannotate` were being added by `qsnp` (hangover from when filters were added in `qsnp`).

This has now been rectified.
`qsnp` no longer adds vcf header entries for filters/info that it doesn't insert
`qannotate`'s `ConfidenceMode` now adds vcf header details for the filters that it applies.
`qannotate` will also put the cutoff values used into the header descriptions so that end users know what values were used.

Both `qsnp` and `qannotate` vcf outputs pass vcf-validation (`vcftools`)