### PR TITLE
adding novaseq and nextseq to the list of platforms that qsv supports

### DIFF
--- a/qsv/src/org/qcmg/qsv/Options.java
+++ b/qsv/src/org/qcmg/qsv/Options.java
@@ -201,6 +201,11 @@ public class Options {
 				platform = "solid";
 			} else if (sequencingPlatform.toLowerCase().contains("hiseq") || sequencingPlatform.toLowerCase().contains("illumina")) {
 				platform = "illumina";
+			} else if (sequencingPlatform.toLowerCase().contains("novaseq") || sequencingPlatform.toLowerCase().contains("nextseq")) {
+				/*
+				 * add novaseq and nextseq to the list of allowed sequencers. Treat them as illumina (for now)
+				 */
+				platform = "illumina";	
 			} else if (sequencingPlatform.toLowerCase().contains("bgiseq") || sequencingPlatform.toLowerCase().contains("mgiseq")) {
 				platform = "bgi";
 			} else {

--- a/qsv/test/org/qcmg/qsv/OptionsTest.java
+++ b/qsv/test/org/qcmg/qsv/OptionsTest.java
@@ -80,6 +80,44 @@ public class OptionsTest {
     	assertEquals("bgi", options.getPlatform());
     	assertEquals("BGISeq500", options.getSequencingPlatform());
     }
+    @Test
+    public void novaSeq() throws Exception {
+    	String[] args = TestUtil.getValidOptions(testFolder, file1, file2, "both", "both", true, "bwamem", "NovaSeq");
+    	Options options = new Options(args);
+    	assertFalse(options.hasHelpOption());
+    	assertFalse(options.hasVersionOption());
+    	assertEquals(options.getIniFile(), testFolder.getRoot().getAbsolutePath() + "/test.ini");
+    	assertEquals(options.getTempDirName(), testFolder.getRoot().getAbsolutePath());
+    	options.parseIniFile();
+    	options.detectBadOptions();
+    	assertEquals("illumina", options.getPlatform());
+    	assertEquals("NovaSeq", options.getSequencingPlatform());
+    }
+    
+    @Test
+    public void nextSeq() throws Exception {
+    	String[] args = TestUtil.getValidOptions(testFolder, file1, file2, "both", "both", true, "bwamem", "NextSeq");
+    	Options options = new Options(args);
+    	assertFalse(options.hasHelpOption());
+    	assertFalse(options.hasVersionOption());
+    	assertEquals(options.getIniFile(), testFolder.getRoot().getAbsolutePath() + "/test.ini");
+    	assertEquals(options.getTempDirName(), testFolder.getRoot().getAbsolutePath());
+    	options.parseIniFile();
+    	options.detectBadOptions();
+    	assertEquals("illumina", options.getPlatform());
+    	assertEquals("NextSeq", options.getSequencingPlatform());
+    }
+    
+    @Test(expected = QSVException.class)
+    public void dummySeq() throws Exception {
+    	String[] args = TestUtil.getValidOptions(testFolder, file1, file2, "both", "both", true, "bwamem", "anySeqButHere");
+    	Options options = new Options(args);
+    	assertFalse(options.hasHelpOption());
+    	assertFalse(options.hasVersionOption());
+    	assertEquals(options.getIniFile(), testFolder.getRoot().getAbsolutePath() + "/test.ini");
+    	assertEquals(options.getTempDirName(), testFolder.getRoot().getAbsolutePath());
+    	options.parseIniFile();
+    }
     
     @Test
     public void testGoodIniFileOptions() throws Exception {


### PR DESCRIPTION
As requested by Ross, this is an urgent change to allow some runs on the `NovaSeq` platform to be processed by `qsv`.
Also adding `NextSeq` as it will only be a matter of time before this is requested.

Lumping them into the same category as the other `illumina` sequences for now.

added tests