### PR TITLE
Qannotate jul2019

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
   }
 
   dependencies {
-	testCompile 'junit:junit:4.12'	
+	testCompile 'junit:junit:4.10'	
   }
   checkstyleMain.onlyIf {project.hasProperty('checkstyle')}
    

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ subprojects {
         html.enabled = false
     }
   }
+
+  dependencies {
+	testCompile 'junit:junit:4.10'	
+  }
   checkstyleMain.onlyIf {project.hasProperty('checkstyle')}
    
    sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
   }
 
   dependencies {
-	testCompile 'junit:junit:4.10'	
+	testCompile 'junit:junit:4.12'	
   }
   checkstyleMain.onlyIf {project.hasProperty('checkstyle')}
    

--- a/qannotate/build.gradle
+++ b/qannotate/build.gradle
@@ -16,7 +16,8 @@ dependencies {
 	compile name: 'snpEff', version: '4.0e'	
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+
+ 
 }
 
  

--- a/qannotate/src/au/edu/qimr/qannotate/Main.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Main.java
@@ -16,10 +16,11 @@ public class Main {
 	public static void main(final String[] args) throws Exception {	
 
 		try {
-           final Options options = new Options(args);             
-        		//LoadReferencedClasses.loadClasses(Main.class);    
+           final Options options = new Options(args);
            logger = QLoggerFactory.getLogger(Main.class, options.getLogFileName(),  options.getLogLevel());	            		               
            logger.logInitialExecutionStats(options.getPGName(), options.getVersion(),args);
+	       logger.tool("logger file " + options.getLogFileName());
+	       logger.tool("logger level " + options.getLogLevel());
            
            checkOptions(options);
            
@@ -45,8 +46,6 @@ public class Main {
     	   		new TandemRepeatMode( options );
             } else if (options.getMode() == Options.MODE.make_valid) {
     	   		new MakeValidMode( options );
-//           } else if (options.getMode() == Options.MODE.snppileup) {
-//   	   			new SnpPileupMode( options );
    	   	    } else if (options.getMode() == Options.MODE.overlap) {
    	   			new OverlapMode( options );
 	   	   	} else if (options.getMode() == Options.MODE.vcf2maftmp) {

--- a/qannotate/src/au/edu/qimr/qannotate/Options.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Options.java
@@ -13,10 +13,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.qcmg.common.log.QLoggerFactory;
+
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 
-import org.qcmg.common.log.QLogger;
+//import org.qcmg.common.log.QLogger;
 
 import au.edu.qimr.qannotate.Messages;
 import au.edu.qimr.qannotate.modes.*;
@@ -38,13 +40,13 @@ public class Options {
     
     private final Options.MODE mode;  
     private final  OptionParser parser;
-    private final QLogger logger = null;
 	 	
     private final String outputFileName ;
     private final String inputFileName ;
     private final String[] databaseFiles;
     private final String logFileName;
     private final String logLevel;  
+    private final boolean isStrictName;
 	
 	//vcf2maf 
     private  final String testSample;
@@ -83,19 +85,19 @@ public class Options {
      * check command line and store arguments and option information
      */   
     public Options(final String[] args) throws IOException{      	
-	    	parser = new OptionParser();    	       
-	    	OptionSet options =  parseArgs(args);
-	    	
-	    	if (options.has("mode")){
-	    		String m = ((String) options.valueOf("mode")).toLowerCase();
-	    		this.mode = MODE.valueOf(m); //already checked the validation of mode
-	    	} else {
-	    		this.mode = null;
-	    	}
+    	parser = new OptionParser();    	       
+    	OptionSet options =  parseArgs(args);
+    	
+    	if (options.has("mode")){
+    		String m = ((String) options.valueOf("mode")).toLowerCase();
+    		this.mode = MODE.valueOf(m); //already checked the validation of mode
+    	} else {
+    		this.mode = null;
+    	}
     		   	
         if (options.has("h") || options.has("help")) { 
-	        	displayHelp(mode);  
-	        	System.exit(0);	
+        	displayHelp(mode);  
+        	System.exit(0);	
         }
         
        //parse parameters        
@@ -106,6 +108,7 @@ public class Options {
         outputFileName = (String) options.valueOf("output") ; 
     	logFileName = (String) options.valueOf("log");  	
     	logLevel = (String) options.valueOf("loglevel");
+    	isStrictName = (options.has("strict2ChromosomeName"))? true : false;  //chromosome name must match bwt input and db file
     	
     	if (null == inputFileName) { 
         	displayHelp(mode);  
@@ -120,7 +123,7 @@ public class Options {
 		  	displayHelp(mode);  
         	System.exit(0);	
 		}
-        
+              
         gap = (options.has("gap"))? (int)options.valueOf("gap") : 1000;  //CADD default is 1000
         bufferSize = (options.has("buffer"))? (Integer) options.valueOf("buffer") : 0; //TRF default is 0
         
@@ -186,7 +189,9 @@ public class Options {
 		parser.accepts("mrPercentage", "Number of mutant reads (MR) required to be High Confidence as a percentage").withRequiredArg().ofType(Float.class)
 		.describedAs("numberOfMutantReadsPercentage");
 		parser.accepts("filtersToIgnore", LOG_DESCRIPTION).withRequiredArg().ofType(String.class);
-
+		parser.accepts("strict2ChromosomeName", "It requires the chromosome name match the one in database file strictly. Without this option, it accepts ambiguous name, "
+				+ "eg. treat 'M' and 'chrMT' as same chromosome name");
+		
         OptionSet options  = parser.parse(args);  
         if (options.has("v") || options.has("version")){
     		System.err.println( "qannotate: Current version is " + getVersion());
@@ -306,7 +311,7 @@ public class Options {
     }
 
 	public String getLogFileName() { return logFileName;}	
-	public String getLogLevel(){ return logLevel; }	 
+	public String getLogLevel(){ return logLevel == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  logLevel; }	 
 	public String getCommandLine() {	return commandLine; }	
 	public String getInputFileName(){return inputFileName;}
 	public String getOutputFileName(){return outputFileName;}
@@ -394,5 +399,7 @@ public class Options {
 	public Optional<Float> getMINPercentage() {
 		return Optional.ofNullable(minPercentage);
 	}
+	
+	public boolean isStrict2chrName() {return isStrictName;}
 
 }

--- a/qannotate/src/au/edu/qimr/qannotate/modes/AbstractMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/AbstractMode.java
@@ -50,7 +50,7 @@ abstract class AbstractMode {
         	header = reader.getHeader();
         	//no chr in front of position
 			for (final VcfRecord vcf : reader) {
-				ChrPosition pos = ChrPositionUtils.getNewchrNameIfStrict(vcf.getChrPosition(), isStrictName) ;				
+				ChrPosition pos = ChrPositionUtils.getNewchrName(vcf.getChrPosition(), isStrictName) ;				
 				//used converted  chr name as key but vcf is kept as original 
 				positionRecordMap.computeIfAbsent(pos, function -> new ArrayList<VcfRecord>(2)).add(vcf);
 			}

--- a/qannotate/src/au/edu/qimr/qannotate/modes/CCMMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/CCMMode.java
@@ -42,12 +42,9 @@ public class CCMMode extends AbstractMode{
 	
 	public CCMMode(Options options) throws IOException {	
 		logger.tool("input: " + options.getInputFileName());
-        logger.tool("output for annotated vcf records: " + options.getOutputFileName());
-        logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
-		
+        logger.tool("output for annotated vcf records: " + options.getOutputFileName());		
 
-        loadVcfRecordsFromFile(new File( options.getInputFileName()));
+        loadVcfRecordsFromFile(new File( options.getInputFileName()), options.isStrict2chrName());
 		
 		/*
 		 * don't have access to header until after records have been loaded...

--- a/qannotate/src/au/edu/qimr/qannotate/modes/CaddMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/CaddMode.java
@@ -90,7 +90,7 @@ public class  CaddMode extends AbstractMode{
 				//add every variants into hashmap
 				pos = re.getPosition();
 				//add2Map(re);
-				ChrPosition cp = ChrPositionUtils.getNewchrNameIfStrict(re.getChrPosition(), isStrict2chrName) ;
+				ChrPosition cp = ChrPositionUtils.getNewchrName(re.getChrPosition(), isStrict2chrName) ;
 				positionRecordMap.computeIfAbsent(cp, v -> new ArrayList<>()).add(re) ;
 			}
 			
@@ -130,7 +130,7 @@ public class  CaddMode extends AbstractMode{
 	    		int s = Integer.parseInt(eles[1]);  //start position = second column
 	    		int e = s + eles[2].length() - 1;   //start position + length -1
 	    		
-	    		ChrPosition cp  = ChrPositionUtils.getNewchrNameIfStrict(new ChrRangePosition(chr, s, e), isStrict2chrName) ;
+	    		ChrPosition cp  = ChrPositionUtils.getNewchrName(new ChrRangePosition(chr, s, e), isStrict2chrName) ;
 	    		List<VcfRecord> inputVcfs = positionRecordMap.get(cp);	    
 				if ( (null == inputVcfs) || inputVcfs.size() == 0 ) {
 					continue; 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
@@ -93,9 +93,8 @@ public class ConfidenceMode extends AbstractMode{
 	
 	//for unit testing
 	ConfidenceMode(){
-//		this.testCols = new TShortArrayList(testCol);
-//		this.controlCols = new TShortArrayList(controlCol);
 	}
+	
 	ConfidenceMode(VcfFileMeta m){
 		this.meta = m;
 		testCols = meta.getAllTestPositions();
@@ -106,10 +105,9 @@ public class ConfidenceMode extends AbstractMode{
 	public ConfidenceMode( Options options) throws Exception{				 
 		logger.tool("input: " + options.getInputFileName());
         logger.tool("output annotated records: " + options.getOutputFileName());
-        logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
- 		
-		loadVcfRecordsFromFile(new File( options.getInputFileName())   );	
+  		
+        //there is no database file, we use input vcf chromosome name directory.
+		loadVcfRecordsFromFile(new File( options.getInputFileName()), true  );	
 		
 		options.getNNSCount().ifPresent(i -> nnsCount = i.intValue());
 		options.getMRCount().ifPresent(i -> mrCount = i.intValue());
@@ -183,7 +181,6 @@ public class ConfidenceMode extends AbstractMode{
 				
 				String [] gtArray = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE);
 				String [] nnsArr = ffMap.get(VcfHeaderUtils.FILTER_NOVEL_STARTS);
-//				String [] mrArr = ffMap.get(VcfHeaderUtils.FORMAT_MUTANT_READS);
 				String [] filterArr = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
 				String [] covArr = ffMap.get(VcfHeaderUtils.FORMAT_READ_DEPTH);
 				String [] ccmArr = ffMap.get(VcfHeaderUtils.FORMAT_CCM);
@@ -290,11 +287,6 @@ public class ConfidenceMode extends AbstractMode{
 									StringUtils.updateStringBuilder(fSb, VcfHeaderUtils.FORMAT_MUTANT_READS, Constants.SEMI_COLON);
 								}
 								
-//								int [] altADs = getAltCoveragesFromADField(adArr[i]);
-//								if ( ! (percentageMode ?  allValuesAboveThreshold(altADs, cov, mrPercentage) : allValuesAboveThreshold(altADs, mrCount))) {
-//									StringUtils.updateStringBuilder(fSb, "MR", Constants.SEMI_COLON);
-//								}
-								
 								/*
 								 * end of read check
 								 */
@@ -317,7 +309,6 @@ public class ConfidenceMode extends AbstractMode{
 								filterArr[i] = VcfHeaderUtils.FILTER_PASS;
 							}
 						}
-//					}
 				}
 				
 				/*

--- a/qannotate/src/au/edu/qimr/qannotate/modes/CustomerConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/CustomerConfidenceMode.java
@@ -32,10 +32,10 @@ public final class CustomerConfidenceMode extends AbstractMode{
 	final String BP = "5BP"; 
 	final String SBIASCOV = "SBIASCOV"; 
 	
-//	String description = null;
+
 	private static final int min_read_counts = 50;
 	private static final int variants_rate = 10 ;
-//	boolean passOnly = false;
+
 	
 	private int test_column = -2; //can't be -1 since will "+1"
 	private int control_column  = -2;
@@ -43,7 +43,7 @@ public final class CustomerConfidenceMode extends AbstractMode{
 	private final QLogger logger  = QLoggerFactory.getLogger(CustomerConfidenceMode.class); 
 	
  	
-//	//unit test only
+	//unit test only
 	CustomerConfidenceMode( ){	}
 	
 	public CustomerConfidenceMode(Options options) throws Exception{	
@@ -53,11 +53,8 @@ public final class CustomerConfidenceMode extends AbstractMode{
         logger.tool("logger file " + options.getLogFileName());
         logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
         
-//        min_read_counts = options.get_min_read_count();
-//        variants_rate = options.get_min_mutant_rate();
-//        passOnly = options.isPassOnly();
-        
-		loadVcfRecordsFromFile(new File( options.getInputFileName())   );	
+      //there is no database file, we use input vcf chromosome name directory.
+		loadVcfRecordsFromFile(new File( options.getInputFileName()), true  );	
 		
 		//get control and test sample column; here use the header from inputRecord(...)
 		SampleColumn column = SampleColumn.getSampleColumn(options.getTestSample(), options.getControlSample(), this.header );

--- a/qannotate/src/au/edu/qimr/qannotate/modes/DbsnpMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/DbsnpMode.java
@@ -32,7 +32,7 @@ public class DbsnpMode extends AbstractMode{
 	private final boolean isStrict2chrName;
 	
 	//for unit Test
-	DbsnpMode(){ this.isStrict2chrName = false; }
+	DbsnpMode(boolean isStrict ){ this.isStrict2chrName = isStrict; }
 	
 	public DbsnpMode(Options options) throws Exception{
 		this.isStrict2chrName = options.isStrict2chrName();

--- a/qannotate/src/au/edu/qimr/qannotate/modes/DbsnpMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/DbsnpMode.java
@@ -81,7 +81,7 @@ public class DbsnpMode extends AbstractMode{
 			//each dbSNP check twice, since indel alleles followed by one reference base, eg. chr1 100 . TT T ...			
 			for (final VcfRecord dbSNPVcf : reader) {				
 				//conver chr name if ambiguous mode, otherwise use original one
-				ChrPosition dbSnpCP = ChrPositionUtils.getNewchrNameIfStrict(dbSNPVcf.getChrPosition(), isStrict2chrName) ;
+				ChrPosition dbSnpCP = ChrPositionUtils.getNewchrName(dbSNPVcf.getChrPosition(), isStrict2chrName) ;
 	
 				List<VcfRecord> inputVcfs = positionRecordMap.get(dbSnpCP);
 				if (null != inputVcfs && inputVcfs.size() != 0){

--- a/qannotate/src/au/edu/qimr/qannotate/modes/GermlineMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/GermlineMode.java
@@ -102,7 +102,7 @@ public class GermlineMode extends AbstractMode{
 	 			if (null != usParams && usParams.length > 3) {
 	 				// contig is first followed by position
 					ChrPosition cp = new ChrPointPosition(usParams[0], Integer.parseInt(usParams[1]));
-					cp = ChrPositionUtils.getNewchrNameIfStrict( cp, isStrict2chrName );					
+					cp = ChrPositionUtils.getNewchrName( cp, isStrict2chrName );					
 					List<VcfRecord> inputVcfs = positionRecordMap.get(cp);
 					if (null == inputVcfs || inputVcfs.size() == 0) {
 						continue; 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/GermlineMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/GermlineMode.java
@@ -38,7 +38,7 @@ public class GermlineMode extends AbstractMode{
 	private final boolean isStrict2chrName;
 	
 	//for unit Test only
-	GermlineMode(){this.isStrict2chrName = true;}
+	GermlineMode(boolean isStrict ){ this.isStrict2chrName = isStrict; }
 
  	public GermlineMode(Options options) throws Exception{
  		this.isStrict2chrName = options.isStrict2chrName();

--- a/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrRangePosition;
+import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.util.IndelUtils.SVTYPE;
@@ -42,6 +43,7 @@ public class HomoplymersMode extends AbstractMode{
 	private int reportWindow;
 	public static final int defaultWindow = 100;
 	public static final int defaultreport = 10;
+	private final boolean isStrict2chrName;
 	
 	@Deprecated //for unit test
 	HomoplymersMode( int homoWindow, int reportWindow){		
@@ -50,22 +52,23 @@ public class HomoplymersMode extends AbstractMode{
 		this.dbfile = null;
 		this.homopolymerWindow = homoWindow;
 		this.reportWindow = reportWindow;
+		this.isStrict2chrName = true;
 	}
 		
 	public HomoplymersMode(Options options) throws IOException {
 		input = options.getInputFileName();
 		output = options.getOutputFileName();
 		dbfile = options.getDatabaseFileName();
+		this.isStrict2chrName = options.isStrict2chrName();
 		homopolymerWindow =  options.getHomoplymersWindow();
 		reportWindow = options.getHomoplymersReportSize();
 		reportWindow = options.getHomoplymersReportSize();
 		logger.tool("input: " + options.getInputFileName());
         logger.tool("reference file: " + dbfile);
         logger.tool("output for annotated vcf records: " + options.getOutputFileName());
-        logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
         logger.tool("window size for homoplymers: " + homopolymerWindow);
         logger.tool("number of homoplymer bases on either side of variant to report: " + reportWindow);
+        logger.tool("accept ambiguous chromosome name, eg. treat M and chrMT as same chromosome name: " + (!isStrict2chrName));
         
         reheader(options.getCommandLine(),options.getInputFileName());
  		addAnnotation(dbfile);		
@@ -106,8 +109,9 @@ public class HomoplymersMode extends AbstractMode{
 		    }
 		    
 		    int sum = 0;
-			for (final VcfRecord re : reader) {	
-				writer.add( annotate(re, referenceBase.get(IndelUtils.getFullChromosome(re.getChromosome()))));
+			for (final VcfRecord re : reader) {					 
+				String contig = isStrict2chrName? re.getChromosome(): ChrPositionUtils.ChrNameConveter(re.getChromosome());			
+				writer.add( annotate(re, referenceBase.get( contig ) ));
 				sum ++;
 			}
 			logger.info(sum + " records have been put through qannotate's homopolymer mode");
@@ -291,7 +295,7 @@ public class HomoplymersMode extends AbstractMode{
 		return max == 1 ? 0 : max;
 	}
 	
-   static Map<String, byte[]> getReferenceBase(File reference) throws IOException {
+   private Map<String, byte[]> getReferenceBase(File reference) throws IOException {
 	   
 	   /*
         * check to see if the index and dict file exist for the reference
@@ -314,8 +318,9 @@ public class HomoplymersMode extends AbstractMode{
 	   try (IndexedFastaSequenceFile indexedFasta = new IndexedFastaSequenceFile(reference, index);) {
 		   SAMSequenceDictionary dict = indexedFasta.getSequenceDictionary();
 		   for (SAMSequenceRecord re: dict.getSequences()) {
-			   String contig = IndelUtils.getFullChromosome(re.getSequenceName());
-			   referenceBase.put(contig, indexedFasta.getSequence(contig).getBases());
+			   //here we store reference base to map, convert contig name if requires
+			   String contig = isStrict2chrName? re.getSequenceName(): ChrPositionUtils.ChrNameConveter(re.getSequenceName());			  
+			   referenceBase.put(contig, indexedFasta.getSequence( re.getSequenceName()).getBases());
 		   }
 	   }
 	   return referenceBase;

--- a/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
@@ -45,14 +45,18 @@ public class HomoplymersMode extends AbstractMode{
 	public static final int defaultreport = 10;
 	private final boolean isStrict2chrName;
 	
-	@Deprecated //for unit test
-	HomoplymersMode( int homoWindow, int reportWindow){		
-		this.input = null;
-		this.output = null;
+	//for unit test
+	HomoplymersMode( String input, int homoWindow, int reportWindow, boolean isStrict) throws IOException{		
+		this.input = input;
+		this.output = input == null? null : input + ".out.vcf";
 		this.dbfile = null;
 		this.homopolymerWindow = homoWindow;
 		this.reportWindow = reportWindow;
-		this.isStrict2chrName = true;
+		this.isStrict2chrName = isStrict;
+		
+		if(input != null) {
+			reheader("cmd",input);
+		}
 	}
 		
 	public HomoplymersMode(Options options) throws IOException {
@@ -79,11 +83,13 @@ public class HomoplymersMode extends AbstractMode{
 	 * https://github.com/samtools/htsjdk/blob/master/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
 	 */
 	protected static Path findSequenceDictionary(final Path path) {
+
         if (path == null) {
             return null;
         }
         // Try and locate the dictionary with the default method
-        final Path dictionary = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(path); path.toAbsolutePath();
+        final Path dictionary = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(path); 
+        path.toAbsolutePath();
         if (Files.exists(dictionary)) {
             return dictionary;
         }
@@ -295,7 +301,7 @@ public class HomoplymersMode extends AbstractMode{
 		return max == 1 ? 0 : max;
 	}
 	
-   private Map<String, byte[]> getReferenceBase(File reference) throws IOException {
+    Map<String, byte[]> getReferenceBase(File reference) throws IOException {
 	   
 	   /*
         * check to see if the index and dict file exist for the reference

--- a/qannotate/src/au/edu/qimr/qannotate/modes/MakeValidMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/MakeValidMode.java
@@ -74,8 +74,6 @@ public class MakeValidMode extends AbstractMode {
 			logger.tool("reference file: " + refFile);
 		}
         logger.tool("output annotated records: " + options.getOutputFileName());
-        logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
         
         processVcfFile(options.getInputFileName(), options.getOutputFileName(), options.getCommandLine(), refFile);
 	}

--- a/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
@@ -36,15 +36,12 @@ public class SnpEffMode extends AbstractMode{
         logger.tool("snpeff config file: " + options.getConfigFileName());
         logger.tool("output for annotated vcf records: " + options.getOutputFileName());
         logger.tool("output for summary File: " + options.getSummaryFileName());
-        logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
 		      
-        tmpFile = options.getOutputFileName() + ".tmp";
-        
-	    	logger.tool("running snpEFF, output to " + tmpFile);
-	    	final boolean ok = addAnnotation( options , tmpFile );
-	
-	    	logger.tool("exit snpEFF: " + ok);
+        tmpFile = options.getOutputFileName() + ".tmp";        
+    	logger.tool("running snpEFF, output to " + tmpFile);
+    	final boolean ok = addAnnotation( options , tmpFile );
+
+    	logger.tool("exit snpEFF: " + ok);
 		
 		//reheader
         if (ok) { 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/Vcf2maf.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/Vcf2maf.java
@@ -60,6 +60,7 @@ public class Vcf2maf extends AbstractMode{
 	private boolean hasACLAP = false; 
 	
 	//for unit test
+	@Deprecated
 	Vcf2maf(int test_column, int control_column, String test, String control, ContentType contentType){ 
 		center = SnpEffMafRecord.center;
 		sequencer = SnpEffMafRecord.Unknown; 
@@ -75,6 +76,10 @@ public class Vcf2maf extends AbstractMode{
  
 	//EFF= Effect ( Effect_Impact | Functional_Class | Codon_Change | Amino_Acid_Change| Amino_Acid_Length | Gene_Name | Transcript_BioType | Gene_Coding | Transcript_ID | Exon_Rank  | Genotype_Number [ | ERRORS | WARNINGS ] )	
 	public Vcf2maf( Options option) throws Exception {
+		logger.tool(	"input: " + option.getInputFileName()	);
+         
+
+		
 		this.center = option.getCenter();
 		this.sequencer = option.getSequencer();		
 		
@@ -104,7 +109,7 @@ public class Vcf2maf extends AbstractMode{
 					
 		String outputname;
 		if(option.getOutputFileName() != null) {
-			outputname =  option.getOutputFileName();
+			outputname =  option.getOutputFileName();			
 		} else if( option.getOutputDir() != null) {
 			if (donorId != null && controlSample != null && testSample != null) {
 				outputname = String.format("%s//%s.%s.%s.maf", option.getOutputDir(), donorId, controlSample , testSample);
@@ -116,7 +121,8 @@ public class Vcf2maf extends AbstractMode{
 		} else {
 			throw new Exception("Please specify output file name or output file directory on command line");
 		}
-	
+		logger.tool(	"output: " + outputname 	);
+		
 		String sPC  = outputname.replace(".maf", ".Somatic.Pass.Consequence.maf") ;
 		String sP = outputname.replace(".maf", ".Somatic.Pass.maf") ;
 		String gPC  = outputname.replace(".maf", ".Germline.Pass.Consequence.maf") ;

--- a/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
@@ -67,8 +67,8 @@ public class AbstractModeTest {
 	    	   assertTrue(i == 3);
 	   }
 	       
-		DbsnpMode db = new DbsnpMode();
-		db.loadVcfRecordsFromFile(new File(inputName));		
+		DbsnpMode db = new DbsnpMode(true);
+		db.loadVcfRecordsFromFile(new File(inputName),false);		
 		db.reheader("testing run",   inputName);
 		db.writeVCF(new File(outputName));
 		

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -924,8 +924,9 @@ public class ConfidenceModeTest {
 	 @Ignore
 	 public void confidenceTest() throws IOException, Exception{	
 	 	DbsnpModeTest.createVcf();
-		final ConfidenceMode mode = new ConfidenceMode();		
-		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName));
+		final ConfidenceMode mode = new ConfidenceMode();	
+		//no database required, chromosome name only from input file
+		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName), true);
 
 		String Scontrol = "EXTERN-MELA-20140505-001";
 		String Stest = "EXTERN-MELA-20140505-002";
@@ -963,7 +964,7 @@ public class ConfidenceModeTest {
 	 public void sampleColumnNoIDTest() throws IOException, Exception{	
 	 	DbsnpModeTest.createVcf();
 		final ConfidenceMode mode = new ConfidenceMode();		
-		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName));
+		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName), true);
 
 		String Scontrol = "EXTERN-MELA-20140505-001";
 		String Stest = "EXTERN-MELA-20140505-002";

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -12,9 +12,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.AfterClass;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.model.MafConfidence;
 import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Constants;
@@ -27,16 +28,15 @@ import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 
 
+
 public class ConfidenceModeTest {
 	
 	 public static final VcfFileMeta TWO_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
 	 public static final VcfFileMeta SINGLE_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createSingleSampleTwoCallerVcf());
+
+	 @Rule
+	 public final TemporaryFolder testFolder = new TemporaryFolder();
 	
-	 @AfterClass
-	 public static void deleteIO(){
-		 new File(DbsnpModeTest.inputName).delete();
-		 new File(DbsnpModeTest.outputName).delete();		 
-	 }
 	 
 	 @Test
 	 public void testThresholds() {
@@ -923,10 +923,12 @@ public class ConfidenceModeTest {
 	
 	 @Ignore
 	 public void confidenceTest() throws IOException, Exception{	
-	 	DbsnpModeTest.createVcf();
+	 	File input = new DbsnpModeTest().createVcf();
+	 	File output = testFolder.newFile();
+	 	
 		final ConfidenceMode mode = new ConfidenceMode();	
 		//no database required, chromosome name only from input file
-		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName), true);
+		mode.loadVcfRecordsFromFile(input, true);
 
 		String Scontrol = "EXTERN-MELA-20140505-001";
 		String Stest = "EXTERN-MELA-20140505-002";
@@ -935,10 +937,10 @@ public class ConfidenceModeTest {
 		mode.header.addOrReplace("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tEXTERN-MELA-20140505-001\tEXTERN-MELA-20140505-002");			
 		
 		mode.addAnnotation();
-		mode.reheader("unitTest", DbsnpModeTest.inputName);
-		mode.writeVCF(new File(DbsnpModeTest.outputName)  );
+		mode.reheader("unitTest", input.getAbsolutePath());
+		mode.writeVCF(output  );
 		
-		try(VCFFileReader reader = new VCFFileReader(DbsnpModeTest.outputName)){			 
+		try(VCFFileReader reader = new VCFFileReader( output); ){			 
 			for (final VcfRecord re : reader) {
 				String ff = re.getFormatFieldStrings();
 				if(re.getPosition() == 2675826) {
@@ -962,9 +964,12 @@ public class ConfidenceModeTest {
 	 
 	 @Ignore
 	 public void sampleColumnNoIDTest() throws IOException, Exception{	
-	 	DbsnpModeTest.createVcf();
+		 
+	 	File input = new DbsnpModeTest().createVcf();
+	 	File output = testFolder.newFile();
+		 
 		final ConfidenceMode mode = new ConfidenceMode();		
-		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName), true);
+		mode.loadVcfRecordsFromFile(input, true);
 
 		String Scontrol = "EXTERN-MELA-20140505-001";
 		String Stest = "EXTERN-MELA-20140505-002";
@@ -973,10 +978,10 @@ public class ConfidenceModeTest {
 		mode.header.addOrReplace("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tqControlSample\tqTestSample");			
 		
 		mode.addAnnotation();
-		mode.reheader("unitTest", DbsnpModeTest.inputName);
-		mode.writeVCF(new File(DbsnpModeTest.outputName)  );
+		mode.reheader("unitTest", input.getAbsolutePath());
+		mode.writeVCF(output );
 		
-		try(VCFFileReader reader = new VCFFileReader(DbsnpModeTest.outputName)){
+		try(VCFFileReader reader = new VCFFileReader( output )){
 			for (final VcfRecord re : reader) {		
 				final VcfInfoFieldRecord infoRecord = new VcfInfoFieldRecord(re.getInfo()); 				
 				if(re.getPosition() == 2675826) 

--- a/qannotate/test/au/edu/qimr/qannotate/modes/CustomerConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/CustomerConfidenceModeTest.java
@@ -8,9 +8,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.model.MafConfidence;
 import org.qcmg.common.vcf.VcfInfoFieldRecord;
 import org.qcmg.common.vcf.VcfRecord;
@@ -20,25 +20,24 @@ import org.qcmg.vcf.VCFFileReader;
 import au.edu.qimr.qannotate.utils.SampleColumn;
 
 public class CustomerConfidenceModeTest {
-	
-	 @AfterClass
-	 public static void deleteIO(){
-		 new File(DbsnpModeTest.inputName).delete();
-	 }
+
+	@Rule
+	public final TemporaryFolder testFolder = new TemporaryFolder();
 	 
 	 @Test
 	 public void sampleidTest() throws Exception{
-		createInputFile();
+		File input = createInputFile();
+		File output = testFolder.newFile();
 		final CustomerConfidenceMode mode = new CustomerConfidenceMode();		
-		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName),true);
+		mode.loadVcfRecordsFromFile( input ,true);
 			 
 		SampleColumn column =  SampleColumn.getSampleColumn(null,null,  mode.header);
 		mode.setSampleColumn(column.getTestSampleColumn(), column.getControlSampleColumn() );
 		mode.addAnnotation();
-		mode.reheader("testing run",   DbsnpModeTest.inputName );
-		mode.writeVCF(new File(DbsnpModeTest.outputName));
+		mode.reheader("testing run",   input.getAbsolutePath() );
+		mode.writeVCF( output );
 		
-		try(VCFFileReader reader = new VCFFileReader(DbsnpModeTest.outputName)){			
+		try(VCFFileReader reader = new VCFFileReader( output )){			
 			for (final VcfRecord re : reader) {		
 				final VcfInfoFieldRecord infoRecord = new VcfInfoFieldRecord(re.getInfo()); 				
 				if(re.getPosition() == 41281388) 
@@ -51,7 +50,7 @@ public class CustomerConfidenceModeTest {
 		}		 
 	 }
 						
-	public static void createInputFile() throws IOException{
+	public File createInputFile() throws IOException{
         final List<String> data = new ArrayList<String>();
         data.add("##fileformat=VCFv4.2");
 //        data.add("##");
@@ -63,9 +62,12 @@ public class CustomerConfidenceModeTest {
         data.add("chr3\t41281389\t.\tT\tG\t.\t%5BP67\tFLANK=ATTTAGCAAAC;CONF=HIGH\tGT:GD:AC:MR:NNS\t0/1:G/T:A0[0],15[16.53],C1[38],0[0],G0[0],105[27.78],T112[37.92],106[22.47]:105:2\t0/1:G/T:A0[0],15[16.53],C1[38],0[0],G0[0],15[27.78],T112[37.92],106[22.47]:15:2");
         data.add("chr3\t41281390\t.\tT\tG\t.\tSBIAS;SBIASCOV\tFLANK=ATTTAGCAAAC;CONF=HIGH\tGT:GD:AC:MR:NNS\t0/1:G/T:A0[0],15[16.53],C1[38],0[0],G0[0],105[27.78],T112[37.92],106[22.47]:105:2\t0/1:G/T:A0[0],15[16.53],C1[38],0[0],G0[0],15[27.78],T112[37.92],106[22.47]:15:2");
 
-        try(BufferedWriter out = new BufferedWriter(new FileWriter(DbsnpModeTest.inputName));){      
+        File input = testFolder.newFile();
+        try(BufferedWriter out = new BufferedWriter(new FileWriter( input ));){      
            for (final String line : data)  out.write(line + "\n");
         }
+        
+        return input;
 	          
 	}
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/CustomerConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/CustomerConfidenceModeTest.java
@@ -30,7 +30,7 @@ public class CustomerConfidenceModeTest {
 	 public void sampleidTest() throws Exception{
 		createInputFile();
 		final CustomerConfidenceMode mode = new CustomerConfidenceMode();		
-		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName));
+		mode.loadVcfRecordsFromFile(new File(DbsnpModeTest.inputName),true);
 			 
 		SampleColumn column =  SampleColumn.getSampleColumn(null,null,  mode.header);
 		mode.setSampleColumn(column.getTestSampleColumn(), column.getControlSampleColumn() );

--- a/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
@@ -82,76 +82,76 @@ public class DbsnpModeTest {
 		 assertTrue(vcf.getInfoRecord().getField("VAF").equals("."));
 		 assertTrue(vcf.getInfoRecord().getField("DB").equals(Constants.EMPTY_STRING) );
 	 }
-	 
-//	@Test
-//	public void annotationTest() throws IOException, Exception{
-//		createDbsnp(); 
-//		
-//		final DbsnpMode mode = new DbsnpMode();		
-//		mode.inputRecord(new File(inputName));
-//		mode.addAnnotation(dbSNPName);
-//		mode.reheader("testing run",   inputName);
-//		mode.writeVCF( new File(outputName));
-//		
-//		 try(VCFFileReader reader = new VCFFileReader(outputName)){
-//			VcfHeader header = reader.getHeader();
-//			
-//			assertTrue (null != header.getFileFormat()) ;  
-//			assertTrue (null != header.getFileDate()) ; 	 
-//			assertTrue (null != header.getUUID()) ;   
-//			assertTrue (null != header.getSource()) ;  
-//			
-//			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_FILE_FORMAT).size() == 1);
-//			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_FILE_DATE ).size() == 1);
-//			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_UUID_LINE ).size() == 1);
-//			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_SOURCE_LINE ).size() == 1);
-//			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_INPUT_LINE ).size() == 1);
-//						
-//			int ii = 0;
-//			for(VcfHeaderRecord re : VcfHeaderUtils.getqPGRecords(header)){
-//				assertEquals( VcfHeaderUtils.getQPGTool(re)  , Constants.NULL_STRING_UPPER_CASE);
-//				assertNotNull(VcfHeaderUtils.getQPGDate(re) );
-//				assertNotNull( VcfHeaderUtils.getQPGCommandLine(re) );
-//				assertEquals(1, VcfHeaderUtils.getQPGOrder(re) );
-//				ii ++;	
-//			}
-//			assertTrue(ii == 1);
-//						
-//			VcfHeaderRecord chrom = header.getChrom();
-//			assertTrue(chrom.toString().startsWith(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE)) ;			
-//			assertTrue(header.getInfoRecord(VcfHeaderUtils.INFO_VAF) != null);  
-//			assertTrue(header.getInfoRecord(VcfHeaderUtils.INFO_DB) != null) ;
-//			  						
-//			int i = 0;
-//			for (final VcfRecord re : reader) {	
-// 				i ++;
-//				if(re.getPosition() == 2675826){
-//					assertTrue(re.getId().equals("rs71432129"));
-//					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_GMAF));
-//					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VAF).equals("0.39") );	
-//				}else if(re.getPosition() == 2675825){
-//					assertTrue(re.getId().equals("rs71432129"));
-//					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_GMAF));
-//					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VAF).equals("0.23") );	
-//				}else if(re.getPosition() == 22012840){
-//					assertTrue(re.getId().equals("rs111477956"));
-//					assertTrue(re.getInfo().replace(VcfHeaderUtils.INFO_VLD,"").replace(VcfHeaderUtils.INFO_DB, "").replace(VcfHeaderUtils.INFO_SOMATIC,"").equals(Constants.SEMI_COLON_STRING + Constants.SEMI_COLON_STRING));
-//				}else if(re.getPosition() == 77242678){
-//					assertTrue(re.getId().equals("rs386662672"));
-//					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VAF) == null );	
-//					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VLD) == null );	
-//					assertTrue(re.getInfo().contains(VcfHeaderUtils.INFO_DB));
-//
-//				}else{
-//					assertTrue(re.getId().equals("."));
-//					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_VLD));
-//					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_VAF));
-//					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_DB));
-//				}				
-//			}
-//			assertTrue(i == 5);
-//		 }
-//	}
+	      
+	 @Test
+	public void annotationTest() throws IOException, Exception{
+		createDbsnp(); 
+		
+		final DbsnpMode mode = new DbsnpMode(false);	
+		mode.loadVcfRecordsFromFile(new File(inputName),false);
+		mode.addAnnotation(dbSNPName);
+		mode.reheader("testing run",   inputName);
+		mode.writeVCF( new File(outputName));
+		
+		 try(VCFFileReader reader = new VCFFileReader(outputName)){
+			VcfHeader header = reader.getHeader();
+			
+			assertTrue (null != header.getFileFormat()) ;  
+			assertTrue (null != header.getFileDate()) ; 	 
+			assertTrue (null != header.getUUID()) ;   
+			assertTrue (null != header.getSource()) ;  
+			
+			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_FILE_FORMAT).size() == 1);
+			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_FILE_DATE ).size() == 1);
+			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_UUID_LINE ).size() == 1);
+			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_SOURCE_LINE ).size() == 1);
+			assertTrue(header.getRecords(VcfHeaderUtils.STANDARD_INPUT_LINE ).size() == 1);
+						
+			int ii = 0;
+			for(VcfHeaderRecord re : VcfHeaderUtils.getqPGRecords(header)){
+				assertEquals( VcfHeaderUtils.getQPGTool(re)  , Constants.NULL_STRING_UPPER_CASE);
+				assertNotNull(VcfHeaderUtils.getQPGDate(re) );
+				assertNotNull( VcfHeaderUtils.getQPGCommandLine(re) );
+				assertEquals(1, VcfHeaderUtils.getQPGOrder(re) );
+				ii ++;	
+			}
+			assertTrue(ii == 1);
+						
+			VcfHeaderRecord chrom = header.getChrom();
+			assertTrue(chrom.toString().startsWith(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE)) ;			
+			assertTrue(header.getInfoRecord(VcfHeaderUtils.INFO_VAF) != null);  
+			assertTrue(header.getInfoRecord(VcfHeaderUtils.INFO_DB) != null) ;
+			  						
+			int i = 0;
+			for (final VcfRecord re : reader) {	
+ 				i ++;
+				if(re.getPosition() == 2675826){
+					assertTrue(re.getId().equals("rs71432129"));
+					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_GMAF));
+					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VAF).equals("0.39") );	
+				}else if(re.getPosition() == 2675825){
+					assertTrue(re.getId().equals("rs71432129"));
+					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_GMAF));
+					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VAF).equals("0.23") );	
+				}else if(re.getPosition() == 22012840){
+					assertTrue(re.getId().equals("rs111477956"));
+					assertTrue(re.getInfo().replace(VcfHeaderUtils.INFO_VLD,"").replace(VcfHeaderUtils.INFO_DB, "").replace(VcfHeaderUtils.INFO_SOMATIC,"").equals(Constants.SEMI_COLON_STRING + Constants.SEMI_COLON_STRING));
+				}else if(re.getPosition() == 77242678){
+					assertTrue(re.getId().equals("rs386662672"));
+					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VAF) == null );	
+					assertTrue(re.getInfoRecord().getField(VcfHeaderUtils.INFO_VLD) == null );	
+					assertTrue(re.getInfo().contains(VcfHeaderUtils.INFO_DB));
+
+				}else{
+					assertTrue(re.getId().equals("."));
+					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_VLD));
+					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_VAF));
+					assertFalse(re.getInfo().contains(VcfHeaderUtils.INFO_DB));
+				}				
+			}
+			assertTrue(i == 5);
+		 }
+	}
 	
 	/**
 	 * The VLD info should add to output vcf if it appear on the dbSNP header
@@ -160,18 +160,27 @@ public class DbsnpModeTest {
 	 */
 	
 	@Test
-	public void vLDTest() throws IOException, Exception{
+	public void vLDandStrictTest() throws IOException, Exception{
 		createDbsnpHeader();
 		
-		final DbsnpMode mode = new DbsnpMode();		
-		mode.loadVcfRecordsFromFile(new File(inputName));
+		final DbsnpMode mode = new DbsnpMode(true);		
+		mode.loadVcfRecordsFromFile(new File(inputName), true);
 		mode.addAnnotation(dbSNPName);		
 		mode.reheader("testing run",   inputName);
 		mode.writeVCF(new File(outputName));
 
 		try (VCFFileReader reader = new VCFFileReader(outputName)) {
+			//won't affect header
 			VcfHeader header = reader.getHeader();	
 			assertEquals( header.getInfoRecord(VcfHeaderUtils.INFO_VLD)!= null, true);
+			
+			
+			int i = 0;
+			for (final VcfRecord re : reader) {	 				
+ 				assertTrue(re.getId().equals(Constants.MISSING_DATA_STRING));
+ 				i ++;
+			}
+			assertTrue(i == 5);
 		}		 
 	}		
 	
@@ -188,7 +197,7 @@ public class DbsnpModeTest {
         data.add("chrY\t2675826\t.\tTG\tCA\t.\tCOVN12;MIUN\tSOMATIC;END=2675826\tACCS\tTG,5,37,CA,0,2\tAA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1");
         data.add("chrY\t2675825\t.\tTTG\tTGG\t.\tCOVN12;MIUN\tSOMATIC;END=2675826\tACCS\tTG,5,37,CA,0,2\tAA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1");
 
-        data.add("chrY\t22012840\t.\tC\tA\t.\tMIUN\tSOMATIC\tGT:GD:AC:MR:NNS\t0/1:C/A:A0[0],15[36.2],C11[36.82],9[33]\t0/1:C/A:A0[0],33[35.73],C6[30.5],2[34]:15:13");  
+        data.add("chrMT\t22012840\t.\tC\tA\t.\tMIUN\tSOMATIC\tGT:GD:AC:MR:NNS\t0/1:C/A:A0[0],15[36.2],C11[36.82],9[33]\t0/1:C/A:A0[0],33[35.73],C6[30.5],2[34]:15:13");  
         data.add("chrY\t77242678\t.\tCA\tTG\t.\tPASS\tEND=77242679\tACCS\tCA,10,14,TG,6,7\tCA,14,9,TG,23,21");
         
         try(BufferedWriter out = new BufferedWriter(new FileWriter(inputName));) {          
@@ -209,7 +218,7 @@ public class DbsnpModeTest {
         data.add(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE);
         data.add("Y\t2675825\trs71432129\tTTG\tTGG,TCA\t.\t.\tRSPOS=2675826;RV;dbSNPBuildID=130;SSR=0;SAO=0;VP=050100000008000100000800;WGT=0;VC=MNV;SLO;CFL;GNO;CAF=[0.33,0.23,0.39]");
         data.add("Y\t2675829\trs112502114\tA\tC\t.\t.\tRSPOS=2675829;RV;dbSNPBuildID=132;SSR=0;SAO=0;VP=050100000008000100000100;WGT=0;VC=SNV;SLO;CFL;GNO");
-        data.add("Y\t22012840\trs111477956\tC\tA\t.\t.\tRSPOS=22012840;RV;GMAF=0.113802559414991;dbSNPBuildID=132;SSR=0;SAO=0;VP=050100000000000100000100;WGT=0;VC=SNV;SLO;GNO;VLD");  
+        data.add("M\t22012840\trs111477956\tC\tA\t.\t.\tRSPOS=22012840;RV;GMAF=0.113802559414991;dbSNPBuildID=132;SSR=0;SAO=0;VP=050100000000000100000100;WGT=0;VC=SNV;SLO;GNO;VLD");  
         data.add("Y\t77242677\trs386662672\tCCA\tCTG\t.\t.\tRS=386662672;RSPOS=77242678;dbSNPBuildID=138;SSR=0;SAO=0;VP=0x050000080005000002000800;WGT=1;VC=MNV;INT;ASP;OTHERKG");
         try(BufferedWriter out = new BufferedWriter(new FileWriter(dbSNPName));) {          
            for (final String line : data)  out.write(line + "\n");

--- a/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
@@ -22,6 +22,8 @@ import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 
+import junit.runner.Version;
+
 public class DbsnpModeTest {
 		
 	@Rule
@@ -182,6 +184,9 @@ public class DbsnpModeTest {
 	 * @throws IOException
 	 */
 	public  File createVcf() throws IOException{
+		
+		System.out.println(this.getClass() + "::JUnit version is: " + Version.id()) ;		
+		
         final List<String> data = new ArrayList<>();
         data.add("##fileformat=VCFv4.0");
         data.add(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE_INCLUDING_FORMAT+"s1\ts2");

--- a/qannotate/test/au/edu/qimr/qannotate/modes/GermlineModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/GermlineModeTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -25,6 +26,21 @@ public class GermlineModeTest {
 	
 	@Rule
 	public final TemporaryFolder testFolder = new TemporaryFolder();
+	File f;
+	File db;
+	File out;
+
+	 
+	 
+	@Before
+	public void creatFiles() throws IOException {
+		f = testFolder.newFile();
+		db = testFolder.newFile();
+		out = testFolder.newFile();
+
+		createVcf(f);
+		createGermlineFile(db);		
+	}
   	
 	 
 	 @Test
@@ -56,20 +72,15 @@ public class GermlineModeTest {
 	 
 	@Test
 	public void germlineModeTest() throws Exception {
-		File f = testFolder.newFile();
-		File db = testFolder.newFile();
-		File out = testFolder.newFile();
-		createVcf(f);
-		createGermlineFile(db);
-		final GermlineMode mode = new GermlineMode();		
-		mode.loadVcfRecordsFromFile(f);
+		final GermlineMode mode = new GermlineMode(false);		
+		mode.loadVcfRecordsFromFile(f,false );
 		mode.addAnnotation(db.getAbsolutePath());						
 		mode.reheader("testing run",   f.getAbsolutePath());
 		mode.writeVCF(out);
 		
 		try(VCFFileReader reader = new VCFFileReader(out)){
 			 
-			 //check header
+			//check header
 			VcfHeader header = reader.getHeader();	
 			assertEquals(false, header.getFilterRecord(VcfHeaderUtils.FILTER_GERMLINE) != null);
 
@@ -86,7 +97,7 @@ public class GermlineModeTest {
  				if (re.getPosition() == 95813205) {
  					assertEquals("T:10:283:293:0", re.getInfoRecord().getField(VcfHeaderUtils.INFO_GERMLINE));
  				}
- 				if (re.getPosition() == 	60781981) {
+ 				if (re.getPosition() == 60781981) {
  					assertEquals("G:10:302:312:0", re.getInfoRecord().getField(VcfHeaderUtils.INFO_GERMLINE));
  				}
 			}
@@ -97,11 +108,6 @@ public class GermlineModeTest {
 	 
 	@Test
 	public void checkNonSomatic() throws Exception {
-		File db = testFolder.newFile();
-		File out = testFolder.newFile();
-		File f = testFolder.newFile();
-		createGermlineFile(db);
-		
 		
 	    final List<String> data = new ArrayList<String>(4);
         data.add("##fileformat=VCFv4.0");
@@ -113,8 +119,8 @@ public class GermlineModeTest {
             for (final String line : data)   bw.write(line + "\n");                  
          }
         
-		final GermlineMode mode = new GermlineMode();		
-		mode.loadVcfRecordsFromFile(f);
+		final GermlineMode mode = new GermlineMode(true);		
+		mode.loadVcfRecordsFromFile(f,false);
 		mode.addAnnotation(db.getAbsolutePath());
 		mode.writeVCF(out);
         
@@ -133,13 +139,10 @@ public class GermlineModeTest {
 		 }	        
 	}
 	@Test
-	public void checkSomatic()throws IOException{
-		File db = testFolder.newFile();
-		createGermlineFile(db);
-		
+	public void checkSomatic()throws IOException{		
 		VcfRecord r = new VcfRecord(new String[]{"chr1","16534","rs201459529","C","T",".",".","AF=1.00;DP=2;FS=0.000;MLEAC=2;MLEAF=1.00;MQ=34.79;MQ0=0;QD=20.87;SOR=2.303;IN=2;DB","GT:AD:DP:GQ:PL:FT:MR:NNS:OABS:INF",".:.:.:.:.:.:.:.:.:.","1/1:0,2:2:6:69,6,0:SBIASCOV;SAT3:2:2:T0[0]2[34.5]:SOMATIC"});
 		
-		final GermlineMode mode = new GermlineMode();		
+		final GermlineMode mode = new GermlineMode(true);		
 		mode.positionRecordMap.put(r.getChrPosition(), Arrays.asList(r));
 		mode.addAnnotation(db.getAbsolutePath());
 		
@@ -157,7 +160,7 @@ public class GermlineModeTest {
         		"##fileformat=VCFv4.2",
         		VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE_INCLUDING_FORMAT,
         		"chr1	95813205	rs11165387	C	T	.	.	FLANK=CTTCGTGTCTT;BaseQRankSum=1.846;ClippingRankSum=-1.363;DP=35;FS=3.217;MQ=60.00;MQRankSum=-1.052;QD=18.76;ReadPosRankSum=-1.432;SOR=0.287;IN=1,2;DB;VAF=0.6175;HOM=0,TCCTTCTTCGtGTCTTTCCTT;EFF=downstream_gene_variant(MODIFIER||3602|||RP11-14O19.1|lincRNA|NON_CODING|ENST00000438093||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/1:17,15:Germline:22:32:T0[]1[]:C1;T8:PASS:.:.:15:C4[36.5]13[38.54];T5[41]10[39.7]:.	0/0:26,0:ReferenceNoVariant:22:26:C1[]1[]:C7:PASS:.:.:.:C8[36.5]18[39.56]:.	0/1:16,18:Germline:21:34:.:.:PASS:99:.:.:.:656.77	./.:.:HomozygousLoss:21:.:.:.:PASS:.:NCIG:.:.:.",
-        		"chr1	60781981	rs5015226	T	G	.	.	FLANK=ACCAAGTGCCT;DP=53;FS=0.000;MQ=60.00;QD=31.16;SOR=0.730;IN=1,2;DB;HOM=0,CGAAAACCAAgTGCCTGCATT;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	1/1:0,46:Germline:34:47:G0[]1[]:G5;T1:PASS:.:.:42:C0[0]1[12];G23[40.04]23[36.83]:.	1/1:0,57:Germline:34:57:G2[]0[]:G3:PASS:.:.:51:G24[39]33[39.18]:.	1/1:0,53:Germline:34:53:.:.:PASS:99:.:.:.:2418.77	1/1:0,60:Germline:34:60:.:.:PASS:99:.:.:.:2749.77"
+        		"chrm	60781981	rs5015226	T	G	.	.	FLANK=ACCAAGTGCCT;DP=53;FS=0.000;MQ=60.00;QD=31.16;SOR=0.730;IN=1,2;DB;HOM=0,CGAAAACCAAgTGCCTGCATT;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	1/1:0,46:Germline:34:47:G0[]1[]:G5;T1:PASS:.:.:42:C0[0]1[12];G23[40.04]23[36.83]:.	1/1:0,57:Germline:34:57:G2[]0[]:G3:PASS:.:.:51:G24[39]33[39.18]:.	1/1:0,53:Germline:34:53:.:.:PASS:99:.:.:.:2418.77	1/1:0,60:Germline:34:60:.:.:PASS:99:.:.:.:2749.77"
         		);
         
         try(BufferedWriter out = new BufferedWriter(new FileWriter(f));) {          
@@ -170,14 +173,14 @@ public class GermlineModeTest {
 	 */
 	static void createGermlineFile(File f) throws IOException{
         List<String> data = Arrays.asList("chr1_11894494_C_T:0:1:1:0:rs372880659",
-"chr1_143540358_A_T:183:1:1:183:rs76379294",
-"chr1_95813205_C_T:10:283:293:0:rs11165387",
-"chr1_36332201_A_G:2:0:2:0:rs79659675",
-"chr1_79040252_A_G:0:1:1:0:novel",
-"chr1_147325053_G_A:1:0:1:0:novel",
-"chr1_44499568_T_G:1:0:1:0:novel",
-"chr1_60781981_T_G:10:302:312:0:rs5015226",
-"chr1_173643835_T_C:0:2:2:0:rs1903411");
+		"chr1_143540358_A_T:183:1:1:183:rs76379294",
+		"chr1_95813205_C_T:10:283:293:0:rs11165387",
+		"chr1_36332201_A_G:2:0:2:0:rs79659675",
+		"chr1_79040252_A_G:0:1:1:0:novel",
+		"chr1_147325053_G_A:1:0:1:0:novel",
+		"chr1_44499568_T_G:1:0:1:0:novel",
+		"MT_60781981_T_G:10:302:312:0:rs5015226",
+		"MT_173643835_T_C:0:2:2:0:rs1903411");
 
         try(BufferedWriter out = new BufferedWriter(new FileWriter(f));) {
            for (String line : data)  out.write(line + "\n");

--- a/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
@@ -10,8 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -24,17 +22,11 @@ import org.qcmg.picard.Faidx;
 public class HomoplymersModeTest {
 	@Rule
 	public final TemporaryFolder testFolder = new TemporaryFolder();
-	private File refFile;
- 
-	
-	@Before
-	public void createSequenceFile() throws IOException {
-		refFile = testFolder.newFile("test.fa");
-		createFaFile(refFile.getAbsolutePath());
-	}
+
 	
 	@Test
 	public void refNameTest() throws IOException {
+		File refFile = createFaFile();		
 		String chr = "chrMT";
 		//SNP  in strict mode  chrM != chrMT
 		VcfRecord re = new VcfRecord(new String[] { chr, "1", null, "T", "A" });		
@@ -50,7 +42,7 @@ public class HomoplymersModeTest {
 		
 		//notStrict mode MT == chrM
 		chr = "MT";
-		String fvcf = testFolder.newFile("test.vcf").getAbsolutePath();
+		String fvcf = testFolder.newFile().getAbsolutePath();
         try(BufferedWriter out = new BufferedWriter(new FileWriter(fvcf));) {    
         	 out.write("##fileformat=VCFv4.2\n"+VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE_INCLUDING_FORMAT + "\n");    
         	 out.write(new VcfRecord(new String[] { chr, "1", null, "T", "A" }).toString());                          
@@ -72,6 +64,7 @@ public class HomoplymersModeTest {
 	@Test
 	public void startOfContig() throws IOException {
 		String chr = "chr1";
+		File refFile = createFaFile();	
 		
 		//SNP  in strict mode but both ref and vcf have chr1
 		VcfRecord re = new VcfRecord(new String[] { chr, "1", null, "T", "A" });		
@@ -94,6 +87,7 @@ public class HomoplymersModeTest {
 	@Test
 	public void endOfContig() throws IOException {
 		String chr = "chr1";
+		File refFile = createFaFile();	
 		//SNP
 		VcfRecord re = new VcfRecord(new String[] {  chr, "40", null, "T", "A" });		
 		HomoplymersMode  homo = new HomoplymersMode(null, 3,3, true);
@@ -115,6 +109,7 @@ public class HomoplymersModeTest {
 	@Test
 	public void testInsert() throws IOException{	
 		String chr = "chr1";
+		File refFile = createFaFile();	
 		VcfRecord re = new VcfRecord( new String[] {chr, "21",null, "T", "TTAA" });
 		
 		//small insertion inside reference region
@@ -146,6 +141,7 @@ public class HomoplymersModeTest {
 	@Test
 	public void testDel() throws IOException{
 		String chr = "chr1";
+		File refFile = createFaFile();	
 		VcfRecord re = new VcfRecord(new String[] {  chr, "21", null, "TCC", "T" });		
 		HomoplymersMode  homo = new HomoplymersMode(null, 3,4, true);	
 		Map<String, byte[]> referenceBase = homo.getReferenceBase(refFile);
@@ -169,6 +165,7 @@ public class HomoplymersModeTest {
 	@Test
 	public void testSNP() throws IOException{
 		String chr = "chr1";
+		File refFile = createFaFile();	
 		//MNP
 		VcfRecord re = new VcfRecord(new String[] {  chr, "21", null, "TCC", "AGG" });		
 		HomoplymersMode  homo = new HomoplymersMode(null, 3,4, true);
@@ -428,7 +425,7 @@ public class HomoplymersModeTest {
 		return (max == 1)? 0 : max;
 	}
 	
-	public void  createFaFile(String file) throws IOException {    
+	public File  createFaFile() throws IOException {    
 		/**
 		1  AATGC
 		6  AATTG
@@ -439,19 +436,24 @@ public class HomoplymersModeTest {
 		31 CCCCC
 		36 CCCCC
 	*/	
+		
+		//int id = (int) (Math.random() * 10000);
+		File file = testFolder.newFile();
+		file = new File(file.getAbsolutePath() + ".fa");
     	final List<String> data = new ArrayList<>();
         data.add(">chr1  AC:CM000663.2  gi:568336023  LN:248956422  rl:Chromosome  M5:6aef897c3d6ff0c78aff06ac189178dd  AS:GRCh38");      
         data.add("AATGCAATTGGATCGGACCCTCCCCCCCCCCCCCCCCCCC");          	
         data.add(">chrM  AC:J01415.2  gi:113200490  LN:16569  rl:Mitochondrion  M5:c68f52674c9fb33aef52dcf399755519  AS:GRCh38  tp:circular");      
         data.add("AATGCAATTGGATCGGACCCTCCCCCCCCCCCCCCCCCCC");
  
-        try(BufferedWriter out = new BufferedWriter(new FileWriter(file));) {          
+        try(BufferedWriter out = new BufferedWriter( new FileWriter(file));) {          
            for (final String line : data)  out.write(line + "\n");
         } 
     	//creat index file
-        Faidx idx = new Faidx(new File(file));
-        idx.outputIdx(file + ".fai");
-        idx.outputDict(file + ".dict");
+        Faidx idx = new Faidx(file);
+        idx.outputIdx(file.getAbsolutePath() + ".fai");
+        idx.outputDict(file.getAbsolutePath() + ".dict");
         
+        return file;      
 	}
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
@@ -22,7 +22,6 @@ import org.qcmg.picard.Faidx;
 public class HomoplymersModeTest {
 	@Rule
 	public final TemporaryFolder testFolder = new TemporaryFolder();
-
 	
 	@Test
 	public void refNameTest() throws IOException {
@@ -457,3 +456,5 @@ public class HomoplymersModeTest {
         return file;      
 	}
 }
+
+

--- a/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
@@ -19,45 +19,35 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.ChrPositionUtils;
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 
 import au.edu.qimr.qannotate.modes.TandemRepeatMode.*;
 
-public class TandemRepeatModeTest {
-	String repeatFileName = "input.repeat";
-	String inputVcfName = "input.vcf";
-	String outputVcfName = "output.vcf";
-	
+public class TandemRepeatModeTest {	
+ 	
 	@Rule
 	public final TemporaryFolder testFolder = new TemporaryFolder();
 
 	@Test
 	public void checkRepeatTest() throws IOException{
+		String chr = "chr1";
 		File f = testFolder.newFile();
-		createRepeat(f);
-		TandemRepeatMode trf = new TandemRepeatMode( inputVcfName, outputVcfName, 0);		
-		Map<String, HashSet<Repeat>> repeats = trf.loadRepeat(f.getAbsolutePath() );		
-		assertTrue(repeats.get("chr1").size() == 9);
-		BlockIndex index = trf.makeIndexedBlock(  repeats.get("chr1"));
-		assertEquals(100, index.firstBlockStart);
-		assertEquals(2000, index.lastBlockEnd);
-		assertEquals(24, index.index.size());		// don't know where 24 comes from...
+		createRepeat(chr, f);
+		TandemRepeatMode trf = new TandemRepeatMode(   0, true );	
+		Map<String, BlockIndex> indexedBlc = trf.loadRepeat( f.getAbsolutePath() );
+		assertTrue( indexedBlc.size() == 1);
 		
-		assertTrue(index.firstBlockStart == 100);
-		assertTrue(index.lastBlockEnd == 2000);
+		BlockIndex idxB = indexedBlc.get(chr);
+		assertEquals(100, idxB.firstBlockStart);
+		assertEquals(2000, idxB.lastBlockEnd);		
+		//some big gap will be divided to multi block, each block maximum size is 200		
+		assertTrue( idxB.indexs.size() == 24);
 		
-		Map<Integer, Block> blocks = index.index;
- 		assertTrue(blocks.size() == 24); //some big gap will be divided to multi block, each block maximum size is 200		
-		
-		Set<Block> uniqBlocks = new HashSet<>(blocks.values());
-		int areaLength = 0;
-		for(Block blk: uniqBlocks) 
-			areaLength += blk.getEnd() - blk.getStart() + 1;
- 		assertTrue(areaLength == (index.lastBlockEnd - index.firstBlockStart + 1));	
- 		
- 		assertTrue(uniqBlocks.size() == 12);
+		//check blocks
+		Map<Integer, Block> blocks = idxB.indexs;		
 		assertTrue(blocks.get(100).getEnd() == 114);
 		assertTrue(blocks.get(115).getEnd() == 129);
 		assertTrue(blocks.get(130).getEnd() == 299);
@@ -70,98 +60,93 @@ public class TandemRepeatModeTest {
 		assertTrue(blocks.get(1801).getEnd() == 1802);
 		assertTrue(blocks.get(1803).getEnd() == 1900);
 		assertTrue(blocks.get(1901).getEnd() == 2000);
+				
+		Set<Block> uniqBlocks = new HashSet<>(idxB.indexs.values());
+		assertTrue(uniqBlocks.size() == 12);
+		int areaLength = uniqBlocks.stream().map( k -> k.getEnd() - k.getStart() + 1).mapToInt(Integer::valueOf).sum();		
+		assertTrue(areaLength == (idxB.lastBlockEnd - idxB.firstBlockStart + 1)); 		
 	}
 	
+	
 	@Test
-	public void orderingOfTRF() {
-		
+	public void orderingOfTRF() {		
 		List<String> rawRepeatData = Arrays.asList("chr22\t36744042\t36744076\t12\t2.9\t12\t84\t12\t45\t1.32    TAAAAATATTTT",
-"chr22\t36744085\t36744105\t3\t7.0\t3       80      20      26      0.92    TAA",
-"chr22\t36744085\t36744114\t15\t2.0\t15      87      12      44      0.88    TAATAAATAAATAAA",
-"chr22\t36744089\t36744114\t4\t6.5\t4       86      13      36      0.84    AATA",
-"chr22\t36744104\t36744117\t5\t3.0\t5       90      10      21      0.75    AAATA",
-"chr22\t36744111\t36744129\t9\t2.1\t9       100     0       38      1.00    TAAAATATT",
-"chr22\t36744125\t36744136\t5\t2.4\t5       100     0       24      0.81    TATTT",
-"chr22\t36744130\t36744176\t10\t4.7\t10      73      19      44      1.20    TATTTTAAGA",
-"chr22\t36744118\t36744157\t12\t3.1\t12      82      10      44      1.11    TTTAAAATATTT",
-"chr22\t36744113\t36744213\t44\t2.3\t45      81      6       118     1.16    AAATAATTAAAATATTTTATTTAAAAAAATTTTTAAAGATATTTT",
-"chr22\t36744554\t36744568\t1\t15.0\t1       100     0       30      0.00    A",
-"chr22\t36744566\t36744593\t5\t5.6\t5       100     0       56      0.94    AAATT");
-		
-		
-		Map<String, HashSet<Repeat>> repeats = new HashMap<>();
-		
+			"chr22\t36744085\t36744105\t3\t7.0\t3       80      20      26      0.92    TAA",
+			"chr22\t36744085\t36744114\t15\t2.0\t15      87      12      44      0.88    TAATAAATAAATAAA",
+			"chr22\t36744089\t36744114\t4\t6.5\t4       86      13      36      0.84    AATA",
+			"chr22\t36744104\t36744117\t5\t3.0\t5       90      10      21      0.75    AAATA",
+			"chr22\t36744111\t36744129\t9\t2.1\t9       100     0       38      1.00    TAAAATATT",
+			"chr22\t36744125\t36744136\t5\t2.4\t5       100     0       24      0.81    TATTT",
+			"chr22\t36744130\t36744176\t10\t4.7\t10      73      19      44      1.20    TATTTTAAGA",
+			"chr22\t36744118\t36744157\t12\t3.1\t12      82      10      44      1.11    TTTAAAATATTT",
+			"chr22\t36744113\t36744213\t44\t2.3\t45      81      6       118     1.16    AAATAATTAAAATATTTTATTTAAAAAAATTTTTAAAGATATTTT",
+			"chr22\t36744554\t36744568\t1\t15.0\t1       100     0       30      0.00    A",
+			"chr22\t36744566\t36744593\t5\t5.6\t5       100     0       56      0.94    AAATT");
+				
+		Map<String, HashSet<Repeat>> repeats = new HashMap<>();		
 		for (String s : rawRepeatData) {
-			Repeat rep = new TandemRepeatMode.Repeat(s);
-			repeats.computeIfAbsent(rep.chr, (v) -> new HashSet<>()).add(rep);
+			Repeat rep = new TandemRepeatMode.Repeat(s.split(Constants.TAB_STRING));
+			repeats.computeIfAbsent("chr22", (v) -> new HashSet<>()).add(rep);
 		}
 		
 		assertEquals(1, repeats.size());
 		assertEquals(12, repeats.get("chr22").size());
-		TandemRepeatMode trf = new TandemRepeatMode( inputVcfName, outputVcfName, 0);	
+		TandemRepeatMode trf = new TandemRepeatMode(   0, true);	
 		BlockIndex bi = trf.makeIndexedBlock(repeats.get("chr22"));
 		assertEquals(36744042, bi.firstBlockStart);
 		assertEquals(36744593, bi.lastBlockEnd);
-		
-		 
-		 // chr22	36744135	rs386395340	T	TAA	911.73	PASS	AC=1;AF=0.500;AN=2;BaseQRankSum=1.905;ClippingRankSum=1.154;DP=52;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=1.264;QD=17.53;ReadPosRankSum=0.934;SOR=0.576;NIOC=0.019;SSOI=0.471;SVTYPE=INS;END=36744136;IN=1;DB;VAF=0.5014;TRF=44_2,10_5,12_3,5_2;CONF=HIGH	GT:GD:AD:DP:GQ:PL:ACINDEL	0/1:T/TAA:27,25:52:99:949,0,1035:22,52,51,24[14,10],24[22],0,1,10/1:T/TAA:57,65:122:99:2517,0,2197:52,124,120,58[27,31],60[54],0,1,1
-		 
+			 
+		 // chr22	36744135	rs386395340	T	TAA	911.73	PASS	AC=1;AF=0.500;AN=2;BaseQRankSum=1.905;ClippingRankSum=1.154;DP=52;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=1.264;QD=17.53;ReadPosRankSum=0.934;SOR=0.576;NIOC=0.019;SSOI=0.471;SVTYPE=INS;END=36744136;IN=1;DB;VAF=0.5014;TRF=44_2,10_5,12_3,5_2;CONF=HIGH	GT:GD:AD:DP:GQ:PL:ACINDEL	0/1:T/TAA:27,25:52:99:949,0,1035:22,52,51,24[14,10],24[22],0,1,10/1:T/TAA:57,65:122:99:2517,0,2197:52,124,120,58[27,31],60[54],0,1,1	 
 		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr22", 36744135, 36744136), "rs386395340","T", "TAA");
 		 vcf.setFilter("PASS");
 		 vcf.setInfo("AC=1;AF=0.500;AN=2;BaseQRankSum=1.905;ClippingRankSum=1.154;DP=52;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=1.264;QD=17.53;ReadPosRankSum=0.934;SOR=0.576;NIOC=0.019;SSOI=0.471;SVTYPE=INS;END=36744136;IN=1;DB;VAF=0.5014;CONF=HIGH");
 		 List<String> ff =  Arrays.asList("GT:GD:AD:DP:GQ:PL:ACINDEL","0/1:T/TAA:27,25:52:99:949,0,1035:22,52,51,24[14,10],24[22],0,1,1","0/1:T/TAA:57,65:122:99:2517,0,2197:52,124,120,58[27,31],60[54],0,1,1");
-		 vcf.setFormatFields(ff);
-		 
-		 trf.annotate(vcf, bi);
-		
-		 
+		 vcf.setFormatFields(ff);		 
+		 trf.annotate(vcf, bi);		 
 		 assertEquals("5_2,10_5,12_3,44_2", vcf.getInfoRecord().getField("TRF"));
 	}
-	
- 		
+			
 	@Test
 	public void noBufferTest() throws IOException{
+		String chr = "crh1";
 		File f = testFolder.newFile();
-		createRepeat(f);
-		TandemRepeatMode trf = new TandemRepeatMode( inputVcfName, outputVcfName, 0);		
-		Map<String, HashSet<Repeat>> repeats = trf.loadRepeat(f.getAbsolutePath() );	
-		BlockIndex index = trf.makeIndexedBlock(  repeats.get("chr1"));
-		assertEquals(100, index.firstBlockStart);
-		assertEquals(2000, index.lastBlockEnd);
-		assertEquals(24, index.index.size());		// don't know where 24 comes from...
-
+		createRepeat(chr, f);		
+		
+		TandemRepeatMode trf = new TandemRepeatMode(   0, true );	
+		BlockIndex index = trf.loadRepeat( f.getAbsolutePath() ).get(chr);
+		
 		//before repeat region
-		VcfRecord vcf = new VcfRecord.Builder("chr1", 98, "A").allele("AT").build();
+		VcfRecord vcf = new VcfRecord.Builder(chr, 98, "A").allele("AT").build();
 		assertFalse(trf.annotate(vcf, index));
 		assertTrue(StringUtils.isMissingDtaString( vcf.getFilter()));
 		assertTrue(StringUtils.isMissingDtaString( vcf.getInfo()));
 		
 		//second base is the start of third repeat
-		vcf = new VcfRecord.Builder("chr1", 99, "A").allele("AT").build();
+		vcf = new VcfRecord.Builder(chr, 99, "A").allele("AT").build();
 		assertTrue( trf.annotate(vcf, index) );	 
 		assertTrue(vcf.getFilter().equals("TRF"));		
 		assertTrue( vcf.getInfoRecord().getField("TRF").equals(("3_14")));
  		
 		//deletion should be same with insertion
-		VcfRecord vcf2 = new VcfRecord.Builder("chr1", 99, "AT").allele("A").build();
+		VcfRecord vcf2 = new VcfRecord.Builder(chr, 99, "AT").allele("A").build();
 		assertTrue( trf.annotate(vcf2, index) );	
 		assertTrue( vcf.getInfoRecord().getField("TRF").equals(("3_14")));		
 		
 		//start at repeat start and another repeat end for SNP
-		vcf = new VcfRecord.Builder("chr1", 500, "A").allele("T").build();
+		vcf = new VcfRecord.Builder(chr, 500, "A").allele("T").build();
 		assertFalse( trf.annotate(vcf, index) );
 		assertTrue(vcf.getInfoRecord().getField("TRF").equals("5_3")  );
 		
 		//start one base region, in homoplymers but no strong supporting reads
-		vcf = new VcfRecord.Builder("chr1", 1803, "A").allele("T").build();
+		vcf = new VcfRecord.Builder(chr, 1803, "A").allele("T").build();
 		assertTrue( trf.annotate(vcf, index) );
 		
 		//adjacant to homoplymers
-		vcf = new VcfRecord.Builder("chr1", 1800, "A").allele("T").build();
+		vcf = new VcfRecord.Builder(chr, 1800, "A").allele("T").build();
 		assertFalse( trf.annotate(vcf, index) );
 		
 		//test new TRF rule by reading strong supporting read couts
-		vcf = new VcfRecord.Builder("chr1", 1800, "A").allele("T").build();
+		vcf = new VcfRecord.Builder(chr, 1800, "A").allele("T").build();
 		assertFalse( trf.annotate(vcf, index) );
 		vcf.appendInfo(IndelUtils.INFO_SSOI + "=0.3");
 		assertFalse( trf.annotate(vcf, index) );
@@ -169,29 +154,27 @@ public class TandemRepeatModeTest {
 		assertTrue( trf.annotate(vcf, index) );
 
 		//just outside TRF region without strong supporting reads
-		vcf = new VcfRecord.Builder("chr1", 2001, "A").allele("T").build();	
+		vcf = new VcfRecord.Builder(chr, 2001, "A").allele("T").build();	
 		assertFalse( trf.annotate(vcf, index) );
 	}
 		
 	@Test
  	public void bufferTest() throws IOException{
+		String chr = "M";
 		File f = testFolder.newFile();
-		createRepeat(f);
-		TandemRepeatMode trf = new TandemRepeatMode( inputVcfName, outputVcfName, 5);		
-		Map<String, HashSet<Repeat>> repeats = trf.loadRepeat(f.getAbsolutePath() );				
-		BlockIndex index = trf.makeIndexedBlock(  repeats.get("chr1"));
-		assertEquals(100, index.firstBlockStart);
-		assertEquals(2000, index.lastBlockEnd);
-		assertEquals(24, index.index.size());		// don't know where 24 comes from...
+		createRepeat(chr, f);	
+		
+		TandemRepeatMode trf = new TandemRepeatMode(   5, true );	
+		BlockIndex index = trf.loadRepeat( f.getAbsolutePath() ).get(chr);
 
 		//before repeat region
-		VcfRecord vcf = new VcfRecord.Builder("chr1", 98, "A").allele("AT").build();
+		VcfRecord vcf = new VcfRecord.Builder(chr, 98, "A").allele("AT").build();
 		assertTrue(trf.annotate(vcf, index));
 		assertTrue( vcf.getFilter().equals("TRF"));
 		assertTrue( vcf.getInfoRecord().getField("TRF").equals("3_14"));
 				
 		//start at repeat start and another repeat end for SNP
-		vcf = new VcfRecord.Builder("chr1", 500, "A").allele("T").build();
+		vcf = new VcfRecord.Builder(chr, 500, "A").allele("T").build();
 		assertFalse( trf.annotate(vcf, index) );
 		
 		String[] trfs =  vcf.getInfoRecord().getField("TRF").split(",");
@@ -199,8 +182,8 @@ public class TandemRepeatModeTest {
 			assertTrue( str.equals("5_3") || str.equals("15_12") ); 
 				
 		//adjacant to homoplymers
-		trf = new TandemRepeatMode( inputVcfName, outputVcfName, 3);			 
-		vcf = new VcfRecord.Builder("chr1", 1800, "A").allele("T").build();
+		trf = new TandemRepeatMode(   3, true);			 
+		vcf = new VcfRecord.Builder(chr, 1800, "A").allele("T").build();
 		assertTrue( trf.annotate(vcf, index) );
  		 
 		trfs =  vcf.getInfoRecord().getField("TRF").split(",");
@@ -209,53 +192,51 @@ public class TandemRepeatModeTest {
 			assertTrue(str.equals("4_6") || str.equals("6_2") || str.equals("1_200") );	
 		 		 
 		//just outside TRF region without strong supporting reads
-		vcf = new VcfRecord.Builder("chr1", 2001, "A").allele("T").build();	
+		vcf = new VcfRecord.Builder(chr, 2001, "A").allele("T").build();	
 		assertTrue( trf.annotate(vcf, index) );
 	}
 
 	@Test
-	public void embededTRFTest() throws IOException{
+	public void embededTRFTest() throws IOException{		
+		String chr = "M";
 		File f = testFolder.newFile();
-		createRepeat(f);
-		TandemRepeatMode trf = new TandemRepeatMode( inputVcfName, outputVcfName, 0);		
-		Map<String, HashSet<Repeat>> repeats = trf.loadRepeat(f.getAbsolutePath() );				
-		BlockIndex index = trf.makeIndexedBlock(  repeats.get("chr1"));
-		assertEquals(100, index.firstBlockStart);
-		assertEquals(2000, index.lastBlockEnd);
-		assertEquals(24, index.index.size());		// don't know where 24 comes from...
+		createRepeat("chrMT", f);			
+		TandemRepeatMode trf = new TandemRepeatMode(   0, false);		
+		String chr1 = ChrPositionUtils.ChrNameConveter(chr);
+		BlockIndex index = trf.loadRepeat( f.getAbsolutePath() ).get(chr1);
+		
 		
 		//DEL same length to homoplymers ref==16bp
-		VcfRecord vcf = new VcfRecord.Builder("chr1", 115, "AAAAAAAAAAAAAAAA").allele("A").build();
+		VcfRecord vcf = new VcfRecord.Builder(chr, 115, "AAAAAAAAAAAAAAAA").allele("A").build();
 		assertTrue(trf.annotate(vcf, index)); 			 
 		for(String str : vcf.getInfoRecord().getField("TRF").split(",") )
 			assertTrue(str.equals("1_12") || str.equals("16_2") );	
 
 		//DEL bigger than homoplymers
-		vcf = new VcfRecord.Builder("chr1", 115, "AAAAAAAAAAAAAAAAA").allele("A").build();
+		vcf = new VcfRecord.Builder(chr, 115, "AAAAAAAAAAAAAAAAA").allele("A").build();
 		assertFalse(trf.annotate(vcf, index)); 
 		for(String str : vcf.getInfoRecord().getField("TRF").split(",") )
 			assertTrue(str.equals("1_12") || str.equals("16_2") );	
 
 		//DEL cross over adjacant TRF "chr1\t100\t115\t3\t13.7"
-		vcf = new VcfRecord.Builder("chr1", 114, "AAAAAAAAAAAAAAAAA").allele("A").build();
+		vcf = new VcfRecord.Builder(chr, 114, "AAAAAAAAAAAAAAAAA").allele("A").build();
 		assertTrue(trf.annotate(vcf, index)); 
 		assertTrue(vcf.getInfoRecord().getField("TRF").contains("1_12"));
 		assertTrue(vcf.getInfoRecord().getField("TRF").contains("3_14"));
 		
 	}
 	
-	private void createRepeat(File f) throws IOException{
+	private void createRepeat(String chr, File f) throws IOException{
 		 final List<String> data = new ArrayList<>();		 
-		 data.add("chr1\t100\t115\t3\t13.7");
-		 data.add("chr1\t115\t130\t1\t12.0");
-//		 data.add("chr1\t115\t300\t8\t2.0");
-		 data.add("chr1\t130\t350\t16\t2.0");
-		 data.add("chr1\t300\t500\t15\t12.2\t5\t100\t0\t22\t0.68\tAAAAC");
-		 data.add("chr1\t500\t600\t5\t3.2\t5\t81\t0\t23\t0.81\tCCGCC");		 
-		 data.add("chr1\t1700\t1799\t6\t2.0\t12\t100\t0\t24\t1.79\tTGCAGG");
-		 data.add("chr1\t1801\t1900\t4\t6.0\t4\t90\t0\t30\t1.19\tGCGG");		
-		 data.add("chr1\t1700\t2000\t4\t6.0\t4\t90\t0\t30\t1.19\tGCGG");
-		 data.add("chr1\t1803\t2000\t1\t200.0");
+		 data.add(chr + "\t100\t115\t3\t13.7");
+		 data.add(chr + "\t115\t130\t1\t12.0");
+		 data.add(chr + "\t130\t350\t16\t2.0");
+		 data.add(chr + "\t300\t500\t15\t12.2\t5\t100\t0\t22\t0.68\tAAAAC");
+		 data.add(chr + "\t500\t600\t5\t3.2\t5\t81\t0\t23\t0.81\tCCGCC");		 
+		 data.add(chr + "\t1700\t1799\t6\t2.0\t12\t100\t0\t24\t1.79\tTGCAGG");
+		 data.add(chr + "\t1801\t1900\t4\t6.0\t4\t90\t0\t30\t1.19\tGCGG");		
+		 data.add(chr + "\t1700\t2000\t4\t6.0\t4\t90\t0\t30\t1.19\tGCGG");
+		 data.add(chr + "\t1803\t2000\t1\t200.0");
 		  
         try(BufferedWriter out = new BufferedWriter(new FileWriter(f));) {          
             for (final String line : data)   out.write(line + "\n");                  

--- a/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
@@ -103,9 +103,9 @@ public class TandemRepeatModeTest {
 		assertEquals(36744042, bi.firstBlockStart);
 		assertEquals(36744593, bi.lastBlockEnd);
 		
-		/*
-		 * chr22	36744135	rs386395340	T	TAA	911.73	PASS	AC=1;AF=0.500;AN=2;BaseQRankSum=1.905;ClippingRankSum=1.154;DP=52;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=1.264;QD=17.53;ReadPosRankSum=0.934;SOR=0.576;NIOC=0.019;SSOI=0.471;SVTYPE=INS;END=36744136;IN=1;DB;VAF=0.5014;TRF=44_2,10_5,12_3,5_2;CONF=HIGH	GT:GD:AD:DP:GQ:PL:ACINDEL	0/1:T/TAA:27,25:52:99:949,0,1035:22,52,51,24[14,10],24[22],0,1,10/1:T/TAA:57,65:122:99:2517,0,2197:52,124,120,58[27,31],60[54],0,1,1
-		 */
+		 
+		 // chr22	36744135	rs386395340	T	TAA	911.73	PASS	AC=1;AF=0.500;AN=2;BaseQRankSum=1.905;ClippingRankSum=1.154;DP=52;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=1.264;QD=17.53;ReadPosRankSum=0.934;SOR=0.576;NIOC=0.019;SSOI=0.471;SVTYPE=INS;END=36744136;IN=1;DB;VAF=0.5014;TRF=44_2,10_5,12_3,5_2;CONF=HIGH	GT:GD:AD:DP:GQ:PL:ACINDEL	0/1:T/TAA:27,25:52:99:949,0,1035:22,52,51,24[14,10],24[22],0,1,10/1:T/TAA:57,65:122:99:2517,0,2197:52,124,120,58[27,31],60[54],0,1,1
+		 
 		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr22", 36744135, 36744136), "rs386395340","T", "TAA");
 		 vcf.setFilter("PASS");
 		 vcf.setInfo("AC=1;AF=0.500;AN=2;BaseQRankSum=1.905;ClippingRankSum=1.154;DP=52;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=1.264;QD=17.53;ReadPosRankSum=0.934;SOR=0.576;NIOC=0.019;SSOI=0.471;SVTYPE=INS;END=36744136;IN=1;DB;VAF=0.5014;CONF=HIGH");
@@ -118,8 +118,7 @@ public class TandemRepeatModeTest {
 		 assertEquals("5_2,10_5,12_3,44_2", vcf.getInfoRecord().getField("TRF"));
 	}
 	
-	
-	
+ 		
 	@Test
 	public void noBufferTest() throws IOException{
 		File f = testFolder.newFile();
@@ -213,7 +212,7 @@ public class TandemRepeatModeTest {
 		vcf = new VcfRecord.Builder("chr1", 2001, "A").allele("T").build();	
 		assertTrue( trf.annotate(vcf, index) );
 	}
-	
+
 	@Test
 	public void embededTRFTest() throws IOException{
 		File f = testFolder.newFile();

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
@@ -14,9 +14,6 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import junit.framework.Assert;
-
-import org.junit.After;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.commandline.Executor;
@@ -37,26 +34,6 @@ public class Vcf2mafIndelTest {
     @org.junit.Rule
     public  TemporaryFolder testFolder = new TemporaryFolder();
     
-//     static String inputName = DbsnpModeTest.inputName;    
-//    static String outputDir = new File(inputName).getAbsoluteFile().getParent() + "/output";
-//    static String outputMafName = "output.maf";
-//    static String logName = "output.log"; 
- 
-//    @After
-//    public void deleteIO() throws IOException{
-//       
-//        File dir = new java.io.File( "." ).getCanonicalFile();
-//        File[] files = dir.listFiles();
-//        if (null != files) {
-//            for(File f: files){ 
-//                if(    f.getName().endsWith(".vcf")  ||  f.getName().contains(".log") || f.getName().endsWith(".maf") ||  f.getName().contains("output")){            
-//                    f.delete();    
-//                }      
-//            }
-//        }
-//        Vcf2mafTest.deleteIO();        
-//    }
-    
     @Test
     public void frame_Shift_Test() throws IOException  {
         File input = testFolder.newFile();
@@ -70,7 +47,7 @@ public class Vcf2mafIndelTest {
             };
             
             try{
-                    Vcf2mafTest.createVcf(input, str);                
+                   new Vcf2mafTest().createVcf(input, str);                
                     final Vcf2maf v2m = new Vcf2maf(1,2, null, null, ContentType.MULTIPLE_CALLERS_MULTIPLE_SAMPLES);    
                     try(VCFFileReader reader = new VCFFileReader(input); ){
                      for (final VcfRecord vcf : reader){
@@ -120,7 +97,7 @@ public class Vcf2mafIndelTest {
                        
         };
             try {
-                Vcf2mafTest.createVcf(input, str);
+                new Vcf2mafTest().createVcf(input, str);
                 final String[] command = {"--mode", "vcf2maf",  "--log", log.getAbsolutePath(),  "-i", input.getAbsolutePath() , "-output" , out.getAbsolutePath()};
                 au.edu.qimr.qannotate.Main.main(command);
             } catch ( Exception e) {
@@ -208,7 +185,7 @@ public class Vcf2mafIndelTest {
         };
            
 
-            Vcf2mafTest.createVcf(input, str);             
+            new Vcf2mafTest().createVcf(input, str);             
             
         final String command = "--mode vcf2maf  --log " + log.getAbsolutePath() + " -i " + input.getAbsolutePath() + " --outdir " + out.getAbsolutePath();            
         final Executor exec = new Executor(command, "au.edu.qimr.qannotate.Main");            
@@ -220,7 +197,7 @@ public class Vcf2mafIndelTest {
             Optional<String> delline = lines.filter(s ->s.contains("8,18,16,8[2,6],9[9],0,0,0")).filter(s->s.contains("DEL")).findFirst();
             
             if(!delline.isPresent())
-                Assert.fail("missing DEL variants");                
+                fail("missing DEL variants");                
             //split string to maf record               
             SnpEffMafRecord maf =  toMafRecord(delline.get());
             
@@ -262,7 +239,7 @@ public class Vcf2mafIndelTest {
         try(Stream<String> lines = Files.lines(path)){
             Optional<String> insline = lines.filter(s -> s.contains("INS")).filter(s -> s.contains("23114")).findFirst();
             if(!insline.isPresent())
-                Assert.fail("missing INS variants");                
+               fail("missing INS variants");                
             SnpEffMafRecord maf =  toMafRecord(insline.get());
                
             //"chr1\t16864\t.\tGCA\tG
@@ -320,7 +297,7 @@ public class Vcf2mafIndelTest {
         };
            
         try {
-            Vcf2mafTest.createVcf(input, str);
+            new Vcf2mafTest().createVcf(input, str);
             final String[] command = {"--mode", "vcf2maf",  "--log", log.getAbsolutePath(),  "-i", input.getAbsolutePath() , "-o" , out.getAbsolutePath()};
             au.edu.qimr.qannotate.Main.main(command);
         } catch ( Exception e) {
@@ -347,7 +324,6 @@ public class Vcf2mafIndelTest {
         //split string to maf record
         SnpEffMafRecord maf = new SnpEffMafRecord();
         String[] eles = line.split("\\t");
-        System.out.println("eles.length: " + eles.length);
         //last two optional column for acsnp
         assertTrue(eles.length == MafElement.values().length);
              

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.qcmg.common.commandline.Executor;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.IndelUtils;
@@ -31,7 +30,6 @@ import au.edu.qimr.qannotate.utils.SnpEffConsequence;
 import au.edu.qimr.qannotate.utils.SnpEffMafRecord;
 
 public class Vcf2mafTest {
-    static String inputName = DbsnpModeTest.inputName;        
     
     @org.junit.Rule
     public  TemporaryFolder testFolder = new TemporaryFolder();
@@ -90,40 +88,40 @@ public class Vcf2mafTest {
      private VcfHeader createMergedVcfHeader() {
          VcfHeader h = new VcfHeader();
          
-//have to remove empty line "##"         
-         Arrays.asList("##fileformat=VCFv4.2",
-"##fileDate=20160523",
-"##qUUID=209dec81-a127-4aa3-92b4-2c15c21b75c7",
-"##qSource=qannotate-2.0 (1170)",
-"##1:qUUID=7554fdcc-7230-400e-aefe-5c9a4c79907b",
-"##1:qSource=qSNP v2.0 (1170)",
-"##1:qDonorId=my_donor",
-"##1:qControlSample=my_control_sample",
-"##1:qTestSample=my_test_sample",
-"##1:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##1:qControlBamUUID=null",
-"##1:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##1:qTestBamUUID=null",
-"##1:qAnalysisId=e3afda85-469f-412b-8919-10cd31d2ca52",
-"##2:qUUID=aa7d805f-2ec8-4aea-b1e6-7bc410a41c4b",
-"##2:qSource=qSNP v2.0 (1170)",
-"##2:qDonorId=my_donor",
-"##2:qControlSample=my_control_sample",
-"##2:qTestSample=my_test_sample",
-"##2:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##2:qControlBamUUID=null",
-"##2:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##2:qTestBamUUID=null",
-"##2:qAnalysisId=3334e934-cb45-4215-9eb5-84b63d96a502",
-"##2:qControlVcf=/mnt/lustre/home/oliverH/q3testing/analysis/9/7/97b3715c-0a80-4115-844e-cc877b2cf409/controlGatkHCCV.vcf",
-"##2:qControlVcfUUID=null",
-"##2:qControlVcfGATKVersion=3.4-46-gbc02625",
-"##2:qTestVcf=/mnt/lustre/home/oliverH/q3testing/analysis/c/f/cfccdb1c-6c26-48e9-bd73-ad4ebd806aa6/testGatkHCCV.vcf",
-"##2:qTestVcfUUID=null",
-"##2:qTestVcfGATKVersion=3.4-46-gbc02625",
-"##INPUT=1,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/e/3/e3afda85-469f-412b-8919-10cd31d2ca52/e3afda85-469f-412b-8919-10cd31d2ca52.vcf",
-//"##INPUT=2,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/3/3/3334e934-cb45-4215-9eb5-84b63d96a502/3334e934-cb45-4215-9eb5-84b63d96a502.vcf").stream().forEach(h::parseHeaderLine);
-"##INPUT=2,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/3/3/3334e934-cb45-4215-9eb5-84b63d96a502/3334e934-cb45-4215-9eb5-84b63d96a502.vcf").stream().forEach(h::addOrReplace);
+			//have to remove empty line "##"         
+			         Arrays.asList("##fileformat=VCFv4.2",
+			"##fileDate=20160523",
+			"##qUUID=209dec81-a127-4aa3-92b4-2c15c21b75c7",
+			"##qSource=qannotate-2.0 (1170)",
+			"##1:qUUID=7554fdcc-7230-400e-aefe-5c9a4c79907b",
+			"##1:qSource=qSNP v2.0 (1170)",
+			"##1:qDonorId=my_donor",
+			"##1:qControlSample=my_control_sample",
+			"##1:qTestSample=my_test_sample",
+			"##1:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+			"##1:qControlBamUUID=null",
+			"##1:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+			"##1:qTestBamUUID=null",
+			"##1:qAnalysisId=e3afda85-469f-412b-8919-10cd31d2ca52",
+			"##2:qUUID=aa7d805f-2ec8-4aea-b1e6-7bc410a41c4b",
+			"##2:qSource=qSNP v2.0 (1170)",
+			"##2:qDonorId=my_donor",
+			"##2:qControlSample=my_control_sample",
+			"##2:qTestSample=my_test_sample",
+			"##2:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+			"##2:qControlBamUUID=null",
+			"##2:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+			"##2:qTestBamUUID=null",
+			"##2:qAnalysisId=3334e934-cb45-4215-9eb5-84b63d96a502",
+			"##2:qControlVcf=/mnt/lustre/home/oliverH/q3testing/analysis/9/7/97b3715c-0a80-4115-844e-cc877b2cf409/controlGatkHCCV.vcf",
+			"##2:qControlVcfUUID=null",
+			"##2:qControlVcfGATKVersion=3.4-46-gbc02625",
+			"##2:qTestVcf=/mnt/lustre/home/oliverH/q3testing/analysis/c/f/cfccdb1c-6c26-48e9-bd73-ad4ebd806aa6/testGatkHCCV.vcf",
+			"##2:qTestVcfUUID=null",
+			"##2:qTestVcfGATKVersion=3.4-46-gbc02625",
+			"##INPUT=1,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/e/3/e3afda85-469f-412b-8919-10cd31d2ca52/e3afda85-469f-412b-8919-10cd31d2ca52.vcf",
+			//"##INPUT=2,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/3/3/3334e934-cb45-4215-9eb5-84b63d96a502/3334e934-cb45-4215-9eb5-84b63d96a502.vcf").stream().forEach(h::parseHeaderLine);
+			"##INPUT=2,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/3/3/3334e934-cb45-4215-9eb5-84b63d96a502/3334e934-cb45-4215-9eb5-84b63d96a502.vcf").stream().forEach(h::addOrReplace);
 
          return h;
      }
@@ -661,13 +659,14 @@ public class Vcf2mafTest {
      }     
      
     
-    public static void createVcf(String[] str) throws IOException{
-        createVcf(new File(inputName), str);
+    public File createVcf(String[] str) throws IOException{    
+        return createVcf( testFolder.newFile()  , str);
     }
-    public static void createVcf(File outputFile, String[] str) throws IOException{
+    public static File createVcf(File outputFile, String[] str) throws IOException{
         try(PrintWriter out = new PrintWriter(new FileWriter(outputFile));) {
             out.println(Arrays.stream(str).collect(Collectors.joining(Constants.NL_STRING)));
-        }          
+        }  
+        return outputFile;
     }
      
 
@@ -752,52 +751,53 @@ public class Vcf2mafTest {
         assertEquals(true, new File(GHCVcf).exists());
     }
 
-    @Test
-    public void fileNameWithNODonorTest() throws IOException{
-         File log = testFolder.newFile();
-         File input = testFolder.newFile();
-         File out = testFolder.newFile();
-        String[] str = {"##fileformat=VCFv4.0",            
-                "##qControlSample=CONTROL",
-                "##qTestSample=TEST",                
-                VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL\tTEST" };
-
-        createVcf(input, str);
+//    @Test
+//    public void fileNameWithNODonorTest() throws IOException{
+//         File log = testFolder.newFile();
+//         File input = testFolder.newFile();
+//         File out = testFolder.newFile();
+//        String[] str = {"##fileformat=VCFv4.0",            
+//                "##qControlSample=CONTROL",
+//                "##qTestSample=TEST",                
+//                VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL\tTEST" };
+//
+//        createVcf(input, str);
+//        
+//        try{            
+//            final String command = "--mode vcf2maf --log " + log.getAbsolutePath() + " -i " + input.getAbsolutePath() + " --outdir " + out.getAbsolutePath();            
+//            final Executor exec = new Executor(command, "au.edu.qimr.qannotate.Main");            
+//            assertEquals(1, exec.getErrCode());            
+//            
+//        }catch(Exception e){
+//             fail(e.getMessage());
+//        }    
+//    }
         
-        try{            
-            final String command = "--mode vcf2maf --log " + log.getAbsolutePath() + " -i " + input.getAbsolutePath() + " --outdir " + out.getAbsolutePath();            
-            final Executor exec = new Executor(command, "au.edu.qimr.qannotate.Main");            
-            assertEquals(1, exec.getErrCode());            
-            
-        }catch(Exception e){
-             fail(e.getMessage());
-        }    
-    }
-        
-    @Test
-    public void fileNameWithNoSampleidTest() throws IOException{
-         File log = testFolder.newFile();
-         File input = testFolder.newFile();
-         File out = testFolder.newFolder();
-        String[] str = {"##fileformat=VCFv4.0",            
-                VcfHeaderUtils.STANDARD_DONOR_ID +"=MELA_0264",
-                VcfHeaderUtils.STANDARD_TEST_BAMID +"=TEST_uuid",                
-                VcfHeaderUtils.STANDARD_CONTROL_BAMID +"=CONTROL_uuid",                
-                VcfHeaderUtils.STANDARD_TEST_SAMPLE +"=TEST_sample",                
-                VcfHeaderUtils.STANDARD_CONTROL_SAMPLE +"=CONTROL_sample",                
-                VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_uuid\tTEST_uuid"};
-
-        createVcf(input, str);
-        
-        try{
-            final String command = "-mode vcf2maf   --log " + log.getAbsolutePath() + " -i " + input.getAbsolutePath() + " --outdir " + out.getAbsolutePath();    
-            final Executor exec = new Executor(command, "au.edu.qimr.qannotate.Main");            
-            assertEquals(0, exec.getErrCode());    
-        } catch (Exception e){
-             fail(e.getMessage());
-        }
-        
-    }
+//    @Test
+//    public void fileNameWithNoSampleidTest() throws IOException{
+//         File log = testFolder.newFile("test.log");
+//         File input = testFolder.newFile("test.vcf");
+//         File out = testFolder.newFolder("test.maf");
+//         
+//        String[] str = {"##fileformat=VCFv4.0",            
+//                VcfHeaderUtils.STANDARD_DONOR_ID +"=MELA_0264",
+//                VcfHeaderUtils.STANDARD_TEST_BAMID +"=TEST_uuid",                
+//                VcfHeaderUtils.STANDARD_CONTROL_BAMID +"=CONTROL_uuid",                
+//                VcfHeaderUtils.STANDARD_TEST_SAMPLE +"=TEST_sample",                
+//                VcfHeaderUtils.STANDARD_CONTROL_SAMPLE +"=CONTROL_sample",                
+//                VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_uuid\tTEST_uuid"};
+//
+//        createVcf(input, str);
+//        
+//        try{
+//            final String command = "-mode vcf2maf   --log " + log.getAbsolutePath() + " -i " + input.getAbsolutePath() + " --outdir " + out.getAbsolutePath();    
+//            final Executor exec = new Executor(command, "au.edu.qimr.qannotate.Main");            
+//            assertEquals(0, exec.getErrCode());    
+//        } catch (Exception e){
+//             fail(e.getMessage());
+//        }
+//        
+//    }
 
 }
 

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.string.StringUtils;
@@ -31,7 +32,7 @@ import au.edu.qimr.qannotate.utils.SnpEffMafRecord;
 
 public class Vcf2mafTest {
     
-    @org.junit.Rule
+    @Rule
     public  TemporaryFolder testFolder = new TemporaryFolder();
     
      @Test
@@ -599,7 +600,7 @@ public class Vcf2mafTest {
                     "chr1\t7722099\trs6698334\tC\tT\t.\t.\tBaseQRankSum=-0.736;ClippingRankSum=0.736;DP=3;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.736;QD=14.92;ReadPosRankSum=0.736;SOR=0.223;IN=2;DB;VLD;VAF=0.06887;EFF=intron_variant(MODIFIER|||c.805+173C>T|1673|CAMTA1|protein_coding|CODING|ENST00000303635|8|1),intron_variant(MODIFIER|||c.805+173C>T|1659|CAMTA1|protein_coding|CODING|ENST00000439411|8|1)\tGT:AD:DP:GQ:FT:MR:NNS:OABS:INF\t.:.:.:.:.:.:.:.:CONF=ZERO\t.:.:.:.:.:.:.:.:.\t0/1:1,2:3:35:COVN8:2:2:C0[0]1[39];T1[35]1[37]:CONF=ZERO\t.:.:.:.:.:.:.:.:."};            
                 createVcf(input, str); 
                 try {
-                    Vcf2mafTest.createVcf(input, str);
+                    createVcf(input, str);
                     final String[] command = {"--mode", "vcf2maf",  "--log", log.getAbsolutePath(),  "-i", input.getAbsolutePath() , "-o" , out.getAbsolutePath()};
                     au.edu.qimr.qannotate.Main.main(command);
                 } catch ( Exception e) {
@@ -662,7 +663,7 @@ public class Vcf2mafTest {
     public File createVcf(String[] str) throws IOException{    
         return createVcf( testFolder.newFile()  , str);
     }
-    public static File createVcf(File outputFile, String[] str) throws IOException{
+    public File createVcf(File outputFile, String[] str) throws IOException{
         try(PrintWriter out = new PrintWriter(new FileWriter(outputFile));) {
             out.println(Arrays.stream(str).collect(Collectors.joining(Constants.NL_STRING)));
         }  

--- a/qannotate/test/au/edu/qimr/qannotate/utils/SampleColumnTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/utils/SampleColumnTest.java
@@ -5,16 +5,12 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.After;
 import org.junit.Test;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
-
-import au.edu.qimr.qannotate.modes.DbsnpModeTest;
 import au.edu.qimr.qannotate.modes.Vcf2mafTest;
 
 public class SampleColumnTest {
-	public static String input = DbsnpModeTest.inputName;	
 	
 	private final String[] header0 = {
     		VcfHeaderUtils.STANDARD_FILE_FORMAT + "=VCFv4.0",			
@@ -29,30 +25,28 @@ public class SampleColumnTest {
 			//VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tqControlSample\tqTestSample"			
     };	
 	
-	@After
-	public void clear(){	new File(input).delete();	}
 	
 	@Test
 	public void sampleNameTest1() throws IOException {
 		String[] sHeader = header0.clone(); 
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tqControlSample\tqTestSample";	
 		
-        	Vcf2mafTest.createVcf(sHeader);                
-        	try(VCFFileReader reader = new VCFFileReader(input); ){
-    			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
-    			assertTrue(column.getControlSample().equals("CONTROL_sample"));
-    			assertTrue(column.getTestSample().equals("TEST_sample"));
-    			
-    			column = SampleColumn.getSampleColumn("alignment#test", "grfli:control" , reader.getHeader());
-       			assertTrue(column.getControlSample().equals("control"));
-       			assertTrue(column.getTestSample().equals("test")); 		
-       			
-       			column = SampleColumn.getSampleColumn("alignment,test", "grfli:align#control" , reader.getHeader());
-       			assertTrue(column.getControlSample().equals("control"));
-      			assertTrue(column.getTestSample().equals("alignment,test")); 	
-	        }catch(Exception e){
-	        	fail(e.getMessage()); 
-	        }
+    	File input = new Vcf2mafTest().createVcf(sHeader);                
+    	try(VCFFileReader reader = new VCFFileReader(input); ){
+			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
+			assertTrue(column.getControlSample().equals("CONTROL_sample"));
+			assertTrue(column.getTestSample().equals("TEST_sample"));
+			
+			column = SampleColumn.getSampleColumn("alignment#test", "grfli:control" , reader.getHeader());
+   			assertTrue(column.getControlSample().equals("control"));
+   			assertTrue(column.getTestSample().equals("test")); 		
+   			
+   			column = SampleColumn.getSampleColumn("alignment,test", "grfli:align#control" , reader.getHeader());
+   			assertTrue(column.getControlSample().equals("control"));
+  			assertTrue(column.getTestSample().equals("alignment,test")); 	
+        }catch(Exception e){
+        	fail(e.getMessage()); 
+        }
 	         
 	}
 	
@@ -61,7 +55,7 @@ public class SampleColumnTest {
 		String[] sHeader = header0.clone(); 
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_bamID\tTEST_bamID";
 		 			
-    	Vcf2mafTest.createVcf(  sHeader );                
+		File input = new Vcf2mafTest().createVcf(  sHeader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));
@@ -86,7 +80,7 @@ public class SampleColumnTest {
 		Sheader[2] = VcfHeaderUtils.STANDARD_CONTROL_SAMPLE + "=Sample:CONTROL_sample";
 		Sheader[Sheader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tSample:CONTROL_sample\tTEST_bamID";
 		 			
-    	Vcf2mafTest.createVcf(  Sheader );                
+		File input = new Vcf2mafTest().createVcf(  Sheader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));
@@ -107,7 +101,7 @@ public class SampleColumnTest {
 		sHeader[7] = VcfHeaderUtils.STANDARD_TEST_BAMID + "=";
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_bam\tTEST_bam";
 		 			
-    	Vcf2mafTest.createVcf(  sHeader );                
+		File input = new Vcf2mafTest().createVcf(  sHeader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));
@@ -126,7 +120,7 @@ public class SampleColumnTest {
 		sHeader[7] = VcfHeaderUtils.STANDARD_TEST_BAMID + "=";
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tbamid_1\tTEST_bam";
 		 			
-    	Vcf2mafTest.createVcf(  sHeader );                
+		File input = new Vcf2mafTest().createVcf(  sHeader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));

--- a/qannotate/test/au/edu/qimr/qannotate/utils/SampleColumnTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/utils/SampleColumnTest.java
@@ -5,13 +5,18 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 import au.edu.qimr.qannotate.modes.Vcf2mafTest;
 
 public class SampleColumnTest {
-	
+
+    @Rule
+    public  TemporaryFolder testFolder = new TemporaryFolder();
+
 	private final String[] header0 = {
     		VcfHeaderUtils.STANDARD_FILE_FORMAT + "=VCFv4.0",			
 			VcfHeaderUtils.STANDARD_DONOR_ID + "=MELA_0264",
@@ -31,7 +36,7 @@ public class SampleColumnTest {
 		String[] sHeader = header0.clone(); 
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tqControlSample\tqTestSample";	
 		
-    	File input = new Vcf2mafTest().createVcf(sHeader);                
+    	File input = new Vcf2mafTest().createVcf(testFolder.newFile(), sHeader);                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));
@@ -55,7 +60,7 @@ public class SampleColumnTest {
 		String[] sHeader = header0.clone(); 
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_bamID\tTEST_bamID";
 		 			
-		File input = new Vcf2mafTest().createVcf(  sHeader );                
+		File input = new Vcf2mafTest().createVcf( testFolder.newFile(), sHeader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));
@@ -80,7 +85,7 @@ public class SampleColumnTest {
 		Sheader[2] = VcfHeaderUtils.STANDARD_CONTROL_SAMPLE + "=Sample:CONTROL_sample";
 		Sheader[Sheader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tSample:CONTROL_sample\tTEST_bamID";
 		 			
-		File input = new Vcf2mafTest().createVcf(  Sheader );                
+		File input = new Vcf2mafTest().createVcf( testFolder.newFile(), Sheader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));
@@ -101,7 +106,7 @@ public class SampleColumnTest {
 		sHeader[7] = VcfHeaderUtils.STANDARD_TEST_BAMID + "=";
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_bam\tTEST_bam";
 		 			
-		File input = new Vcf2mafTest().createVcf(  sHeader );                
+		File input = new Vcf2mafTest().createVcf( testFolder.newFile(), sHeader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));
@@ -120,7 +125,7 @@ public class SampleColumnTest {
 		sHeader[7] = VcfHeaderUtils.STANDARD_TEST_BAMID + "=";
 		sHeader[sHeader.length-1] = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tbamid_1\tTEST_bam";
 		 			
-		File input = new Vcf2mafTest().createVcf(  sHeader );                
+		File input = new Vcf2mafTest().createVcf(testFolder.newFile(),  sHeader );                
     	try(VCFFileReader reader = new VCFFileReader(input); ){
 			SampleColumn column = SampleColumn.getSampleColumn(null, null , reader.getHeader());
 			assertTrue(column.getControlSample().equals("CONTROL_sample"));

--- a/qbamannotate/build.gradle
+++ b/qbamannotate/build.gradle
@@ -16,6 +16,6 @@ dependencies {
 	compile 'com.github.samtools:htsjdk:2.14.1'
 
     testCompile project(':qtesting')
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qbamfilter/build.gradle
+++ b/qbamfilter/build.gradle
@@ -14,6 +14,6 @@ dependencies {
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
 	compile 'org.antlr:antlr:3.2'
 	compile 'com.github.samtools:htsjdk:2.14.1'
-    testCompile 'junit:junit:4.10'
+ //   
 }
 

--- a/qbamfix/build.gradle
+++ b/qbamfix/build.gradle
@@ -13,6 +13,6 @@ dependencies {
 
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'commons-cli:commons-cli:1.2'
-    testCompile 'junit:junit:4.10'
+    
 }
 

--- a/qbammerge/build.gradle
+++ b/qbammerge/build.gradle
@@ -16,6 +16,6 @@ dependencies {
 	
     testCompile project(':qtesting')
     testCompile project(':qsplit')
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qbasepileup/build.gradle
+++ b/qbasepileup/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 	testCompile 'org.easymock:easymock:3.1'
 }
 

--- a/qcnv/build.gradle
+++ b/qcnv/build.gradle
@@ -15,6 +15,5 @@ dependencies {
     compile 'commons-cli:commons-cli:1.2'	
 	compile group: 'com.github.samtools', name: 'htsjdk', version: '2.14.1'
 	compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
-	testCompile group: 'junit', name: 'junit', version: '4.10'
 }
 

--- a/qcommon/build.gradle
+++ b/qcommon/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 	compile 'org.apache.commons:commons-lang3:3.4'  
 	compile 'net.sf.trove4j:trove4j:3.0.3'
 	//compile name: 'trove', version: '3.1a1'
-    testCompile 'junit:junit:4.10'
+  //  
 		
     compile 'com.amazonaws:aws-java-sdk-s3:1.11.241'
     compile 'uk.co.lucasweb:aws-v4-signer-java:1.3'	

--- a/qcommon/src/org/qcmg/common/log/QLoggerFactory.java
+++ b/qcommon/src/org/qcmg/common/log/QLoggerFactory.java
@@ -66,7 +66,7 @@ public class QLoggerFactory {
 	 * @see QLoggerFactory#getLogger(Class, String, String)
 	 */
 	public synchronized static QLogger getLogger(Class<?> clazz) {
-		return getLogger(clazz, null, null);
+		return getLogger( clazz, null, null );
 	}
 	
 	private static void setupParentLogger(String logFile, String logLevel) {

--- a/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
+++ b/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
@@ -274,7 +274,7 @@ public class ChrPositionUtils {
 		}
 		
         if (refName.startsWith(Constants.CHR)) {
-        	return ref;
+        	return Constants.CHR + refName.substring(3).toUpperCase();
         }
 				
 		/*
@@ -294,28 +294,14 @@ public class ChrPositionUtils {
 		return ref;
 	}
 	
-//	public static boolean compareAmbiguousChrName(String chrA, String chrB) {
-//		
-//		if(chrA == null || chrB == null) { 
-//			return false;
-//		}	
-//		
-//		if(chrA.trim().equals(chrB.trim()) || ChrNameConveter(chrA).equals(ChrNameConveter(chrB))){
-//			return true;
-//		}
-//				
-//	 
-//		return false;
-//	}
-	
 	/**
 	 * to convert chromosome name if accept ambiguous match, otherwise return original input. 
-	 * In ambiguous match, it will add "chr" to "X", "Y" and digit between 1 and 23, convert "chrM", "MT","M", "chrMT" ignore case to "chrMT"
+	 * In ambiguous match, it will add "chr" to "X", "Y" and digit [1,23], convert "chrM", "MT","M", "chrMT" ignore case to "chrMT"
 	 * @param cp input value of ChrPosition
-	 * @param isStrict2chrName whether to match the chromosome name strictly
+	 * @param isStrict2chrName return original value, otherwise change chromosome name
 	 * @return the input ChrPosition if it require to match the chromosome name strictly. otherwise return a modified ChrPosition value.
 	 */
-	public static ChrPosition getNewchrNameIfStrict(ChrPosition cp, boolean isStrict2chrName) {
+	public static ChrPosition getNewchrName(ChrPosition cp, boolean isStrict2chrName) {
 		
 		//chr name convertion in ambiguous mode		
 		if( !isStrict2chrName ) {

--- a/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
+++ b/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
@@ -116,15 +116,15 @@ public class ChrPositionUtils {
 	}
 	
 
-	public static ChrPosition cloneWithNewChromosomeName(ChrPosition cp, String newChr) {
-		if (cp instanceof ChrPointPosition) {
-			return ChrPointPosition.valueOf(newChr, cp.getStartPosition());
-		} else if  (cp instanceof ChrRangePosition) {
-			return new ChrRangePosition(newChr, cp.getStartPosition(), cp.getEndPosition());
-		} else {
-			throw new UnsupportedOperationException("cloneWithNewName not yet implemented for any types other than ChrPointPosition and ChrRangePosition!!!");
-		}
-	}
+//	public static ChrPosition cloneWithNewChromosomeName(ChrPosition cp, String newChr) {
+//		if (cp instanceof ChrPointPosition) {
+//			return ChrPointPosition.valueOf(newChr, cp.getStartPosition());
+//		} else if  (cp instanceof ChrRangePosition) {
+//			return new ChrRangePosition(newChr, cp.getStartPosition(), cp.getEndPosition());
+//		} else {
+//			throw new UnsupportedOperationException("cloneWithNewName not yet implemented for any types other than ChrPointPosition and ChrRangePosition!!!");
+//		}
+//	}
 	
 	/**
 	 * ASsumes that String is in the IGV notation.
@@ -254,4 +254,84 @@ public class ChrPositionUtils {
 		return false;
 	}
 	
+	/**
+	 * 
+	 * @param ref: chromosome name
+	 * @return converted name, eg. M, MT, chrmt to chrMT; X,Y to chrX,chrY; 1 to chr1
+	 */
+	public static String ChrNameConveter(String ref) {
+		if (ref == null ) return null; //stop exception
+		
+		
+		String refName = ref.toLowerCase();
+		
+		if( refName.equals("m") || refName.equals("mt")|| refName.equals("chrm")|| refName.equals("chrmt")) {
+			return Constants.CHR + "MT";
+		}
+		
+		if (refName.equals("x") || refName.equals("y") ) {
+			return Constants.CHR + ref.toUpperCase();
+		}
+		
+        if (refName.startsWith(Constants.CHR)) {
+        	return ref;
+        }
+				
+		/*
+		 * If ref is an integer less than 23, slap "chr" in front of it
+		 */
+		if (Character.isDigit(ref.charAt(0))) {
+			try {
+				int refInt = Integer.parseInt(ref);
+				if (refInt < 23 && refInt > 0) {
+					return Constants.CHR + ref;
+				}
+			} catch (NumberFormatException nfe) {
+				// don't do anything here - will return the original reference
+			}
+		}
+		
+		return ref;
+	}
+	
+//	public static boolean compareAmbiguousChrName(String chrA, String chrB) {
+//		
+//		if(chrA == null || chrB == null) { 
+//			return false;
+//		}	
+//		
+//		if(chrA.trim().equals(chrB.trim()) || ChrNameConveter(chrA).equals(ChrNameConveter(chrB))){
+//			return true;
+//		}
+//				
+//	 
+//		return false;
+//	}
+	
+	/**
+	 * to convert chromosome name if accept ambiguous match, otherwise return original input. 
+	 * In ambiguous match, it will add "chr" to "X", "Y" and digit between 1 and 23, convert "chrM", "MT","M", "chrMT" ignore case to "chrMT"
+	 * @param cp input value of ChrPosition
+	 * @param isStrict2chrName whether to match the chromosome name strictly
+	 * @return the input ChrPosition if it require to match the chromosome name strictly. otherwise return a modified ChrPosition value.
+	 */
+	public static ChrPosition getNewchrNameIfStrict(ChrPosition cp, boolean isStrict2chrName) {
+		
+		//chr name convertion in ambiguous mode		
+		if( !isStrict2chrName ) {
+			String newChr = ChrPositionUtils.ChrNameConveter(  cp.getChromosome() );
+			if ( ! newChr.equals(cp.getChromosome())) {				
+				if (cp instanceof ChrPointPosition) {
+					return ChrPointPosition.valueOf(newChr, cp.getStartPosition());
+				} else if  (cp instanceof ChrRangePosition) {
+					return new ChrRangePosition(newChr, cp.getStartPosition(), cp.getEndPosition());
+				} else {
+					throw new UnsupportedOperationException("cloneWithNewName not yet implemented for any types other than ChrPointPosition and ChrRangePosition!!!");
+				}				
+				 
+			}		 
+		}
+		
+		return cp;
+	}	
 }

--- a/qcommon/src/org/qcmg/common/util/IndelUtils.java
+++ b/qcommon/src/org/qcmg/common/util/IndelUtils.java
@@ -190,33 +190,33 @@ public class IndelUtils {
 	 * @param ref
 	 * @return
 	 */
-	public static String getFullChromosome(String ref) {
-		if (ref == null ) return null; //stop exception
-		
-        if (ref.startsWith(Constants.CHR)) {
-        	return ref;
-        }
-		
-		if (ref.equals("X") || ref.equals("Y") || ref.equals("M") || ref.equals("MT")) {
-			return "chr" + ref;
-		}
-		
-		/*
-		 * If ref is an integer less than 23, slap "chr" in front of it
-		 */
-		if (Character.isDigit(ref.charAt(0))) {
-			try {
-				int refInt = Integer.parseInt(ref);
-				if (refInt < 23 && refInt > 0) {
-					return Constants.CHR + ref;
-				}
-			} catch (NumberFormatException nfe) {
-				// don't do anything here - will return the original reference
-			}
-		}
-		
-		return ref;
-	}
+//	public static String getFullChromosome(String ref) {
+//		if (ref == null ) return null; //stop exception
+//		
+//        if (ref.startsWith(Constants.CHR)) {
+//        	return ref;
+//        }
+//		
+//		if (ref.equals("X") || ref.equals("Y") || ref.equals("M") || ref.equals("MT")) {
+//			return "chr" + ref;
+//		}
+//		
+//		/*
+//		 * If ref is an integer less than 23, slap "chr" in front of it
+//		 */
+//		if (Character.isDigit(ref.charAt(0))) {
+//			try {
+//				int refInt = Integer.parseInt(ref);
+//				if (refInt < 23 && refInt > 0) {
+//					return Constants.CHR + ref;
+//				}
+//			} catch (NumberFormatException nfe) {
+//				// don't do anything here - will return the original reference
+//			}
+//		}
+//		
+//		return ref;
+//	}
 
 	/**
 	 * 

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -1490,21 +1490,7 @@ public class VcfUtils {
 		return conf;
 	}
 
-
-
-	/**
-	 * will return true if:
-	 * altCount is >= maxCoverage
-	 * OR
-	 * altCount is 5% (or more) of the totalReadCount
-	 * 
-	 * @param altCount
-	 * @param totalReadCount
-	 * @param percentage
-	 * @param minCoverage
-	 * @return
-	 */
-	public static boolean mutationInNorma(int altCount, int totalReadCount, float percentage, int maxCoverage) {
+	public static boolean mutationInNormal(int altCount, int totalReadCount, float percentage, int maxCoverage) {
 		if (altCount == 0) {
 			return false;
 		}
@@ -1520,7 +1506,6 @@ public class VcfUtils {
 		float passingCount = totalReadCount > 0 ? (((float)totalReadCount / 100) * percentage) : 0;
 		return altCount >= passingCount;
 	}
-	public static boolean mutationInNorma(int altCount, int totalReadCount, int percentage, int maxCoverage) {
-		return mutationInNorma(altCount, totalReadCount, (float) percentage, maxCoverage);
-	}
+
+	 
 }

--- a/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
@@ -226,7 +226,7 @@ public class ChrPositionUtilsTest {
 		
 		assertEquals("chr10", ChrPositionUtils.ChrNameConveter("10"));
 		assertEquals("chr10", ChrPositionUtils.ChrNameConveter("chr10"));
-		assertEquals("chrM", ChrPositionUtils.ChrNameConveter("M"));
+		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("M"));
 		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("MT"));
 		assertEquals("GL12345", ChrPositionUtils.ChrNameConveter("GL12345"));
 	}
@@ -242,10 +242,10 @@ public class ChrPositionUtilsTest {
 		assertEquals("chr1", ChrPositionUtils.ChrNameConveter("1"));
 		assertEquals("chrY", ChrPositionUtils.ChrNameConveter("Y"));
 		assertEquals("chrX", ChrPositionUtils.ChrNameConveter("X"));
-		assertEquals("chrM", ChrPositionUtils.ChrNameConveter("M"));
+		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("M"));
 		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("MT"));
 		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("chrMT"));
-		assertEquals("chrM", ChrPositionUtils.ChrNameConveter("chrM"));
+		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("chrM"));
 		assertEquals("MTT", ChrPositionUtils.ChrNameConveter("MTT"));
 		assertEquals("GL123", ChrPositionUtils.ChrNameConveter("GL123"));
 		assertEquals("chr10", ChrPositionUtils.ChrNameConveter("chr10"));

--- a/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
@@ -34,14 +34,25 @@ public class ChrPositionUtilsTest {
 		assertEquals(true, ChrPositionUtils.arePositionsWithinDelta(cp1, cp2, 4));
 	}
 	
+//	@Test
+//	public void cloneWithNewName() {
+//		ChrRangePosition cp = new ChrRangePosition("1", 100, 200);
+//		assertEquals("chr1", ChrPositionUtils.cloneWithNewChromosomeName(cp, "chr1").getChromosome());
+//		assertEquals("chrXY", ChrPositionUtils.cloneWithNewChromosomeName(cp, "chrXY").getChromosome());
+//		assertEquals("myCP", ChrPositionUtils.cloneWithNewChromosomeName(cp, "myCP").getChromosome());
+//		assertEquals("1", ChrPositionUtils.cloneWithNewChromosomeName(cp, "1").getChromosome());
+//		
+//	}
+	
 	@Test
-	public void cloneWithNewName() {
-		ChrRangePosition cp = new ChrRangePosition("1", 100, 200);
-		assertEquals("chr1", ChrPositionUtils.cloneWithNewChromosomeName(cp, "chr1").getChromosome());
-		assertEquals("chrXY", ChrPositionUtils.cloneWithNewChromosomeName(cp, "chrXY").getChromosome());
-		assertEquals("myCP", ChrPositionUtils.cloneWithNewChromosomeName(cp, "myCP").getChromosome());
-		assertEquals("1", ChrPositionUtils.cloneWithNewChromosomeName(cp, "1").getChromosome());
-		
+	public void getNewchrName() {
+
+		assertEquals("1", ChrPositionUtils.getNewchrName(new ChrRangePosition("1", 100, 200), true ).getChromosome());
+		assertEquals("chr1", ChrPositionUtils.getNewchrName(new ChrRangePosition("1", 100, 200), false ).getChromosome());
+		assertEquals("CHRXY", ChrPositionUtils.getNewchrName( new ChrRangePosition("CHRXY", 100, 200), true ).getChromosome());
+		assertEquals("chrXY", ChrPositionUtils.getNewchrName( new ChrRangePosition("CHRXY", 100, 200), false ).getChromosome());		
+		assertEquals("CHRM", ChrPositionUtils.getNewchrName( new ChrRangePosition("CHRM", 100, 200), true ).getChromosome());
+		assertEquals("chrMT", ChrPositionUtils.getNewchrName( new ChrRangePosition("CHRM", 100, 200), false ).getChromosome());		
 	}
 	
 	@Test
@@ -207,6 +218,37 @@ public class ChrPositionUtilsTest {
 		assertEquals(true, ChrPositionUtils.areAdjacent(preceedingCP2, preceedingCP));
 		assertEquals(false, ChrPositionUtils.areAdjacent(preceedingCP2, cp));
 		assertEquals(false, ChrPositionUtils.areAdjacent(cp, preceedingCP2));
+	}
+	
+	
+	@Test
+	public void testGetFullChromosome() {
+		
+		assertEquals("chr10", ChrPositionUtils.ChrNameConveter("10"));
+		assertEquals("chr10", ChrPositionUtils.ChrNameConveter("chr10"));
+		assertEquals("chrM", ChrPositionUtils.ChrNameConveter("M"));
+		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("MT"));
+		assertEquals("GL12345", ChrPositionUtils.ChrNameConveter("GL12345"));
+	}
+	
+	@Test
+	public void testAddChromosomeReference() {
+		
+		assertEquals("chr10", ChrPositionUtils.ChrNameConveter("10"));
+		assertEquals("23", ChrPositionUtils.ChrNameConveter("23"));
+		assertEquals("chr22", ChrPositionUtils.ChrNameConveter("22"));
+		assertEquals("99", ChrPositionUtils.ChrNameConveter("99"));
+		assertEquals("100", ChrPositionUtils.ChrNameConveter("100"));
+		assertEquals("chr1", ChrPositionUtils.ChrNameConveter("1"));
+		assertEquals("chrY", ChrPositionUtils.ChrNameConveter("Y"));
+		assertEquals("chrX", ChrPositionUtils.ChrNameConveter("X"));
+		assertEquals("chrM", ChrPositionUtils.ChrNameConveter("M"));
+		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("MT"));
+		assertEquals("chrMT", ChrPositionUtils.ChrNameConveter("chrMT"));
+		assertEquals("chrM", ChrPositionUtils.ChrNameConveter("chrM"));
+		assertEquals("MTT", ChrPositionUtils.ChrNameConveter("MTT"));
+		assertEquals("GL123", ChrPositionUtils.ChrNameConveter("GL123"));
+		assertEquals("chr10", ChrPositionUtils.ChrNameConveter("chr10"));
 	}
 	
 }

--- a/qcommon/test/org/qcmg/common/util/IndelUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/IndelUtilsTest.java
@@ -192,35 +192,4 @@ public class IndelUtilsTest {
 		assertEquals("BC", IndelUtils.getRefForIndels("ABC", SVTYPE.DEL));
 		assertEquals("5299XYZ", IndelUtils.getRefForIndels("15299XYZ", SVTYPE.DEL));
 	}
-	
-	@Test
-	public void testGetFullChromosome() {
-		
-		assertEquals("chr10", IndelUtils.getFullChromosome("10"));
-		assertEquals("chr10", IndelUtils.getFullChromosome("chr10"));
-		assertEquals("chrM", IndelUtils.getFullChromosome("M"));
-		assertEquals("chrMT", IndelUtils.getFullChromosome("MT"));
-		assertEquals("GL12345", IndelUtils.getFullChromosome("GL12345"));
-	}
-	
-	@Test
-	public void testAddChromosomeReference() {
-		
-		assertEquals("chr10", IndelUtils.getFullChromosome("10"));
-		assertEquals("23", IndelUtils.getFullChromosome("23"));
-		assertEquals("chr22", IndelUtils.getFullChromosome("22"));
-		assertEquals("99", IndelUtils.getFullChromosome("99"));
-		assertEquals("100", IndelUtils.getFullChromosome("100"));
-		assertEquals("chr1", IndelUtils.getFullChromosome("1"));
-		assertEquals("chrY", IndelUtils.getFullChromosome("Y"));
-		assertEquals("chrX", IndelUtils.getFullChromosome("X"));
-		assertEquals("chrM", IndelUtils.getFullChromosome("M"));
-		assertEquals("chrMT", IndelUtils.getFullChromosome("MT"));
-		assertEquals("chrMT", IndelUtils.getFullChromosome("chrMT"));
-		assertEquals("chrM", IndelUtils.getFullChromosome("chrM"));
-		assertEquals("MTT", IndelUtils.getFullChromosome("MTT"));
-		assertEquals("GL123", IndelUtils.getFullChromosome("GL123"));
-		assertEquals("chr10", IndelUtils.getFullChromosome("chr10"));
-	}
-
 }

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -1251,13 +1251,13 @@ public class VcfUtilsTest {
 	@Test
 	public void minWithAM() {
 		//static boolean mutationInNorma(int altCount, int totalReadCount, int percentage, int minCoverage) {
-		assertEquals(true, VcfUtils.mutationInNorma(1, 10, 5, 0));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 20, 5, 0));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 30, 5, 0));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 30, 5, 1));
-		assertEquals(false, VcfUtils.mutationInNorma(1, 30, 5, 2));
-		assertEquals(false, VcfUtils.mutationInNorma(1, 30, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 300, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 10, 5, 0));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 20, 5, 0));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 30, 5, 0));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 30, 5, 1));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 30, 5, 2));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 30, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 300, 5, 3));
 	}
 	
 	@Test
@@ -1295,31 +1295,31 @@ public class VcfUtilsTest {
 	
 	@Test
 	public void min() {
-		assertEquals(false, VcfUtils.mutationInNorma(0, 0, 0, 0));
-		assertEquals(false, VcfUtils.mutationInNorma(0, 10, 1, 2));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 10, 1, 2));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 1, 2));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 1, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 25, 2));
-		assertEquals(false, VcfUtils.mutationInNorma(2, 10, 25, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(0, 0, 0, 0));
+		assertEquals(false, VcfUtils.mutationInNormal(0, 10, 1, 2));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 10, 1, 2));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 1, 2));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 1, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 25, 2));
+		assertEquals(false, VcfUtils.mutationInNormal(2, 10, 25, 3));
 		
 		
-		assertEquals(false, VcfUtils.mutationInNorma(1, 24, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 63, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 79, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 99, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 24, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 63, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 79, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 99, 5, 3));
 		
-		assertEquals(false, VcfUtils.mutationInNorma(1, 30, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(1, 10, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(2, 10, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 10, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 10, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 30, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(1, 10, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 10, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 10, 5, 3));
 		
-		assertEquals(false, VcfUtils.mutationInNorma(1, 100, 5, 3));
-		assertEquals(false, VcfUtils.mutationInNorma(2, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(3, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(4, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(5, 100, 5, 3));
-		assertEquals(true, VcfUtils.mutationInNorma(6, 100, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(1, 100, 5, 3));
+		assertEquals(false, VcfUtils.mutationInNormal(2, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(3, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(4, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(5, 100, 5, 3));
+		assertEquals(true, VcfUtils.mutationInNormal(6, 100, 5, 3));
 	}
 }

--- a/qcoverage/build.gradle
+++ b/qcoverage/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	
-	testCompile 'junit:junit:4.10'
+	
     testCompile project(':qtesting')
 }
 

--- a/qio/build.gradle
+++ b/qio/build.gradle
@@ -5,5 +5,5 @@ def isExecutable = true
 dependencies {
     configurations.compile.transitive = true
     compile project(':qcommon')
-    testCompile 'junit:junit:4.10'
+ //   
 } 

--- a/qmaftools/build.gradle
+++ b/qmaftools/build.gradle
@@ -16,6 +16,6 @@ dependencies {
 	
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qmito/build.gradle
+++ b/qmito/build.gradle
@@ -13,5 +13,5 @@ dependencies {
 
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }

--- a/qmotif/build.gradle
+++ b/qmotif/build.gradle
@@ -18,6 +18,6 @@ dependencies {
     compile group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
 	compile 'com.github.samtools:htsjdk:2.14.1'	
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qmule/build.gradle
+++ b/qmule/build.gradle
@@ -14,6 +14,6 @@ dependencies {
 	compile 'com.google.code.findbugs:findbugs:1.3.9'	
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qpicard/build.gradle
+++ b/qpicard/build.gradle
@@ -10,6 +10,6 @@ dependencies {
 	
 	compile 'com.github.broadinstitute:picard:1.130'
 	compile 'com.github.samtools:htsjdk:2.14.1'
-    testCompile 'junit:junit:4.10'
+ //   
 	 
 }

--- a/qpicard/src/org/qcmg/picard/Faidx.java
+++ b/qpicard/src/org/qcmg/picard/Faidx.java
@@ -1,0 +1,70 @@
+package org.qcmg.picard;
+
+import java.io.*;
+import java.util.*;
+
+
+public class Faidx {
+    public static class SamSequenceRecord{
+        String name=null;
+        int length=0;
+        long begin;
+        int linelen=-1;
+    }
+    public final List<SamSequenceRecord> dict = new ArrayList<>();
+    public Faidx(final File fn) throws IOException {
+        long offset=0;
+        FileReader rz = new FileReader(fn);
+        int c;
+        SamSequenceRecord ssr = null;
+        while((c=rz.read())!=-1) {
+            if (c == '>') {
+                offset++;
+                StringBuilder sb=new StringBuilder();
+                ssr = new SamSequenceRecord();
+                boolean ws=false;
+                while((c=rz.read())!=-1 )
+                    {
+                    offset++;
+                    if( c=='\n') break;
+                    if(!ws && Character.isWhitespace(c)) ws=true;
+                    if(!ws) sb.append((char)c);
+                    }
+                ssr.name=sb.toString();
+                ssr.begin=offset;
+                dict.add(ssr);
+            } else{
+                int n=0;
+                do  {
+                    offset++;
+                    if( c == '\n') break;
+                    n++;
+                    c = rz.read();
+                   } while(c!=-1);
+                ssr.length+=n;
+                if(ssr.linelen==-1){
+                    ssr.linelen = n;
+                    }
+                }
+            }
+        }
+    public void outputIdx(String fo) throws IOException {
+    	 try(BufferedWriter out = new BufferedWriter(new FileWriter(fo));) {   
+    		 for(SamSequenceRecord ssr: dict){
+    			 	out.write(ssr.name+"\t"+ssr.length+"\t"+ssr.begin+"\t"+ssr.linelen+"\t"+(ssr.linelen+1)+"\n");
+    	        }
+          }    	
+    }
+    public void outputDict(String fo) throws IOException {
+   	 try(BufferedWriter out = new BufferedWriter(new FileWriter(fo));) {   
+   		 for(SamSequenceRecord ssr: dict){
+   			 	out.write("@SQ\tSN:" + ssr.name+"\tLN:"+ssr.length+"\n");
+   	        }
+         }    	
+   }
+    public void print(PrintStream out){    	
+        for(SamSequenceRecord ssr: dict){
+            out.println(ssr.name+"\t"+ssr.length+"\t"+ssr.begin+"\t"+ssr.linelen+"\t"+(ssr.linelen+1));
+        }
+    }
+}

--- a/qpileup/build.gradle
+++ b/qpileup/build.gradle
@@ -34,6 +34,6 @@ dependencies {
     compile name: 'jhdf5obj'  
 
 	testCompile 'org.easymock:easymock:3.1'
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qprofiler/build.gradle
+++ b/qprofiler/build.gradle
@@ -16,5 +16,5 @@ dependencies {
 	compile 'org.apache.commons:commons-math3:3.3'
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }

--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }
 
 //create a fat jar file only for dispatching our qprofiler to outside

--- a/qsignature/build.gradle
+++ b/qsignature/build.gradle
@@ -14,6 +14,6 @@ dependencies {
     
 	compile 'com.github.samtools:htsjdk:2.14.1'
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
@@ -200,22 +200,22 @@ public class SignatureUtil {
 	}
 	
 	
-	public static List<VcfRecord> addChrToVcfRecords(List<VcfRecord> vcfs) {
-		
-		List<VcfRecord> updatedVcfs = new ArrayList<>();
-		for (VcfRecord v : vcfs) {
-			if (Character.isDigit(v.getChrPosition().getChromosome().charAt(0))) {
-				ChrPosition oldCP = v.getChrPosition();
-				v = VcfUtils.cloneWithNewChrPos(v, ChrPositionUtils.cloneWithNewChromosomeName(oldCP, "chr" + oldCP.getChromosome()));
-			}
-			updatedVcfs.add(v);
-		}
-		return updatedVcfs;
-		
-//		return vcfs.stream()
-//				.map(f -> (Character.isDigit(f.getChrPosition().getChromosome().charAt(0)) ? "chr" + f : f))
-//				.collect(Collectors.toList());
-	}
+//	public static List<VcfRecord> addChrToVcfRecords(List<VcfRecord> vcfs) {
+//		
+//		List<VcfRecord> updatedVcfs = new ArrayList<>();
+//		for (VcfRecord v : vcfs) {
+//			if (Character.isDigit(v.getChrPosition().getChromosome().charAt(0))) {
+//				ChrPosition oldCP = v.getChrPosition();
+//				v = VcfUtils.cloneWithNewChrPos(v, ChrPositionUtils.cloneWithNewChromosomeName(oldCP, "chr" + oldCP.getChromosome()));
+//			}
+//			updatedVcfs.add(v);
+//		}
+//		return updatedVcfs;
+//		
+////		return vcfs.stream()
+////				.map(f -> (Character.isDigit(f.getChrPosition().getChromosome().charAt(0)) ? "chr" + f : f))
+////				.collect(Collectors.toList());
+//	}
 
 	public static Map<File, Map<ChrPosition, double[]>> getDonorSnpChipData(String donor, List<File> files) throws IOException {
 		

--- a/qsnp/build.gradle
+++ b/qsnp/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile 'net.sf.jopt-simple:jopt-simple:4.6'
     compile 'org.lz4:lz4-java:1.5.0'
     compile 'org.scala-lang:scala-library:2.12.3'
-    testCompile 'junit:junit:4.10'
+    
 }
 
  

--- a/qsplit/build.gradle
+++ b/qsplit/build.gradle
@@ -13,8 +13,7 @@ dependencies {
     compile project(':qpicard')
     testCompile project(':qtesting')
 	
-	compile group: 'com.github.samtools', name: 'htsjdk', version: '2.14.1'
-	compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
-	testCompile group: 'junit', name: 'junit', version: '4.10'
+    compile group: 'com.github.samtools', name: 'htsjdk', version: '2.14.1'
+    compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
 }
 

--- a/qsv/build.gradle
+++ b/qsv/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	compile 'com.github.samtools:htsjdk:2.14.1'	
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'	
 		
-	testCompile 'junit:junit:4.10'
+	
 	testCompile 'org.easymock:easymock:3.1'
 }
 

--- a/qtesting/build.gradle
+++ b/qtesting/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     configurations.compile.transitive = true	
     compile project(':qio')
 	compile project(':qcommon')	
-	testCompile 'junit:junit:4.10'
+	
 }
 

--- a/qvisualise/build.gradle
+++ b/qvisualise/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     configurations.compile.transitive = true
     compile project(':qcommon')
 	compile 'net.sf.jopt-simple:jopt-simple:4.6'
-	testCompile 'junit:junit:4.10'
+	
 }
 


### PR DESCRIPTION

add option --strict2ChromosomeName" by default  (without this option) we accept ambiguous chr name, eg. mt == chrMT. With this option, the contig name between database file and input must exactly match, also case sensitive.  Some mode without database file, such as confidenceMode, vcf2mafMode will ignore this option. 