### PR TITLE
Fix to ChrPositionComparator - ready for GRCh38

### DIFF
--- a/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
@@ -14,7 +14,9 @@ import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeader;
@@ -28,6 +30,9 @@ import au.edu.qimr.qannotate.utils.SampleColumn;
 public class AbstractModeTest {
 	public static String outputName = "output.vcf";
 	public static String inputName = "input.vcf";
+	
+	@Rule
+	public  TemporaryFolder testFolder = new TemporaryFolder();
 	
 	@BeforeClass
 	public static void createInput() throws IOException{	
@@ -145,20 +150,111 @@ public class AbstractModeTest {
 //			fail( "My method didn't throw when I expected it to" );
 		}catch(Exception e){
 		}
-
-
+	}
+	
+	
+	@Test
+	public void ordering() throws IOException {
+		List<String> data = new ArrayList<>();
+		data.add("##fileformat=VCFv4.0");
+	    data.add(VcfHeaderUtils.STANDARD_UUID_LINE + "=abcd_12345678_xzy_999666333");
+	    data.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO");
+	    
+	    data.add("chrY\t14923588\t.\tG\tA\t.\tSBIAS\t;FS=GTGATATTCCC\tGT:GD:AC:MR:NNS\t0/1:G/A:A0[0],15[36.2],G11[36.82],9[33]\t0/1:G/A:A0[0],33[35.73],G6[30.5],2[34]:15:13"); 
+        data.add("chr1\t2675826\t.\tTG\tCA\t.\tCOVN12;MIUN\tSOMATIC;END=2675826\tACCS\tTG,5,37,CA,0,2\tAA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1");
+        data.add("chrY\t2675825\t.\tTTG\tTGG\t.\tCOVN12;MIUN\tSOMATIC;END=2675826\tACCS\tTG,5,37,CA,0,2\tAA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1");
+        data.add("chr3\t22012840\t.\tC\tA\t.\tMIUN\tSOMATIC\tGT:GD:AC:MR:NNS\t0/1:C/A:A0[0],15[36.2],C11[36.82],9[33]\t0/1:C/A:A0[0],33[35.73],C6[30.5],2[34]:15:13");  
+        data.add("chrY\t77242678\t.\tCA\tTG\t.\tPASS\tEND=77242679\tACCS\tCA,10,14,TG,6,7\tCA,14,9,TG,23,21");
+        
+        /*
+         * create vcf file
+         */
+        File vcfFile = testFolder.newFile();
+        File outputVcfFile = testFolder.newFile();
+        createVcf(vcfFile, data);
+        
+        ConfidenceMode mode = new ConfidenceMode();
+		mode.loadVcfRecordsFromFile(vcfFile);
+		mode.writeVCF(outputVcfFile);
+		
+		/*
+		 * now check the ordering
+		 */
+		try (VCFFileReader reader = new VCFFileReader(outputVcfFile)) {
+			int i = 0;
+			for (VcfRecord v : reader) {
+				i++;
+				if (i == 1) {
+					assertEquals("chr1", v.getChromosome());
+				} else if (i == 2) {
+					assertEquals("chr3", v.getChromosome());
+				} else if (i >= 3) {
+					assertEquals("chrY", v.getChromosome());
+				}
+			}
+		}		 
+	}
+	
+	@Test
+	public void orderingWith38Contigs() throws IOException {
+		List<String> data = new ArrayList<>();
+		data.add("##fileformat=VCFv4.0");
+		data.add(VcfHeaderUtils.STANDARD_UUID_LINE + "=abcd_12345678_xzy_999666333");
+		data.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO");
+		
+		data.add("chrUn_GL000216v2\t14923588\t.\tG\tA\t.\tSBIAS\t;FS=GTGATATTCCC\tGT:GD:AC:MR:NNS\t0/1:G/A:A0[0],15[36.2],G11[36.82],9[33]\t0/1:G/A:A0[0],33[35.73],G6[30.5],2[34]:15:13"); 
+		data.add("chr17_KI270729v1_random\t2675826\t.\tTG\tCA\t.\tCOVN12;MIUN\tSOMATIC;END=2675826\tACCS\tTG,5,37,CA,0,2\tAA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1");
+		data.add("chrY\t2675825\t.\tTTG\tTGG\t.\tCOVN12;MIUN\tSOMATIC;END=2675826\tACCS\tTG,5,37,CA,0,2\tAA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1");
+		data.add("chr3\t22012840\t.\tC\tA\t.\tMIUN\tSOMATIC\tGT:GD:AC:MR:NNS\t0/1:C/A:A0[0],15[36.2],C11[36.82],9[33]\t0/1:C/A:A0[0],33[35.73],C6[30.5],2[34]:15:13");  
+		data.add("chrY\t77242678\t.\tCA\tTG\t.\tPASS\tEND=77242679\tACCS\tCA,10,14,TG,6,7\tCA,14,9,TG,23,21");
+		data.add("chr1\t77242678\t.\tCA\tTG\t.\tPASS\tEND=77242679\tACCS\tCA,10,14,TG,6,7\tCA,14,9,TG,23,21");
+		
+		/*
+		 * create vcf file
+		 */
+		File vcfFile = testFolder.newFile();
+		File outputVcfFile = testFolder.newFile();
+		createVcf(vcfFile, data);
+		
+		ConfidenceMode mode = new ConfidenceMode();
+		mode.loadVcfRecordsFromFile(vcfFile);
+		mode.writeVCF(outputVcfFile);
+		
+		/*
+		 * now check the ordering
+		 */
+		try (VCFFileReader reader = new VCFFileReader(outputVcfFile)) {
+			int i = 0;
+			for (VcfRecord v : reader) {
+				i++;
+				if (i == 1) {
+					assertEquals("chr1", v.getChromosome());
+				} else if (i == 2) {
+					assertEquals("chr3", v.getChromosome());
+				} else if (i == 3 || i == 4) {
+					assertEquals("chrY", v.getChromosome());
+				} else if (i == 5) {
+					assertEquals("chr17_KI270729v1_random", v.getChromosome());
+				} else if (i == 6) {
+					assertEquals("chrUn_GL000216v2", v.getChromosome());
+				}
+			}
+		}		 
 	}
 	
 	public static void createVcf() throws IOException{
-        final List<String> data = new ArrayList<String>();
+        final List<String> data = new ArrayList<>();
         data.add("##fileformat=VCFv4.0");
         data.add(VcfHeaderUtils.STANDARD_UUID_LINE + "=abcd_12345678_xzy_999666333");
         data.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO");
-        try(BufferedWriter out = new BufferedWriter(new FileWriter(inputName));) {          
-            for (final String line : data)   out.write(line +"\n");                  
-         }  
-
+        createVcf(new File(inputName), data);
 	}
 	
-	
+	public static void createVcf(File vcfFile, List<String> data) throws IOException {
+		try (BufferedWriter out = new BufferedWriter(new FileWriter(vcfFile));) {          
+			for (final String line : data) {
+				out.write(line +"\n");                  
+			}
+		 }
+	}
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
@@ -212,8 +212,8 @@ public class AbstractModeTest {
 		/*
 		 * create vcf file
 		 */
-		File vcfFile = testFolder.newFile("my.input.file.vcf");
-		File outputVcfFile = testFolder.newFile("my.output.file.vcf");
+		File vcfFile = testFolder.newFile();
+		File outputVcfFile = testFolder.newFile();
 		createVcf(vcfFile, data);
 		
 		ConfidenceMode mode = new ConfidenceMode();

--- a/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/AbstractModeTest.java
@@ -212,8 +212,8 @@ public class AbstractModeTest {
 		/*
 		 * create vcf file
 		 */
-		File vcfFile = testFolder.newFile();
-		File outputVcfFile = testFolder.newFile();
+		File vcfFile = testFolder.newFile("my.input.file.vcf");
+		File outputVcfFile = testFolder.newFile("my.output.file.vcf");
 		createVcf(vcfFile, data);
 		
 		ConfidenceMode mode = new ConfidenceMode();

--- a/qcommon/src/org/qcmg/common/model/ChrPositionComparator.java
+++ b/qcommon/src/org/qcmg/common/model/ChrPositionComparator.java
@@ -59,7 +59,21 @@ public class ChrPositionComparator implements Comparator<ChrPosition> {
 			new Comparator<String>() {
 			@Override
 			public int compare(String o1, String o2) {
-				return list.indexOf(o1) - list.indexOf(o2);
+				int i1 = list.indexOf(o1);
+				int i2 = list.indexOf(o2);
+				if (i1 >= 0 && i2 >= 0) {
+					return i1 - i2;
+				} else if (i1 >= 0 && i2 == -1) {
+					// o1.chr in list but not o2.chr => o1 < o2
+					return -1;
+				} else if (i1 == -1 && i2 >= 0) {
+					// o2.chr in list but not o1.chr => o2 < o1
+					return 1;
+				} else {
+					assert i1 == -1 && i2 == -1;
+					// neither o1 nor o2 chr in list => "natural" ordering
+					return o1.compareTo(o2);
+				}
 			}
 		};
 		

--- a/qcommon/test/org/qcmg/common/model/ChrPositionComparatorTest.java
+++ b/qcommon/test/org/qcmg/common/model/ChrPositionComparatorTest.java
@@ -54,4 +54,70 @@ public class ChrPositionComparatorTest {
 		assertEquals(v3, vcfs.get(2));
 		assertEquals(v4, vcfs.get(3));
 	}
+	
+	/**
+	 * Test case when reference list of contigs is a subset of contigs in the records to be sorted
+	 */
+	@Test
+	public void vcfSortingReferenceAgnostic() {
+		VcfRecord v1 = VcfUtils.createVcfRecord("chr1", 300);
+		VcfRecord v2 = VcfUtils.createVcfRecord("chr2", 300);
+		VcfRecord v3 = VcfUtils.createVcfRecord("chr2_KI270729v1_random", 300);
+		VcfRecord v4 = VcfUtils.createVcfRecord("chr3", 300);
+		
+		List<VcfRecord> vcfs = Arrays.asList(v1, v2, v3, v4);
+		
+		vcfs.sort(ChrPositionComparator.getVcfRecordComparatorForGRCh37());
+		assertEquals(v1, vcfs.get(0));
+		assertEquals(v2, vcfs.get(1));
+		assertEquals(v3, vcfs.get(3));
+		assertEquals(v4, vcfs.get(2));
+		
+		VcfRecord v5 = VcfUtils.createVcfRecord("chrUn_GL000216v2", 300);
+		vcfs = Arrays.asList(v5, v1, v2, v3, v4);
+		vcfs.sort(ChrPositionComparator.getVcfRecordComparatorForGRCh37());
+		assertEquals(v1, vcfs.get(0));
+		assertEquals(v2, vcfs.get(1));
+		assertEquals(v3, vcfs.get(3));
+		assertEquals(v4, vcfs.get(2));
+		assertEquals(v5, vcfs.get(4));
+	}
+	/**
+	 * Test case when reference list of contigs is a subset of contigs in the records to be sorted
+	 */
+	@Test
+	public void vcfSortingReferenceAgnostic2() {
+		VcfRecord v1 = VcfUtils.createVcfRecord("chrUn_GL000216v2", 100);
+		VcfRecord v2 = VcfUtils.createVcfRecord("chr17_KI270729v1_random", 100);
+		VcfRecord v3 = VcfUtils.createVcfRecord("chrUn_KI270516v1", 100);
+		VcfRecord v4 = VcfUtils.createVcfRecord("chrUn_KI270438v1", 100);
+		VcfRecord v5 = VcfUtils.createVcfRecord("chrUn_KI270742v1", 100);
+		VcfRecord v6 = VcfUtils.createVcfRecord("chrUn_GL000216v2", 100);
+		VcfRecord v7 = VcfUtils.createVcfRecord("chrY", 300);
+		VcfRecord v8 = VcfUtils.createVcfRecord("chr1", 300);
+		
+		List<VcfRecord> vcfs = Arrays.asList(v1, v2, v3, v4, v5, v6, v7, v8);
+		
+		vcfs.sort(ChrPositionComparator.getVcfRecordComparatorForGRCh37());
+		assertEquals(v8, vcfs.get(0));
+		assertEquals(v7, vcfs.get(1));
+		assertEquals(v2, vcfs.get(2));
+		assertEquals(v1, vcfs.get(3));
+	}
+	
+	@Test
+	public void cpSortingReferenceAgnostic2() {
+		ChrPosition cp1 = new ChrPointPosition("chrUn_GL000216v2", 100);
+		ChrPosition cp2 = new ChrPointPosition("chr17_KI270729v1_random", 100);
+		ChrPosition cp3 = new ChrPointPosition("chrY", 100);
+		ChrPosition cp4 = new ChrPointPosition("chr1", 100);
+		
+		List<ChrPosition> cps = Arrays.asList(cp1, cp2, cp3, cp4);
+		
+		cps.sort(ChrPositionComparator.getCPComparatorForGRCh37());
+		assertEquals(cp4, cps.get(0));
+		assertEquals(cp3, cps.get(1));
+		assertEquals(cp2, cps.get(2));
+		assertEquals(cp1, cps.get(3));
+	}
 }


### PR DESCRIPTION
There is a bug in the `ChrPositionComparator` class that meant some of the alt chromosome names present in GRCh38 were appearing at the top of vcf files.
This bug is in the `ChrPositionComparator.getCPComparatorForGRCh37()` method, which is used by `qannotate` when writing out vcf records.

eg.
```
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  8ea71427-4117-481f-9e8d-ffc9f9a82314_1  95c9c626-cd9b-4ac1-8f50-53448f5a75d1_1  8ea71427-4117-481f-9e8d-ffc9f9a82314_2  95c9c626-cd9b-4ac1-8f50-53448f5a75d1_2
chrUn_GL000216v2        12      .       T       C       .       .       FLANK=AATTCCATTCC;IN=1;HOM=0,AATTCAATTCtATTCCATTCC      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS 0/0:3,1:4:.:C2;T7:COV:.:.:C0[0]1[37];T3[41]0[0] 0/1:4,3:7:C1[]0[]:C18;T27:COV;NNS;MR;5BP=1:SOMATIC:3:C2[36.5]1[37];T4[37.75]0[0]        ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chr17_KI270729v1_random 12      .       G       A       .       .       FLANK=GTTCTATTCCA;IN=1;HOM=2,ATTCCGTTCTgTTCCATGCCA      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS ./.:0,2:2:.:A5:COV:.:.:A0[0]2[41]       1/1:0,3:3:A0[]1[]:A5;T1:COV;SBIASCOV;NNS;MR;5BP=1:.:3:A0[0]3[35.33]     ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chrUn_KI270516v1        15      .       C       T       .       .       FLANK=ATACATGGAAG;IN=1;HOM=2,AAAAAATACAcGGAAGCATTC      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS 1/1:1,3:4:T0[]1[]:.:COV;NNS;MR;5BP=1:.:3:C0[0]1[41];T1[41]2[39] ./.:1,0:1:.:.:COV:.:.:C1[41]0[0]        ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chrUn_KI270438v1        15      .       C       T       .       .       FLANK=GGATATTTGGA;BaseQRankSum=3.225;ClippingRankSum=0.000;DP=50;ExcessHet=3.0103;FS=0.000;MQ=52.08;MQRankSum=0.603;QD=25.36;ReadPosRankSum=-0.355;SOR=4.977;IN=1,2;HOM=2,CTAGTGGATAcTTGGAGTGCT GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL   1/1:1,20:21:T1[]0[]:T5:PASS:.:.:7:C1[27]0[0];T15[38.67]5[37.4]:.        1/1:3,38:41:.:T11:PASS:.:.:10:C1[32]2[39];T29[39.93]9[29.22]:.  ./.:.:.:.:.:PASS:.:NCIG:.:.:.   1/1:2,35:37:.:.:PASS:65:SOMATIC:.:.:1403.77
chrUn_KI270742v1        18      .       G       A       .       .       FLANK=GACATAGAGGC;BaseQRankSum=-0.311;ClippingRankSum=0.000;DP=10;ExcessHet=3.0103;FS=0.000;MQ=44.49;MQRankSum=-0.370;QD=2.28;ReadPosRankSum=-0.140;SOR=0.105;IN=1,2;HOM=2,CCAGAGACATgGAGGCATGTT        GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL   0/0:7,2:9:A1[]0[]:A2;G4:PASS:.:.:.:A2[36.5]0[0];G7[40.43]0[0]:. 0/1:17,5:22:A1[]0[];G3[]0[]:A5;G15:SBIASCOV;NNS;5BP=1:.:SOMATIC:3:A5[38.4]0[0];G17[39.24]0[0]:. 0/1:8,2:10:.:.:MR:51:.:.:.:22.79        0/1:18,5:23:.:.:PASS:99:.:.:.:82.77
chrUn_GL000216v2        18      .       A       T       .       .       FLANK=ATTCCTTTCCA;IN=1;HOM=2,ATTCTATTCCaTTCCATTCCA      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS 0/0:5,2:7:A1[]0[]:A8;T3:COV:.:.:A4[39]1[12];T1[41]1[12] 0/1:6,3:9:T0[]1[]:A37;G1;T14:NNS;MR;5BP=1:SOMATIC:3:A5[36.6]1[12];T2[41]1[41]   ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chrUn_GL000216v2        22      .       C       T       .       .       FLANK=CATTCTATTCC;IN=1;HOM=2,TATTCCATTCcATTCCATTCC      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS 0/1:6,4:10:T3[]0[]:C11;T2:SBIASALT;NNS;MR;5BP=3:.:3:C4[37.75]2[24.5];T4[34.25]0[0]      0/1:6,8:14:T5[]0[]:C36;T18:5BP=5:.:6:C5[33]1[37];T7[36]1[41]    ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chrUn_KI270435v1        31      .       A       G       .       .       FLANK=TTGAGGCCTAT;BaseQRankSum=0.674;ClippingRankSum=0.000;DP=6;ExcessHet=3.0103;FS=0.000;MQ=49.88;MQRankSum=0.000;QD=12.44;ReadPosRankSum=0.431;SOR=0.693;IN=1,2;HOM=2,GCACTTTGAGaCCTATGGTGG   GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL   ./.:2,1:3:.:A2;G2:COV:.:.:.:A0[0]2[39];G1[41]0[0]:.     1/1:2,3:5:.:A1;G8:COV;SBIASALT;NNS;MR:.:.:1:A0[0]2[39];G3[41]0[0]:.     0/1:2,2:4:.:.:COV;MR:75:.:.:.:49.77     1/1:0,8:8:.:.:PASS:24:.:.:.:304.78
chr1    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chr2    9        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
```

This was happening because the comparator wasn't handling chromosome names that were not in a specific list (GRCh37 list of chromosome names). It was assuming that all values it was comparing were in the supplied list.
eg.
`return list.indexOf(o1) - list.indexOf(o2)`


GRCh38 has lots of chromosome names, the vast majority of which are not in the list.
This change expands on the compare method so that if both of the elements are not in the list, the natural (`String`) ordering is applied.
If one of the elements being compared is in the list, then it will appear above the non-appearing element.
This will ensure that the vcf records in vcf files produced by `qannotate` contain the standard chromosome names (chr1, chr2, etc...) at the top of the vcf file, with the alt chromosome names at the end.

eg.

```
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  8ea71427-4117-481f-9e8d-ffc9f9a82314_1  95c9c626-cd9b-4ac1-8f50-53448f5a75d1_1  8ea71427-4117-481f-9e8d-ffc9f9a82314_2  95c9c626-cd9b-4ac1-8f50-53448f5a75d1_2
chr1    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chr2    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chr3    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chrY    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chrY    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chrY    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chrY    5        .      T       C       .       .       DP=5;ExcessHet=3.0103;FS=0.000;MQ=54.82;QD=29.77;SOR=3.258;IN=2;DB;HOM=0,TCTGCACTGAtCACCCAAGTG  GT:AD:DP:FT:GQ:INF:QL   ./.:.:.:COV:.:.:.       ./.:.:.:COV:.:.:.       ./.:.:.:PASS:.:NCIG:.   1/1:0,4:4:COV;MR:12:SOMATIC:152.03
chr17_KI270729v1_random 12      .       G       A       .       .       FLANK=GTTCTATTCCA;IN=1;HOM=2,ATTCCGTTCTgTTCCATGCCA      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS ./.:0,2:2:.:A5:COV:.:.:A0[0]2[41]       1/1:0,3:3:A0[]1[]:A5;T1:COV;SBIASCOV;NNS;MR;5BP=1:.:3:A0[0]3[35.33]     ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chrUn_GL000216v2        12      .       T       C       .       .       FLANK=AATTCCATTCC;IN=1;HOM=0,AATTCAATTCtATTCCATTCC      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS 0/0:3,1:4:.:C2;T7:COV:.:.:C0[0]1[37];T3[41]0[0] 0/1:4,3:7:C1[]0[]:C18;T27:COV;NNS;MR;5BP=1:SOMATIC:3:C2[36.5]1[37];T4[37.75]0[0]        ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chrUn_GL000216v2        18      .       A       T       .       .       FLANK=ATTCCTTTCCA;IN=1;HOM=2,ATTCTATTCCaTTCCATTCCA      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS 0/0:5,2:7:A1[]0[]:A8;T3:COV:.:.:A4[39]1[12];T1[41]1[12] 0/1:6,3:9:T0[]1[]:A37;G1;T14:NNS;MR;5BP=1:SOMATIC:3:A5[36.6]1[12];T2[41]1[41]   ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
chrUn_GL000216v2        22      .       C       T       .       .       FLANK=CATTCTATTCC;IN=1;HOM=2,TATTCCATTCcATTCCATTCC      GT:AD:DP:EOR:FF:FT:INF:NNS:OABS 0/1:6,4:10:T3[]0[]:C11;T2:SBIASALT;NNS;MR;5BP=3:.:3:C4[37.75]2[24.5];T4[34.25]0[0]      0/1:6,8:14:T5[]0[]:C36;T18:5BP=5:.:6:C5[33]1[37];T7[36]1[41]    ./.:.:.:.:.:COV:.:.:.   ./.:.:.:.:.:COV:.:.:.
```
It also has the effect of grouping the vcf records into their chromosomes which means that indexing bgzipped vcf files works.

Fixes #93 
