### PR TITLE
update qannotate unit test without update sorceCode under src floder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
   }
   checkstyleMain.onlyIf {project.hasProperty('checkstyle')}
 
-   dependencies { testCompile 'junit:junit:4.10' }
+   dependencies { testCompile 'junit:junit:4.12' }
    
    sourceSets {
       main { java.srcDirs=['src']; resources.srcDirs=['src'] }

--- a/qannotate/test/au/edu/qimr/qannotate/OptionsTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/OptionsTest.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
+@RunWith(CallBlockJUnit4ClassRunner.class )
 public class OptionsTest {
 	
 	@Rule

--- a/qannotate/test/au/edu/qimr/qannotate/modes/CCMModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/CCMModeTest.java
@@ -16,9 +16,6 @@ public class CCMModeTest {
 	public static final String REF = "0/0";
 	public static final String DOT = "./.";
 	
-	
-	
-	
 	@Test
 	public void singleCallerMultiSample() {
 		 VcfRecord vcf1 = new VcfRecord(new String[]{"chr8","12306635","rs28428895","C","T",".",".","FLANK=ACACATACATA","GT:GD:AC:MR:NNS:FT","0/1:C/T:C10[39],3[30],G1[11],0[0],T7[41.29],1[42]:8:8:.","0/0:C/C:C19[36.11],20[38.45],T1[42],0[0]:1:1:."});

--- a/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
@@ -2,7 +2,6 @@ package au.edu.qimr.qannotate.modes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedWriter;
@@ -18,7 +17,6 @@ import org.junit.Test;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeader;
-import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 

--- a/qannotate/test/au/edu/qimr/qannotate/modes/GermlineModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/GermlineModeTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
@@ -21,6 +22,9 @@ import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 
+import au.edu.qimr.qannotate.CallBlockJUnit4ClassRunner;
+
+@RunWith(CallBlockJUnit4ClassRunner.class )
 public class GermlineModeTest {
 	
 	@Rule

--- a/qannotate/test/au/edu/qimr/qannotate/modes/MakeValidModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/MakeValidModeTest.java
@@ -14,7 +14,6 @@ import org.qcmg.common.vcf.header.VcfHeader;
 
 public class MakeValidModeTest {
 	
-	
 	@Test
 	public void makeValidSecondCaller() {
 		//chr1    823538  rs375868960     G       T       63.77   MR;NNS  SOMATIC;IN=2;DB;GERM=60,185;HOM=0,TCTGGGCCTAtTCCTTCCTTT;CONF=ZERO  GT:AD:DP:GQ:PL:GD:AC:OABS:MR:NNS        .:.:.:.:.:G/G:G5[39.4],13[39.62]:.:0:0  0/1:53,6:59:92:92,0,2176:G/T:G11[37.82],31[40.45]:.:0:0

--- a/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
@@ -17,14 +17,17 @@ import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 
+import au.edu.qimr.qannotate.CallBlockJUnit4ClassRunner;
 import au.edu.qimr.qannotate.modes.TandemRepeatMode.*;
 
+@RunWith(CallBlockJUnit4ClassRunner.class )
 public class TandemRepeatModeTest {
 	String repeatFileName = "input.repeat";
 	String inputVcfName = "input.vcf";

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
@@ -16,9 +16,9 @@ import java.util.stream.Stream;
 
 import junit.framework.Assert;
 
-import org.junit.After;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.qcmg.common.commandline.Executor;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.IndelUtils.SVTYPE;
@@ -27,10 +27,11 @@ import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 
+import au.edu.qimr.qannotate.CallBlockJUnit4ClassRunner;
 import au.edu.qimr.qannotate.utils.MafElement;
 import au.edu.qimr.qannotate.utils.SnpEffMafRecord;
 
-
+@RunWith(CallBlockJUnit4ClassRunner.class )
 public class Vcf2mafIndelTest {
     
     

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.qcmg.common.commandline.Executor;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
@@ -25,11 +26,13 @@ import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 
+import au.edu.qimr.qannotate.CallBlockJUnit4ClassRunner;
 import au.edu.qimr.qannotate.Options;
 import au.edu.qimr.qannotate.utils.MafElement;
 import au.edu.qimr.qannotate.utils.SnpEffConsequence;
 import au.edu.qimr.qannotate.utils.SnpEffMafRecord;
 
+@RunWith(CallBlockJUnit4ClassRunner.class )
 public class Vcf2mafTest {
     static String inputName = DbsnpModeTest.inputName;        
     


### PR DESCRIPTION
this branch is copied from the master, there is no new feature of qannotate. Here we just changed the exsiting test code to cope with junit 4.12