### PR TITLE
Develop.master

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -243,9 +243,8 @@ public class BamSummaryReport2 extends SummaryReport {
         parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUPS );  
         
         for(String rg : readGroups ) {
-        	String rgName = (readGroups.size() == 1 && rg.equals(XmlUtils.UNKNOWN_READGROUP))? null : rg;
         	//output tLen inside pairSummary, eg. inward, f3f5
-        	rgSummaries.get(rg).pairTlen2Xml(XmlUtils.createReadGroupNode(parent, rgName));       	
+        	rgSummaries.get(rg).pairTlen2Xml(XmlUtils.createReadGroupNode(parent, rg));       	
         }	
 	}			
 	private void createCigar(Element parent) {

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -254,8 +254,7 @@ public class BamSummaryReport2 extends SummaryReport {
         parent = XmlElementUtils.createSubElement(parent, XmlUtils.READGROUPS );  
         
         for(String rg : readGroups ) {
-        	String rgName = (readGroups.size() == 1 && rg.equals(XmlUtils.UNKNOWN_READGROUP))? null : rg;
-        	Element ele = XmlUtils.createMetricsNode( XmlUtils.createReadGroupNode(parent, rgName), null, 
+        	Element ele = XmlUtils.createMetricsNode( XmlUtils.createReadGroupNode(parent, rg), null, 
         			new Pair<String, Number>(ReadGroupSummary.READ_COUNT,rgSummaries.get(rg).getCigarReadCount()) )	;
         	
         	//cigar string from reads including duplicateReads, notProperPairs and unmappedReads but excluding discardedReads (failed, secondary and supplementary).

--- a/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
+++ b/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
@@ -111,7 +111,7 @@
     <xs:complexType name="SequenceMetricsType">    
 	     <xs:choice>
 		     <xs:sequence>
-			     <xs:element name="variableGroup" maxOccurs="unbounded" type="groupType"/>
+			     <xs:element name="variableGroup" maxOccurs="unbounded"  minOccurs="0" type="groupType"/>
 		     </xs:sequence>
 		     <xs:sequence>
 			     <xs:element ref="value" maxOccurs="unbounded"/>

--- a/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/util/XmlUtils.java
@@ -21,7 +21,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 
 public class XmlUtils {
 	public static final String OTHER = "others";
-	public static final String UNKNOWN_READGROUP = "unkown_readgroup_id";	
+	public static final String UNKNOWN_READGROUP = "unknown_readgroup_id";	
 	
 	public static final String METRICS = "Metrics";
 	public static final String READGROUPS ="readGroups";

--- a/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportMetricsTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportMetricsTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.w3c.dom.Element;
-import org.qcmg.common.date.DateUtils;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.util.XmlElementUtils;
@@ -145,7 +144,7 @@ public class BamSummaryReportMetricsTest {
 	public void cigarTest() {
 		Element summaryE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.BAM_SUMMARY).get(0);			
 		Element tagE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.CIGAR).get(0);
-		for(String rg : new String[] {"1959T", "1959N", "unkown_readgroup_id" }) {
+		for(String rg : new String[] {"1959T", "1959N", "unknown_readgroup_id" }) {
 			//get counts from <bamMetrics>
 			Element ele =getElementByFirst(tagE, "readGroup",  k -> k.getAttribute(XmlUtils.NAME).equals(rg));
 			String readCount = XmlElementUtils.getChildElement(ele,  XmlUtils.SEQUENCE_METRICS, 0).getAttribute(ReadGroupSummary.READ_COUNT);
@@ -231,7 +230,7 @@ public class BamSummaryReportMetricsTest {
 		for(String tagName : new String[] { XmlUtils.QNAME, XmlUtils.POS }) {
 			Element tagE = XmlElementUtils.getOffspringElementByTagName(root, tagName).get(0);
 			
-			for(String rg : new String[] {"1959T", "1959N", "unkown_readgroup_id" }) {			
+			for(String rg : new String[] {"1959T", "1959N", "unknown_readgroup_id" }) {			
 				Element ele =getElementByFirst(tagE, "readGroup",  k -> k.getAttribute(XmlUtils.NAME).equals(rg));
 				String readCount = tagName.equals(XmlUtils.POS ) ? 
 					 XmlElementUtils.getChildElement(ele,  XmlUtils.SEQUENCE_METRICS, 0).getAttribute(ReadGroupSummary.READ_COUNT) :
@@ -304,23 +303,20 @@ public class BamSummaryReportMetricsTest {
 		}
 		
 		int freq = 10000;
-		String str; 
-		QLogger logger = QLoggerFactory.getLogger(QProfiler2.class, testFolder.newFile("my.log").getAbsolutePath(), "DEBUG");
+		String str;
 		long start = System.currentTimeMillis();		
 		for(int i = 0; i < freq; i ++) {
 			str = myList.get(i%100);
 			Collections.binarySearch( myList, str, null);  
 		}
-		logger.getRunTime(start, System.currentTimeMillis());
+		QLogger.getRunTime(start, System.currentTimeMillis());
 		
 		start = System.currentTimeMillis();		
 		for(int i = 0; i < freq; i ++) {
 			str = myList.get(i%100);
 			myList.indexOf(str);
 		}
-		logger.getRunTime(start, System.currentTimeMillis());
-		
-		
+		QLogger.getRunTime(start, System.currentTimeMillis());		
 	}
 	
 }

--- a/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportTest.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -20,6 +22,7 @@ import org.qcmg.qprofiler2.summarise.CycleSummaryTest;
 import org.qcmg.qprofiler2.summarise.PairSummary;
 import org.qcmg.qprofiler2.summarise.PairSummaryTest;
 import org.qcmg.qprofiler2.summarise.PositionSummary;
+import org.qcmg.qprofiler2.summarise.ReadGroupSummary;
 import org.qcmg.qprofiler2.util.XmlUtils;
 import org.w3c.dom.Element;
 
@@ -231,5 +234,26 @@ public class BamSummaryReportTest {
 	 
 		return eles;
 	}
+	
+	
+	
+	@Test
+	public void unKnownIdTest() throws Exception{
+		final Element root = XmlElementUtils.createRootElement("root",null);
+		BamSummaryReport2 bsr = new BamSummaryReport2( -1, false);
+		SAMRecord record = new SAMRecord(null);
+		record.setReadName("243_146_1");
+		record.setBaseQualities(new byte[] {1,2,3,4,5,6,7});
+		record.setReadBases(new byte[] {1,2,3,4,5,6,7});				
+		record.setAlignmentStart(239007);
+		record.setReferenceName("chrY");
+		record.setFlags(64);		
+		bsr.parseRecord(record);
+		bsr.toXml(root);
 		
+		for(Element ele: XmlElementUtils.getOffspringElementByTagName(root, "readGroup")) {
+			assertEquals( ele.getAttribute("name"), "unknown_readgroup_id");
+		} 		
+	}
+	
 }


### PR DESCRIPTION
# Description

In qprofiler2 We will put “unknown_readgroup_id” as default readGroup name if the RG tag is missing. However, in TLEN and CIGAR section we only set this default value when whole BAM file missing RG tag. It causes the whole file inconsistence, we set “unknown_readgroup_id” to other section but empty string on TLEN and CIGAR section. We just found this bug, since all our BAMs have RG tag but only some reads may be missing it. Today is the first time each reads in a BAM miss RG tag. 

## Type of change
1. fix typo: "unkown" to "unknown"
2. set "unknown_readgroup_id" as default name value in <readgroup> under <TLEN> and <CIGAR>
3. update xsd make it allow zero child element under <sequeneMetircs>

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

run the existing unit test. added a new unit test

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
