### PR TITLE
updated imports to use java.util.Array rather than scala version

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
@@ -23,16 +23,14 @@ import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
-import org.qcmg.picard.SAMOrBAMWriterFactory;
 import org.qcmg.qbamfilter.query.QueryExecutor;
 
 import au.edu.qimr.qannotate.Options;
 import au.edu.qimr.qannotate.utils.ContigPileup;
 import au.edu.qimr.qannotate.utils.VariantPileup;
-import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SamReader;
-import scala.actors.threadpool.Arrays;
+import java.util.Arrays;
 
 public class OverlapMode extends AbstractMode{
 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
@@ -21,7 +21,7 @@ import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.vcf.VCFFileReader;
 import org.qcmg.vcf.VCFFileWriter;
 
-import scala.actors.threadpool.Arrays;
+import java.util.Arrays;
 import au.edu.qimr.qannotate.Options;
 import ca.mcgill.mcb.pcingola.snpEffect.commandLine.SnpEff;
 

--- a/qannotate/src/au/edu/qimr/qannotate/utils/VariantPileup.java
+++ b/qannotate/src/au/edu/qimr/qannotate/utils/VariantPileup.java
@@ -11,7 +11,7 @@ import org.qcmg.common.util.IndelUtils.SVTYPE;
 import org.qcmg.common.util.Pair;
 import org.qcmg.common.vcf.VcfRecord;
 import htsjdk.samtools.SAMRecord;
-import scala.actors.threadpool.Arrays;
+import java.util.Arrays;
 
 public class VariantPileup {
 	

--- a/qannotate/test/au/edu/qimr/qannotate/utils/ContigPileupTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/utils/ContigPileupTest.java
@@ -16,14 +16,13 @@ import org.qcmg.common.model.ChrPointPosition;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.picard.SAMFileReaderFactory;
-import org.qcmg.qbamfilter.query.QueryExecutor;
 
 import static org.junit.Assert.assertTrue;
 
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SamReader;
-import scala.actors.threadpool.Arrays;
+import java.util.Arrays;
 
 public class ContigPileupTest {
 	

--- a/qannotate/test/au/edu/qimr/qannotate/utils/SnpPileupTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/utils/SnpPileupTest.java
@@ -9,12 +9,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.qcmg.common.model.ChrPointPosition;
-import org.qcmg.common.util.BaseUtils;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.picard.SAMOrBAMWriterFactory;
 
@@ -22,7 +20,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileWriter;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReader;
-import scala.actors.threadpool.Arrays;
 
 public class SnpPileupTest {
 	static final String inputBam = "input.bam"; 


### PR DESCRIPTION
# Description

`Qannotate` has a number of classes that are importing the wrong Arrays class.
They are importing `scala.actors.threadpool.Arrays` rather than `java.util.Arrays`
The `scala.actors.threadpool` package is present in the `snpEff` jar file that `qannotate` relies on. By updating these classes to use `java.util.Arrays` we will reduce the coupling to the `snpEff` jar from our code, which is good.
We will also be using the Arrays class that I think was originally intended to be used.


Fixes #101 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran all the junit test associated with this project.
Also ran a full gradle build on the adamajava suite of projects

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
