### PR TITLE
Q3indel vcf header

### DIFF
--- a/qcommon/src/org/qcmg/common/util/IndelUtils.java
+++ b/qcommon/src/org/qcmg/common/util/IndelUtils.java
@@ -19,9 +19,20 @@ public class IndelUtils {
 		
 		public final int order;
 		public final boolean isSnpOrCS;
-		SVTYPE(int od, boolean isSnpOrCS){this.order = od;this.isSnpOrCS = isSnpOrCS;}		
-		public int getOrder(){return order; }
-		static public int getSize() { return CTX.order + 1;}
+		
+		SVTYPE(int od, boolean isSnpOrCS){
+			this.order = od;
+			this.isSnpOrCS = isSnpOrCS;
+		}
+		
+		public int getOrder(){
+			return order; 
+		}
+		
+		static public int getSize() { 
+			return CTX.order + 1;
+		}
+		
 		public String toVariantType(){
 			switch (order){
 				case 1: return "SNV";
@@ -35,58 +46,58 @@ public class IndelUtils {
 	
 	//qbasepileup indel vcf header info column ID
 	public static final String INFO_END = "END"; 
-	public static final String DESCRITPION_INFO_END = "End position of the variant described in this record"; 
+	public static final String DESCRIPTION_INFO_END = "End position of the variant described in this record"; 
 	
 	public static final String INFO_SVTYPE = "SVTYPE";
-	public static final String DESCRITPION_INFO_SVTYPE = "Type of structural variant";
+	public static final String DESCRIPTION_INFO_SVTYPE = "Type of structural variant";
 
 	public static final String INFO_SOMATIC = "SOMATIC";
-	public static final String DESCRITPION_INFO_SOMATIC = "set to somatic unless there are more than three novel starts on normal BAM;"
+	public static final String DESCRIPTION_INFO_SOMATIC = "Set to somatic unless there are more than three novel starts on normal BAM;"
 			+ " or more than 10% imformative reads are supporting reads; or homopolymeric sequence exists on either side with nearby indels.";
 		
 	public static final String FILTER_COVN12 ="COVN12";
-	public static final String DESCRITPION_FILTER_COVN12 = "For somatic calls: less than 12 reads coverage in normal BAM";
+	public static final String DESCRIPTION_FILTER_COVN12 = "For somatic calls: less than 12 reads coverage in normal BAM";
 	
 	public static final String FILTER_COVN8 = "COVN8";
-	public static final String DESCRITPION_FILTER_COVN8 = "For germline calls: less than 8 reads coverage in normal";	
+	public static final String DESCRIPTION_FILTER_COVN8 = "For germline calls: less than 8 reads coverage in normal";	
 	
 	public static final String FILTER_COVT = "COVT";
-	public static final String DESCRITPION_FILTER_COVT = "For germline calls: less than 8 reads coverage in tumour";
+	public static final String DESCRIPTION_FILTER_COVT = "For germline calls: less than 8 reads coverage in tumour";
 	
 	public static final String FILTER_HCOVN = "HCOVN";
-	public static final String DESCRITPION_FILTER_HCOVN = "more than 1000 reads in normal BAM";
+	public static final String DESCRIPTION_FILTER_HCOVN = "More than 1000 reads in normal BAM";
 	
 	public static final String FILTER_HCOVT = "HCOVT";
-	public static final String DESCRITPION_FILTER_HCOVT = "more than 1000 reads in tumour BAM";
+	public static final String DESCRIPTION_FILTER_HCOVT = "More than 1000 reads in tumour BAM";
 	
 	public static final String FILTER_MIN = "MIN";
-	public static final String DESCRITPION_FILTER_MIN = "For somatic calls: mutation also found in pileup of normal BAM";
+	public static final String DESCRIPTION_FILTER_MIN = "For somatic calls: mutation also found in pileup of normal BAM";
 	
 	public static final String FILTER_NNS = "NNS";
-	public static final String DESCRITPION_FILTER_NNS = "For somatic calls: less than 4 novel starts not considering read pair in tumour BAM";
+	public static final String DESCRIPTION_FILTER_NNS = "For somatic calls: less than 4 novel starts not considering read pair in tumour BAM";
 	
 	public static final String FILTER_TPART = "TPART";
-	public static final String DESCRITPION_FILTER_TPART = "The number in the tumour partials column is >=3 and is >10% of the total reads at that position";
+	public static final String DESCRIPTION_FILTER_TPART = "The number in the tumour partials column is >=3 and is >10% of the total reads at that position";
 
 	public static final String FILTER_NPART = "NPART";
-	public static final String DESCRITPION_FILTER_NPART = "The number in the normal partials column is >=3 and is >5% of the total reads at that position";
+	public static final String DESCRIPTION_FILTER_NPART = "The number in the normal partials column is >=3 and is >5% of the total reads at that position";
 
 	public static final String FILTER_TBIAS = "TBIAS";
-	public static final String DESCRITPION_FILTER_TBIAS = "For somatic calls: the supporting tumour reads value is >=3 and the count on one strand is =0 or >0 "
+	public static final String DESCRIPTION_FILTER_TBIAS = "For somatic calls: the supporting tumour reads value is >=3 and the count on one strand is =0 or >0 "
 			+ "and is either <10% of supporting reads or >90% of supporting reads";
 
 	public static final String FILTER_NBIAS = "NBIAS";
-	public static final String DESCRITPION_FILTER_NBIAS = "For germline calls: the supporting normal reads value is >=3 and the count on one strand is =0 or >0 "
+	public static final String DESCRIPTION_FILTER_NBIAS = "For germline calls: the supporting normal reads value is >=3 and the count on one strand is =0 or >0 "
 			+ "and is either <5% of supporting reads or >95% of supporting reads";
 	
 	public static final String INFO_NIOC = "NIOC";
-	public static final String DESCRITPION_INFO_NIOC = "counts of nearby indels compare with total coverage";	
+	public static final String DESCRIPTION_INFO_NIOC = "Counts of nearby indels compare with total coverage";	
 	
 	public static final String INFO_SSOI = "SSOI";
-	public static final String DESCRITPION_INFO_SSOI = "counts of strong support indels compare with total informative reads coverage";	
+	public static final String DESCRIPTION_INFO_SSOI = "Counts of strong support indels compare with total informative reads coverage";	
 
 	public static final String FORMAT_ACINDEL = "ACINDEL";
-	public static final String DESCRITPION_FORMAT_ACINDEL = "counts of indels, follow formart:"
+	public static final String DESCRIPTION_FORMAT_ACINDEL = "Counts of indels, follow formart:"
 			+ "novelStarts,totalCoverage,informativeReadCount,strongSuportReadCount[forwardsuportReadCount,backwardsuportReadCount],suportReadCount[novelStarts],partialReadCount,nearbyIndelCount,nearybySoftclipCount";
 
 	public static final int MAX_INDEL_LENGTH = 200;

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -1095,23 +1095,11 @@ public class VcfUtils {
 		}
 	}
 	
-//	public static boolean isDPFormatFieldPresent(VcfRecord v) {
-//		return v.getFormatFields().get(0).contains(VcfHeaderUtils.FORMAT_READ_DEPTH);
-//	}
-	
 	public static final void prepareGATKVcfForMerge(VcfRecord v) {
 		/*
 		 * need to remove AC and AN from info field
 		 */
 		removeElementsFromInfoField(v);
-//		VcfInfoFieldRecord i = v.getInfoRecord();
-//		if (null != i) {
-//			i.removeField("AN");
-//			i.removeField("AC");
-//			i.removeField("AF");
-//			i.removeField("MLEAF");
-//			i.removeField("MLEAC");
-//		}
 		Map<String, String[]> ffMap = getFormatFieldsAsMap(v.getFormatFields());
 		ffMap.remove("PL");
 		
@@ -1120,7 +1108,6 @@ public class VcfUtils {
 		 */
 		ffMap.computeIfAbsent(VcfHeaderUtils.FORMAT_READ_DEPTH, f -> new String[]{Constants.MISSING_DATA_STRING});
 		ffMap.computeIfAbsent(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS, f -> new String[]{Constants.MISSING_DATA_STRING});
-//		ffMap.computeIfAbsent(VcfHeaderUtils.FORMAT_INFO, f -> new String[]{Constants.MISSING_DATA_STRING});
 		ffMap.computeIfAbsent(VcfHeaderUtils.FORMAT_QL, f -> new String[]{StringUtils.isNullOrEmptyOrMissingData(v.getQualString()) ? Constants.MISSING_DATA_STRING : v.getQualString()});
 		/*
 		 * reset qual field as it won't be applicable once merged

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -1083,7 +1083,7 @@ public class VcfUtils {
 				tFFs.add(tFF);
 				Map<String, String [] > ffMap = getFormatFieldsAsMap(tFFs);
 				String [] adArray = ffMap.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS);
-				if (null != adArray || adArray.length > 0) {
+				if (null != adArray && adArray.length > 0) {
 					String newAD = calculateAD(adArray[0] , newGT, tGT);
 					adArray[0] = newAD;
 					tFFs = convertFFMapToList(ffMap);
@@ -1103,14 +1103,15 @@ public class VcfUtils {
 		/*
 		 * need to remove AC and AN from info field
 		 */
-		VcfInfoFieldRecord i = v.getInfoRecord();
-		if (null != i) {
-			i.removeField("AN");
-			i.removeField("AC");
-			i.removeField("AF");
-			i.removeField("MLEAF");
-			i.removeField("MLEAC");
-		}
+		removeElementsFromInfoField(v);
+//		VcfInfoFieldRecord i = v.getInfoRecord();
+//		if (null != i) {
+//			i.removeField("AN");
+//			i.removeField("AC");
+//			i.removeField("AF");
+//			i.removeField("MLEAF");
+//			i.removeField("MLEAC");
+//		}
 		Map<String, String[]> ffMap = getFormatFieldsAsMap(v.getFormatFields());
 		ffMap.remove("PL");
 		
@@ -1128,6 +1129,18 @@ public class VcfUtils {
 		v.setFormatFields(convertFFMapToList(ffMap));
 	}
 	
+	public static void removeElementsFromInfoField(VcfRecord vcf) {
+		removeElementsFromInfoField(vcf, "AN", "AC", "AF","MLEAF","MLEAC");
+	}
+	
+	public static void removeElementsFromInfoField(VcfRecord vcf, String ... elements) {
+		VcfInfoFieldRecord i = vcf.getInfoRecord();
+		if (null != i) {
+			for (String s : elements) {
+				i.removeField(s);
+			}
+		}
+	}
 	
 	public static String getUpdateAltString(String newRef, String origRef, String origAlt) {
 		/*

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -9,10 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.Set;
-import java.util.TreeSet;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -21,8 +18,6 @@ import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.common.model.GenotypeEnum;
 import org.qcmg.common.model.MafConfidence;
 import org.qcmg.common.model.PileupElement;
-import org.qcmg.common.string.StringUtils;
-import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 
@@ -242,6 +237,24 @@ public class VcfUtilsTest {
 		assertEquals(3, mergedVcf.getFormatFields().size());
 		assertEquals("0/1:10,3:13:78:49.77", mergedVcf.getFormatFields().get(1));
 		assertEquals("0/2:8,0,5:13:99:157.77", mergedVcf.getFormatFields().get(2));
+	}
+	
+	@Test
+	public void removeGATKINFOFelds() {
+		String s = "chrY	2672735	.	ATT	A	123.86	COVN8;NNS	GATKINFO;NIOC=0;SSOI=1.000;SVTYPE=DEL;END=2672737;IN=1	GT:GD:ACINDEL	0/1:ATT/A:1,1,1,1[1,0],1[1],0,0,1	.";
+		VcfRecord vcf  = new VcfRecord(s.split("\t"));
+		VcfUtils.removeElementsFromInfoField(vcf);
+		assertEquals("GT:GD:ACINDEL	0/1:ATT/A:1,1,1,1[1,0],1[1],0,0,1	.", vcf.getFormatFieldStrings());
+		
+		s = "chrY	2672735	.	ATT	A	123.86	COVN8;NNS	GATKINFO;NIOC=0;SSOI=1.000;SVTYPE=DEL;END=2672737;IN=1;AN=1	GT:GD:ACINDEL	0/1:ATT/A:1,1,1,1[1,0],1[1],0,0,1	.";
+		vcf  = new VcfRecord(s.split("\t"));
+		VcfUtils.removeElementsFromInfoField(vcf);
+		assertEquals("GATKINFO;NIOC=0;SSOI=1.000;SVTYPE=DEL;END=2672737;IN=1", vcf.getInfo());
+		
+		s = "chrY	2672735	.	ATT	A	123.86	COVN8;NNS	GATKINFO;NIOC=0;SSOI=1.000;SVTYPE=DEL;END=2672737;IN=1;AN=1	GT:GD:ACINDEL	0/1:ATT/A:1,1,1,1[1,0],1[1],0,0,1	.";
+		vcf  = new VcfRecord(s.split("\t"));
+		VcfUtils.removeElementsFromInfoField(vcf, "AC");
+		assertEquals("GATKINFO;NIOC=0;SSOI=1.000;SVTYPE=DEL;END=2672737;IN=1;AN=1", vcf.getInfo());
 	}
 	
 	@Test


### PR DESCRIPTION
The vcf file that `q3indel` produces doesn't pass `vcftools` `vcf-validator`.
This PR contains some code changes that address this.
It is essentially removing some GATK infused entries in the INFO field of the vcf records.

This is a dual repository change as there are changes to `q3indel` which resides in our internal repo.
The following tags were created pre and post changes relating to this PR/issue:


`https://genomeinfo.qimrberghofer.edu.au/svn/genomeinfo/production/java/tags/pre_commit_githib_issue_87`
and
`https://genomeinfo.qimrberghofer.edu.au/svn/genomeinfo/production/java/tags/post_commit_githib_issue_87`

fixes #87 