### PR TITLE
bump await times for threads

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
@@ -108,7 +108,7 @@ public class OverlapMode extends AbstractMode{
 		// wait for threads to complete
 		try {
 			logger.info("waiting for  threads to finish (max wait will be 40 hours)");
-			pileupThreads.awaitTermination(100, TimeUnit.HOURS);
+			pileupThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 			logger.info("All threads finished");			
 		} catch (Exception e) {
 			logger.error("Exception caught whilst waiting for threads to finish: " + e.getMessage(), e);

--- a/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
@@ -108,7 +108,7 @@ public class OverlapMode extends AbstractMode{
 		// wait for threads to complete
 		try {
 			logger.info("waiting for  threads to finish (max wait will be 40 hours)");
-			pileupThreads.awaitTermination(40, TimeUnit.HOURS);
+			pileupThreads.awaitTermination(100, TimeUnit.HOURS);
 			logger.info("All threads finished");			
 		} catch (Exception e) {
 			logger.error("Exception caught whilst waiting for threads to finish: " + e.getMessage(), e);

--- a/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
@@ -107,8 +107,8 @@ public class OverlapMode extends AbstractMode{
     	
 		// wait for threads to complete
 		try {
-			logger.info("waiting for  threads to finish (max wait will be 20 hours)");
-			pileupThreads.awaitTermination(20, TimeUnit.HOURS);
+			logger.info("waiting for  threads to finish (max wait will be 40 hours)");
+			pileupThreads.awaitTermination(40, TimeUnit.HOURS);
 			logger.info("All threads finished");			
 		} catch (Exception e) {
 			logger.error("Exception caught whilst waiting for threads to finish: " + e.getMessage(), e);

--- a/qbamfilter/src/org/qcmg/qbamfilter/query/QueryMT.java
+++ b/qbamfilter/src/org/qcmg/qbamfilter/query/QueryMT.java
@@ -24,6 +24,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.ValidationStringency;
 
 import org.qcmg.common.log.QLogger;
+import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.picard.SAMOrBAMWriterFactory;
 import org.qcmg.picard.SAMRecordFilterWrapper;
@@ -186,12 +187,12 @@ public class QueryMT {
 		// wait for threads to complete
 		try {
 			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-			readThreads.awaitTermination(100, TimeUnit.HOURS);
-			filterThreads.awaitTermination(20, TimeUnit.HOURS);
-			writeThreadA.awaitTermination(20, TimeUnit.HOURS);
+			readThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+			filterThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+			writeThreadA.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
 			if (outBadQueue != null) {
-				writeThreadB.awaitTermination(20, TimeUnit.HOURS);
+				writeThreadB.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 				if (outBadQueue.size() != 0)
 					throw new Exception(" threads have completed but Queue of unmatched Records isn't empty):  "
 									+ outBadQueue.size());

--- a/qbamfilter/src/org/qcmg/qbamfilter/query/QueryMT.java
+++ b/qbamfilter/src/org/qcmg/qbamfilter/query/QueryMT.java
@@ -185,13 +185,13 @@ public class QueryMT {
 
 		// wait for threads to complete
 		try {
-			logger.info("waiting for  threads to finish (max wait will be 20 hours)");
-			readThreads.awaitTermination(20, TimeUnit.HOURS);
-			filterThreads.awaitTermination(20, TimeUnit.HOURS);
-			writeThreadA.awaitTermination(20, TimeUnit.HOURS);
+			logger.info("waiting for  threads to finish (max wait will be 40 hours)");
+			readThreads.awaitTermination(40, TimeUnit.HOURS);
+			filterThreads.awaitTermination(40, TimeUnit.HOURS);
+			writeThreadA.awaitTermination(40, TimeUnit.HOURS);
 
 			if (outBadQueue != null) {
-				writeThreadB.awaitTermination(20, TimeUnit.HOURS);
+				writeThreadB.awaitTermination(40, TimeUnit.HOURS);
 				if (outBadQueue.size() != 0)
 					throw new Exception(" threads have completed but Queue of unmatched Records isn't empty):  "
 									+ outBadQueue.size());

--- a/qbamfilter/src/org/qcmg/qbamfilter/query/QueryMT.java
+++ b/qbamfilter/src/org/qcmg/qbamfilter/query/QueryMT.java
@@ -185,13 +185,13 @@ public class QueryMT {
 
 		// wait for threads to complete
 		try {
-			logger.info("waiting for  threads to finish (max wait will be 40 hours)");
-			readThreads.awaitTermination(40, TimeUnit.HOURS);
-			filterThreads.awaitTermination(40, TimeUnit.HOURS);
-			writeThreadA.awaitTermination(40, TimeUnit.HOURS);
+			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+			readThreads.awaitTermination(100, TimeUnit.HOURS);
+			filterThreads.awaitTermination(20, TimeUnit.HOURS);
+			writeThreadA.awaitTermination(20, TimeUnit.HOURS);
 
 			if (outBadQueue != null) {
-				writeThreadB.awaitTermination(40, TimeUnit.HOURS);
+				writeThreadB.awaitTermination(20, TimeUnit.HOURS);
 				if (outBadQueue.size() != 0)
 					throw new Exception(" threads have completed but Queue of unmatched Records isn't empty):  "
 									+ outBadQueue.size());

--- a/qbasepileup/src/org/qcmg/qbasepileup/coverage/CoveragePileupMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/coverage/CoveragePileupMT.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrRangePosition;
+import org.qcmg.common.util.Constants;
 import org.qcmg.qbamfilter.query.QueryExecutor;
 import org.qcmg.qbasepileup.InputBAM;
 import org.qcmg.qbasepileup.QBasePileupUtil;
@@ -100,9 +101,9 @@ public class CoveragePileupMT {
             writeThread.shutdown();
 
             logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-            readThread.awaitTermination(100, TimeUnit.HOURS);
-            pileupThreads.awaitTermination(20, TimeUnit.HOURS);
-            writeThread.awaitTermination(20, TimeUnit.HOURS);
+            readThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            pileupThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            writeThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
             if (readQueue.size() != 0 || writeQueue.size() != 0) {
             	exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/coverage/CoveragePileupMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/coverage/CoveragePileupMT.java
@@ -99,10 +99,10 @@ public class CoveragePileupMT {
             writeThread.execute(new Writing(writeQueue, options.getOutput(), Thread.currentThread(), pileupLatch, writeLatch));
             writeThread.shutdown();
 
-            logger.info("waiting for  threads to finish (max wait will be 60 hours)");
-            readThread.awaitTermination(60, TimeUnit.HOURS);
-            pileupThreads.awaitTermination(60, TimeUnit.HOURS);
-            writeThread.awaitTermination(60, TimeUnit.HOURS);
+            logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+            readThread.awaitTermination(100, TimeUnit.HOURS);
+            pileupThreads.awaitTermination(20, TimeUnit.HOURS);
+            writeThread.awaitTermination(20, TimeUnit.HOURS);
 
             if (readQueue.size() != 0 || writeQueue.size() != 0) {
             	exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupByChrMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupByChrMT.java
@@ -36,6 +36,7 @@ import htsjdk.samtools.SAMRecordIterator;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrRangePosition;
+import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qbamfilter.query.QueryExecutor;
 import org.qcmg.qbasepileup.InputBAM;
@@ -118,9 +119,9 @@ public class IndelBasePileupByChrMT {
             writeThread.shutdown();
 
             logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-            readThread.awaitTermination(100, TimeUnit.HOURS);
-            pileupThreads.awaitTermination(20, TimeUnit.HOURS);
-            writeThread.awaitTermination(20, TimeUnit.HOURS);
+            readThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            pileupThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            writeThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
             if (readQueue.size() != 0 || writeQueue.size() != 0) {
             		exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupByChrMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupByChrMT.java
@@ -117,10 +117,10 @@ public class IndelBasePileupByChrMT {
             writeThread.execute(new Writing(writeQueue, outputFile, pileupFile, Thread.currentThread(), pileupLatch, writeLatch, headers));
             writeThread.shutdown();
 
-            logger.info("waiting for  threads to finish (max wait will be 60 hours)");
-            readThread.awaitTermination(60, TimeUnit.HOURS);
-            pileupThreads.awaitTermination(60, TimeUnit.HOURS);
-            writeThread.awaitTermination(60, TimeUnit.HOURS);
+            logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+            readThread.awaitTermination(100, TimeUnit.HOURS);
+            pileupThreads.awaitTermination(20, TimeUnit.HOURS);
+            writeThread.awaitTermination(20, TimeUnit.HOURS);
 
             if (readQueue.size() != 0 || writeQueue.size() != 0) {
             		exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupMT.java
@@ -31,6 +31,7 @@ import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrRangePosition;
+import org.qcmg.common.util.Constants;
 import org.qcmg.qbamfilter.query.QueryExecutor;
 import org.qcmg.qbasepileup.InputBAM;
 import org.qcmg.qbasepileup.Options;
@@ -116,9 +117,9 @@ public class IndelBasePileupMT {
             writeThread.shutdown();
 
             logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-            readThread.awaitTermination(100, TimeUnit.HOURS);
-            pileupThreads.awaitTermination(20, TimeUnit.HOURS);
-            writeThread.awaitTermination(20, TimeUnit.HOURS);
+            readThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            pileupThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            writeThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
             if (readQueue.size() != 0 || writeQueue.size() != 0) {
             	exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/indel/IndelBasePileupMT.java
@@ -115,10 +115,10 @@ public class IndelBasePileupMT {
             writeThread.execute(new Writing(writeQueue, outputFile, pileupFile, Thread.currentThread(), pileupLatch, writeLatch, headers));
             writeThread.shutdown();
 
-            logger.info("waiting for  threads to finish (max wait will be 60 hours)");
-            readThread.awaitTermination(60, TimeUnit.HOURS);
-            pileupThreads.awaitTermination(60, TimeUnit.HOURS);
-            writeThread.awaitTermination(60, TimeUnit.HOURS);
+            logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+            readThread.awaitTermination(100, TimeUnit.HOURS);
+            pileupThreads.awaitTermination(20, TimeUnit.HOURS);
+            writeThread.awaitTermination(20, TimeUnit.HOURS);
 
             if (readQueue.size() != 0 || writeQueue.size() != 0) {
             	exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupByFileMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupByFileMT.java
@@ -115,10 +115,10 @@ public class SnpBasePileupByFileMT {
 			writeThread.execute(new Writing(writeQueue, options.getOutput(), Thread.currentThread(), pileupLatch, writeLatch));
 			writeThread.shutdown();
 
-			logger.info("waiting for  threads to finish (max wait will be 60 hours)");
+			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
 
-			pileupThreads.awaitTermination(60, TimeUnit.HOURS);
-			writeThread.awaitTermination(60, TimeUnit.HOURS);
+			pileupThreads.awaitTermination(100, TimeUnit.HOURS);
+			writeThread.awaitTermination(20, TimeUnit.HOURS);
 
 			if (readQueue.size() != 0 || writeQueue.size() != 0) {
 				exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupByFileMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupByFileMT.java
@@ -36,6 +36,7 @@ import htsjdk.samtools.SAMRecord;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qbamfilter.query.QueryExecutor;
 import org.qcmg.qbasepileup.InputBAM;
@@ -117,8 +118,8 @@ public class SnpBasePileupByFileMT {
 
 			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
 
-			pileupThreads.awaitTermination(100, TimeUnit.HOURS);
-			writeThread.awaitTermination(20, TimeUnit.HOURS);
+			pileupThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+			writeThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
 			if (readQueue.size() != 0 || writeQueue.size() != 0) {
 				exitStatus.incrementAndGet();

--- a/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupMT.java
@@ -131,8 +131,8 @@ public class SnpBasePileupMT {
 			writeThread.shutdown();
 
 			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-			pileupThreads.awaitTermination(100, TimeUnit.HOURS);
-			writeThread.awaitTermination(20, TimeUnit.HOURS);
+			pileupThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+			writeThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
 			logger.info("All threads finished");
 

--- a/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupMT.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/snp/SnpBasePileupMT.java
@@ -130,9 +130,9 @@ public class SnpBasePileupMT {
 			writeThread.execute(new Writing(writeQueue, options.getOutput(), Thread.currentThread(), pileupLatch, writeLatch));
 			writeThread.shutdown();
 
-			logger.info("waiting for  threads to finish (max wait will be 60 hours)");
-			pileupThreads.awaitTermination(60, TimeUnit.HOURS);
-			writeThread.awaitTermination(60, TimeUnit.HOURS);
+			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+			pileupThreads.awaitTermination(100, TimeUnit.HOURS);
+			writeThread.awaitTermination(20, TimeUnit.HOURS);
 
 			logger.info("All threads finished");
 

--- a/qcnv/src/org/qcmg/cnv/MtCounts.java
+++ b/qcnv/src/org/qcmg/cnv/MtCounts.java
@@ -84,7 +84,7 @@ public class MtCounts {
        //wait threads finish
    	   logger.info("submited counting threads are " + index);	 
        queryThreads.shutdown();
-       queryThreads.awaitTermination(40, TimeUnit.HOURS);
+       queryThreads.awaitTermination(100, TimeUnit.HOURS);
        queryThreads.shutdownNow();
        
        logger.info("completed parallel query based on genome file name");	       

--- a/qcnv/src/org/qcmg/cnv/MtCounts.java
+++ b/qcnv/src/org/qcmg/cnv/MtCounts.java
@@ -84,7 +84,7 @@ public class MtCounts {
        //wait threads finish
    	   logger.info("submited counting threads are " + index);	 
        queryThreads.shutdown();
-       queryThreads.awaitTermination(20, TimeUnit.HOURS);
+       queryThreads.awaitTermination(40, TimeUnit.HOURS);
        queryThreads.shutdownNow();
        
        logger.info("completed parallel query based on genome file name");	       

--- a/qcnv/src/org/qcmg/cnv/MtCounts.java
+++ b/qcnv/src/org/qcmg/cnv/MtCounts.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.ValidationStringency;
 
 import org.qcmg.common.log.*;
+import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.picard.SAMRecordFilterWrapper;
 
@@ -84,7 +85,7 @@ public class MtCounts {
        //wait threads finish
    	   logger.info("submited counting threads are " + index);	 
        queryThreads.shutdown();
-       queryThreads.awaitTermination(100, TimeUnit.HOURS);
+       queryThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
        queryThreads.shutdownNow();
        
        logger.info("completed parallel query based on genome file name");	       

--- a/qcommon/src/org/qcmg/common/util/Constants.java
+++ b/qcommon/src/org/qcmg/common/util/Constants.java
@@ -46,6 +46,12 @@ public class Constants {
 	public static final String CHR = "chr";
 	public static final String MISSING_GT = "./.";
 	
+	/*
+	 * Number of hours that an ExecutorService will wait for before terminating
+	 * Set to 100 initially
+	 */
+	public static final int EXECUTOR_SERVICE_AWAIT_TERMINATION = 100;
+	
 	
 	// SAM Header Prefixes
 	public static final String HEADER_PREFIX = "@HD";

--- a/qmule/src/org/qcmg/qmule/bam/CheckBam.java
+++ b/qmule/src/org/qcmg/qmule/bam/CheckBam.java
@@ -117,12 +117,8 @@ public class CheckBam {
 		// don't allow any new threads to start
 		producerThreads.shutdown();
 		
-		logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
-		if ( ! pLatch.await(40, TimeUnit.HOURS)) {
-			// we've hit the 40 hour limit - shutdown the threads and throw an exception
-			producerThreads.shutdownNow();
-			throw new Exception("Producer thread has timed out");
-		}
+		logger.info("waiting for Producer thread to finish");
+		pLatch.await();
 		logger.info("Producer thread finished, counter size: " + counter.longValue());
 		// output flag stats too
 		long dups = 0;

--- a/qmule/src/org/qcmg/qmule/bam/CheckBam.java
+++ b/qmule/src/org/qcmg/qmule/bam/CheckBam.java
@@ -117,9 +117,9 @@ public class CheckBam {
 		// don't allow any new threads to start
 		producerThreads.shutdown();
 		
-		logger.info("waiting for Producer thread to finish (max wait will be 20 hours)");
-		if ( ! pLatch.await(20, TimeUnit.HOURS)) {
-			// we've hit the 20 hour limit - shutdown the threads and throw an exception
+		logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
+		if ( ! pLatch.await(40, TimeUnit.HOURS)) {
+			// we've hit the 40 hour limit - shutdown the threads and throw an exception
 			producerThreads.shutdownNow();
 			throw new Exception("Producer thread has timed out");
 		}

--- a/qmule/src/org/qcmg/qmule/qcnv/MtCNVSeq.java
+++ b/qmule/src/org/qcmg/qmule/qcnv/MtCNVSeq.java
@@ -24,6 +24,7 @@ import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.ValidationStringency;
 
 import org.qcmg.common.log.*;
+import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
 
 
@@ -71,7 +72,7 @@ public class MtCNVSeq {
 	       }	  
 	       //wait threads finish
 	       queryThreads.shutdown();
-	       queryThreads.awaitTermination(100, TimeUnit.HOURS);
+	       queryThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 	       queryThreads.shutdownNow();
 	       logger.debug("completed parallel query based on genome file name");
 	       

--- a/qmule/src/org/qcmg/qmule/qcnv/MtCNVSeq.java
+++ b/qmule/src/org/qcmg/qmule/qcnv/MtCNVSeq.java
@@ -71,7 +71,7 @@ public class MtCNVSeq {
 	       }	  
 	       //wait threads finish
 	       queryThreads.shutdown();
-	       queryThreads.awaitTermination(20, TimeUnit.HOURS);
+	       queryThreads.awaitTermination(40, TimeUnit.HOURS);
 	       queryThreads.shutdownNow();
 	       logger.debug("completed parallel query based on genome file name");
 	       

--- a/qmule/src/org/qcmg/qmule/qcnv/MtCNVSeq.java
+++ b/qmule/src/org/qcmg/qmule/qcnv/MtCNVSeq.java
@@ -71,7 +71,7 @@ public class MtCNVSeq {
 	       }	  
 	       //wait threads finish
 	       queryThreads.shutdown();
-	       queryThreads.awaitTermination(40, TimeUnit.HOURS);
+	       queryThreads.awaitTermination(100, TimeUnit.HOURS);
 	       queryThreads.shutdownNow();
 	       logger.debug("completed parallel query based on genome file name");
 	       

--- a/qpileup/src/org/qcmg/pileup/mode/BootstrapMT.java
+++ b/qpileup/src/org/qcmg/pileup/mode/BootstrapMT.java
@@ -24,6 +24,7 @@ import htsjdk.samtools.reference.ReferenceSequence;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.util.Constants;
 import org.qcmg.pileup.Options;
 import org.qcmg.pileup.PileupConstants;
 import org.qcmg.pileup.PileupUtil;
@@ -152,8 +153,8 @@ public class BootstrapMT {
 	        }
 	        viewThreads.shutdown();
 
-	        readThread.awaitTermination(100, TimeUnit.HOURS);
-	        viewThreads.awaitTermination(20, TimeUnit.HOURS);	         
+	        readThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+	        viewThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);	         
 	        
 	        if (readQueue.size() != 0) {
 	        	logger.info("Setting exitStatus to 1 in execute thread as readQueue is not empty.");

--- a/qpileup/src/org/qcmg/pileup/mode/BootstrapMT.java
+++ b/qpileup/src/org/qcmg/pileup/mode/BootstrapMT.java
@@ -152,8 +152,8 @@ public class BootstrapMT {
 	        }
 	        viewThreads.shutdown();
 
-	        readThread.awaitTermination(40, TimeUnit.HOURS);
-	        viewThreads.awaitTermination(40, TimeUnit.HOURS);	         
+	        readThread.awaitTermination(100, TimeUnit.HOURS);
+	        viewThreads.awaitTermination(20, TimeUnit.HOURS);	         
 	        
 	        if (readQueue.size() != 0) {
 	        	logger.info("Setting exitStatus to 1 in execute thread as readQueue is not empty.");

--- a/qpileup/src/org/qcmg/pileup/mode/BootstrapMT.java
+++ b/qpileup/src/org/qcmg/pileup/mode/BootstrapMT.java
@@ -152,8 +152,8 @@ public class BootstrapMT {
 	        }
 	        viewThreads.shutdown();
 
-	        readThread.awaitTermination(20, TimeUnit.HOURS);
-	        viewThreads.awaitTermination(20, TimeUnit.HOURS);	         
+	        readThread.awaitTermination(40, TimeUnit.HOURS);
+	        viewThreads.awaitTermination(40, TimeUnit.HOURS);	         
 	        
 	        if (readQueue.size() != 0) {
 	        	logger.info("Setting exitStatus to 1 in execute thread as readQueue is not empty.");

--- a/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
+++ b/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
@@ -28,6 +28,7 @@ import org.qcmg.common.date.DateUtils;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ProfileType;
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
 import org.qcmg.common.util.LoadReferencedClasses;
 import org.qcmg.qprofiler.bam.BamSummarizer;
@@ -217,7 +218,7 @@ public class QProfiler {
 		// don't allow any new tasks to be executed
 		exec.shutdown();
 		try {
-			exec.awaitTermination(100, TimeUnit.HOURS);
+			exec.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			// restore interrupted status
 			Thread.currentThread().interrupt();

--- a/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
+++ b/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
@@ -217,7 +217,7 @@ public class QProfiler {
 		// don't allow any new tasks to be executed
 		exec.shutdown();
 		try {
-			exec.awaitTermination(40, TimeUnit.HOURS);
+			exec.awaitTermination(100, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			// restore interrupted status
 			Thread.currentThread().interrupt();

--- a/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
+++ b/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
@@ -217,7 +217,7 @@ public class QProfiler {
 		// don't allow any new tasks to be executed
 		exec.shutdown();
 		try {
-			exec.awaitTermination(20, TimeUnit.HOURS);
+			exec.awaitTermination(40, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			// restore interrupted status
 			Thread.currentThread().interrupt();

--- a/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizerMT.java
+++ b/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizerMT.java
@@ -166,13 +166,8 @@ public class BamSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
-			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
-				// we've hit the 40 hour limit - shutdown the threads and throw an exception
-				producerThreads.shutdownNow();
-				consumerThreads.shutdownNow();
-				throw new Exception("Producer thread has timed out");
-			}
+			logger.info("waiting for Producer thread to finish");
+			 pLatch.await();
 			logger.info("producer thread finished, queue size: " + (q == null ? getQueueSize(queues) : getQueueSize(q) ) );
 			
 			if ( ! cLatch.await(30, TimeUnit.SECONDS)) {

--- a/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizerMT.java
+++ b/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizerMT.java
@@ -166,9 +166,9 @@ public class BamSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 20 hours)");
-			if ( ! pLatch.await(20, TimeUnit.HOURS)) {
-				// we've hit the 20 hour limit - shutdown the threads and throw an exception
+			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
+			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
+				// we've hit the 40 hour limit - shutdown the threads and throw an exception
 				producerThreads.shutdownNow();
 				consumerThreads.shutdownNow();
 				throw new Exception("Producer thread has timed out");

--- a/qprofiler/src/org/qcmg/qprofiler/fa/FaSummarizerMT.java
+++ b/qprofiler/src/org/qcmg/qprofiler/fa/FaSummarizerMT.java
@@ -71,9 +71,9 @@ public class FaSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 20 hours)");
-			if ( ! pLatch.await(20, TimeUnit.HOURS)) {
-				// we've hit the 20 hour limit - shutdown the threads and throw an exception
+			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
+			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
+				// we've hit the 40 hour limit - shutdown the threads and throw an exception
 				producerThreads.shutdownNow();
 				consumerThreads.shutdownNow();
 				throw new Exception("Producer thread has timed out");

--- a/qprofiler/src/org/qcmg/qprofiler/fa/FaSummarizerMT.java
+++ b/qprofiler/src/org/qcmg/qprofiler/fa/FaSummarizerMT.java
@@ -71,13 +71,8 @@ public class FaSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
-			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
-				// we've hit the 40 hour limit - shutdown the threads and throw an exception
-				producerThreads.shutdownNow();
-				consumerThreads.shutdownNow();
-				throw new Exception("Producer thread has timed out");
-			}
+			logger.info("waiting for Producer thread to finish");
+			pLatch.await();
 			logger.info("producer thread finished, queue size: " + q.size());
 			
 			if ( ! cLatch.await(10, TimeUnit.MINUTES)) {

--- a/qprofiler/src/org/qcmg/qprofiler/fastq/FastqSummarizerMT.java
+++ b/qprofiler/src/org/qcmg/qprofiler/fastq/FastqSummarizerMT.java
@@ -72,9 +72,9 @@ public class FastqSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 20 hours)");
-			if ( ! pLatch.await(20, TimeUnit.HOURS)) {
-				// we've hit the 20 hour limit - shutdown the threads and throw an exception
+			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
+			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
+				// we've hit the 40 hour limit - shutdown the threads and throw an exception
 				producerThreads.shutdownNow();
 				consumerThreads.shutdownNow();
 				throw new Exception("Producer thread has timed out");

--- a/qprofiler/src/org/qcmg/qprofiler/fastq/FastqSummarizerMT.java
+++ b/qprofiler/src/org/qcmg/qprofiler/fastq/FastqSummarizerMT.java
@@ -72,13 +72,8 @@ public class FastqSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
-			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
-				// we've hit the 40 hour limit - shutdown the threads and throw an exception
-				producerThreads.shutdownNow();
-				consumerThreads.shutdownNow();
-				throw new Exception("Producer thread has timed out");
-			}
+			logger.info("waiting for Producer thread to finish");
+			pLatch.await();
 			logger.info("producer thread finished, queue size: " + q.size());
 			
 			if ( ! cLatch.await(30, TimeUnit.SECONDS)) {

--- a/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
@@ -26,6 +26,7 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.messages.QMessage;
 import org.qcmg.common.model.ProfileType;
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
 import org.qcmg.common.util.LoadReferencedClasses;
 import org.qcmg.common.util.XmlElementUtils;
@@ -176,7 +177,7 @@ public class QProfiler2 {
 		// don't allow any new tasks to be executed
 		exec.shutdown();
 		try {
-			exec.awaitTermination(100, TimeUnit.HOURS);
+			exec.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			// restore interrupted status
 			Thread.currentThread().interrupt();

--- a/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
@@ -176,7 +176,7 @@ public class QProfiler2 {
 		// don't allow any new tasks to be executed
 		exec.shutdown();
 		try {
-			exec.awaitTermination(20, TimeUnit.HOURS);
+			exec.awaitTermination(40, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			// restore interrupted status
 			Thread.currentThread().interrupt();

--- a/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
@@ -176,7 +176,7 @@ public class QProfiler2 {
 		// don't allow any new tasks to be executed
 		exec.shutdown();
 		try {
-			exec.awaitTermination(40, TimeUnit.HOURS);
+			exec.awaitTermination(100, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			// restore interrupted status
 			Thread.currentThread().interrupt();

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizerMT2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizerMT2.java
@@ -136,9 +136,9 @@ public class BamSummarizerMT2 implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 20 hours)");
-			if ( ! pLatch.await(20, TimeUnit.HOURS)) {
-				// we've hit the 20 hour limit - shutdown the threads and throw an exception
+			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
+			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
+				// we've hit the 40 hour limit - shutdown the threads and throw an exception
 				producerThreads.shutdownNow();
 				consumerThreads.shutdownNow();
 				throw new Exception("Producer thread has timed out");

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizerMT2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizerMT2.java
@@ -136,13 +136,8 @@ public class BamSummarizerMT2 implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
-			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
-				// we've hit the 40 hour limit - shutdown the threads and throw an exception
-				producerThreads.shutdownNow();
-				consumerThreads.shutdownNow();
-				throw new Exception("Producer thread has timed out");
-			}
+			logger.info("waiting for Producer thread to finish");
+			pLatch.await();
 			logger.info("producer thread finished, queue size: " +   getQueueSize(queues)   );
 			
 			if ( ! cLatch.await(30, TimeUnit.SECONDS)) {

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummarizerMT.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummarizerMT.java
@@ -71,9 +71,9 @@ public class FastqSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 20 hours)");
-			if ( ! pLatch.await(20, TimeUnit.HOURS)) {
-				// we've hit the 20 hour limit - shutdown the threads and throw an exception
+			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
+			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
+				// we've hit the 40 hour limit - shutdown the threads and throw an exception
 				producerThreads.shutdownNow();
 				consumerThreads.shutdownNow();
 				throw new Exception("Producer thread has timed out");

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummarizerMT.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummarizerMT.java
@@ -71,13 +71,8 @@ public class FastqSummarizerMT implements Summarizer {
 		
 		// wait for threads to complete
 		try {
-			logger.info("waiting for Producer thread to finish (max wait will be 40 hours)");
-			if ( ! pLatch.await(40, TimeUnit.HOURS)) {
-				// we've hit the 40 hour limit - shutdown the threads and throw an exception
-				producerThreads.shutdownNow();
-				consumerThreads.shutdownNow();
-				throw new Exception("Producer thread has timed out");
-			}
+			logger.info("waiting for Producer thread to finish");
+			pLatch.await();
 			logger.info("producer thread finished, queue size: " + q.size());
 			
 			if ( ! cLatch.await(30, TimeUnit.SECONDS)) {

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
 import org.qcmg.common.util.LoadReferencedClasses;
 import org.qcmg.sig.model.Comparison;
@@ -192,7 +193,7 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 		}
 		service.shutdown();
 		try {
-			if ( ! service.awaitTermination(100, TimeUnit.HOURS)) {
+			if ( ! service.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS)) {
 				logger.info("Timed out getting data from threads");
 			}
 		} catch (InterruptedException e) {
@@ -236,7 +237,7 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 		}
 		service.shutdown();
 		try {
-			if ( ! service.awaitTermination(100, TimeUnit.HOURS)) {
+			if ( ! service.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS)) {
 				logger.info("Timed out getting data from threads");
 			}
 		} catch (InterruptedException e) {

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
@@ -216,8 +216,16 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 						try {
 							genotypes = SignatureUtil.loadSignatureRatiosFloatGenotype(f, minimumCoverage, homCutoff, hetUpperCutoff, hetLowerCutoff);
 						} catch (Exception e) {
-							// TODO Auto-generated catch block
+							/*
+							 * set exit status, log exception and re-throw
+							 */
+							exitStatus = 1;
 							e.printStackTrace();
+							try {
+								throw e;
+							} catch (Exception e1) {
+								e1.printStackTrace();
+							}
 						}
 						TIntShortHashMap prevGenotypes = cache.putIfAbsent(f, genotypes);
 						if (null != prevGenotypes) {

--- a/qsignature/src/org/qcmg/sig/SignatureFindRelated.java
+++ b/qsignature/src/org/qcmg/sig/SignatureFindRelated.java
@@ -26,6 +26,7 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.util.ChrPositionUtils;
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.DonorUtils;
 import org.qcmg.common.util.FileUtils;
 import org.qcmg.common.util.LoadReferencedClasses;
@@ -161,7 +162,7 @@ public class SignatureFindRelated {
 			}
 		});
 		service.shutdown();
-		if ( ! service.awaitTermination(100, TimeUnit.HOURS)) {
+		if ( ! service.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS)) {
 			
 			logger.info("Timed out getting data from threads");
 			return -1;

--- a/qsignature/src/org/qcmg/sig/SignatureFindRelatedMulti.java
+++ b/qsignature/src/org/qcmg/sig/SignatureFindRelatedMulti.java
@@ -33,6 +33,7 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.util.ChrPositionUtils;
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.DonorUtils;
 import org.qcmg.common.util.FileUtils;
 import org.qcmg.common.util.LoadReferencedClasses;
@@ -167,7 +168,7 @@ public class SignatureFindRelatedMulti {
 			});
 		}
 		service.shutdown();
-		if ( ! service.awaitTermination(100, TimeUnit.HOURS)) {
+		if ( ! service.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS)) {
 			
 			logger.info("Timed out getting data from threads");
 			return -1;

--- a/qsignature/src/org/qcmg/sig/SignatureGenerator.java
+++ b/qsignature/src/org/qcmg/sig/SignatureGenerator.java
@@ -604,7 +604,7 @@ public class SignatureGenerator {
 		
 		// wait till the producer count down latch has hit zero
 		try {
-			pLatch.await(40, TimeUnit.HOURS);
+			pLatch.await();
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Producer thread");
@@ -612,7 +612,7 @@ public class SignatureGenerator {
 		
 		// and now the consumer latch
 		try {
-			cLatch.await(10, TimeUnit.HOURS);
+			cLatch.await();
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Consumer thread");

--- a/qsignature/src/org/qcmg/sig/SignatureGenerator.java
+++ b/qsignature/src/org/qcmg/sig/SignatureGenerator.java
@@ -604,7 +604,7 @@ public class SignatureGenerator {
 		
 		// wait till the producer count down latch has hit zero
 		try {
-			pLatch.await(10, TimeUnit.HOURS);
+			pLatch.await(40, TimeUnit.HOURS);
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Producer thread");
@@ -612,7 +612,7 @@ public class SignatureGenerator {
 		
 		// and now the consumer latch
 		try {
-			cLatch.await(1, TimeUnit.HOURS);
+			cLatch.await(10, TimeUnit.HOURS);
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Consumer thread");

--- a/qsignature/src/org/qcmg/sig/SignatureGeneratorBespoke.java
+++ b/qsignature/src/org/qcmg/sig/SignatureGeneratorBespoke.java
@@ -552,7 +552,7 @@ public class SignatureGeneratorBespoke {
 		
 		// wait till the producer count down latch has hit zero
 		try {
-			pLatch.await(40, TimeUnit.HOURS);
+			pLatch.await(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Producer thread");
@@ -560,7 +560,7 @@ public class SignatureGeneratorBespoke {
 		
 		// and now the consumer latch
 		try {
-			cLatch.await(10, TimeUnit.HOURS);
+			cLatch.await(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Consumer thread");

--- a/qsignature/src/org/qcmg/sig/SignatureGeneratorBespoke.java
+++ b/qsignature/src/org/qcmg/sig/SignatureGeneratorBespoke.java
@@ -552,7 +552,7 @@ public class SignatureGeneratorBespoke {
 		
 		// wait till the producer count down latch has hit zero
 		try {
-			pLatch.await(10, TimeUnit.HOURS);
+			pLatch.await(40, TimeUnit.HOURS);
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Producer thread");
@@ -560,7 +560,7 @@ public class SignatureGeneratorBespoke {
 		
 		// and now the consumer latch
 		try {
-			cLatch.await(1, TimeUnit.HOURS);
+			cLatch.await(10, TimeUnit.HOURS);
 		} catch (final InterruptedException e) {
 			e.printStackTrace();
 			throw new Exception("Exception caught in Consumer thread");

--- a/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
+++ b/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
@@ -32,6 +32,7 @@ import htsjdk.samtools.SAMRecordIterator;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.string.StringUtils;
+import org.qcmg.common.util.Constants;
 import org.qcmg.picard.HeaderUtils;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qbamfilter.query.QueryExecutor;
@@ -162,8 +163,8 @@ public class AnnotateFilterMT implements Runnable {
 			writeThreads.shutdown();
 
 			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-			filterThreads.awaitTermination(100, TimeUnit.HOURS);
-			writeThreads.awaitTermination(20, TimeUnit.HOURS);
+			filterThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+			writeThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
 			if (readQueue.size() != 0 || writeQueue.size() != 0 || writeClipQueue.size() != 0) {
 				throw new Exception(

--- a/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
+++ b/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
@@ -161,9 +161,9 @@ public class AnnotateFilterMT implements Runnable {
 			writeThreads.execute(new Writing(writeClipQueue, clippedFile, Thread.currentThread(), filterLatch, writeLatch, coordinateHeader));
 			writeThreads.shutdown();
 
-			logger.info("waiting for  threads to finish (max wait will be 20 hours)");
-			filterThreads.awaitTermination(60, TimeUnit.HOURS);
-			writeThreads.awaitTermination(60, TimeUnit.HOURS);
+			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+			filterThreads.awaitTermination(100, TimeUnit.HOURS);
+			writeThreads.awaitTermination(20, TimeUnit.HOURS);
 
 			if (readQueue.size() != 0 || writeQueue.size() != 0 || writeClipQueue.size() != 0) {
 				throw new Exception(

--- a/qsv/src/org/qcmg/qsv/discordantpair/FindDiscordantPairClustersMT.java
+++ b/qsv/src/org/qcmg/qsv/discordantpair/FindDiscordantPairClustersMT.java
@@ -284,7 +284,7 @@ public class FindDiscordantPairClustersMT implements Callable <Map<String, List<
 		service.shutdown();
 		
 		try {
-			service.awaitTermination(40, TimeUnit.HOURS);
+			service.awaitTermination(100, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			logger.warn("Thread interrupted while running ClusterClassifier");
 			Thread.currentThread().interrupt();

--- a/qsv/src/org/qcmg/qsv/discordantpair/FindDiscordantPairClustersMT.java
+++ b/qsv/src/org/qcmg/qsv/discordantpair/FindDiscordantPairClustersMT.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.util.Constants;
 import org.qcmg.qsv.QSVParameters;
 import org.qcmg.qsv.report.SVCountReport;
 import org.qcmg.qsv.util.QSVUtil;
@@ -284,7 +285,7 @@ public class FindDiscordantPairClustersMT implements Callable <Map<String, List<
 		service.shutdown();
 		
 		try {
-			service.awaitTermination(100, TimeUnit.HOURS);
+			service.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			logger.warn("Thread interrupted while running ClusterClassifier");
 			Thread.currentThread().interrupt();

--- a/qsv/src/org/qcmg/qsv/discordantpair/FindDiscordantPairClustersMT.java
+++ b/qsv/src/org/qcmg/qsv/discordantpair/FindDiscordantPairClustersMT.java
@@ -284,7 +284,7 @@ public class FindDiscordantPairClustersMT implements Callable <Map<String, List<
 		service.shutdown();
 		
 		try {
-			service.awaitTermination(10, TimeUnit.HOURS);
+			service.awaitTermination(40, TimeUnit.HOURS);
 		} catch (InterruptedException e) {
 			logger.warn("Thread interrupted while running ClusterClassifier");
 			Thread.currentThread().interrupt();

--- a/qsv/src/org/qcmg/qsv/isize/SAMRecordCounterMT.java
+++ b/qsv/src/org/qcmg/qsv/isize/SAMRecordCounterMT.java
@@ -26,6 +26,7 @@ import htsjdk.samtools.SAMRecord;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qsv.QSVException;
 import org.qcmg.qsv.annotate.RunTypeRecord;
@@ -80,8 +81,8 @@ public class SAMRecordCounterMT {
             }
             processThreads.shutdown();
 
-            readThread.awaitTermination(100, TimeUnit.HOURS);
-            processThreads.awaitTermination(20, TimeUnit.HOURS);
+            readThread.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            processThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
 
             if (readQueue.size() != 0) {

--- a/qsv/src/org/qcmg/qsv/isize/SAMRecordCounterMT.java
+++ b/qsv/src/org/qcmg/qsv/isize/SAMRecordCounterMT.java
@@ -80,8 +80,8 @@ public class SAMRecordCounterMT {
             }
             processThreads.shutdown();
 
-            readThread.awaitTermination(60, TimeUnit.HOURS);
-            processThreads.awaitTermination(60, TimeUnit.HOURS);
+            readThread.awaitTermination(100, TimeUnit.HOURS);
+            processThreads.awaitTermination(20, TimeUnit.HOURS);
 
 
             if (readQueue.size() != 0) {

--- a/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
+++ b/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
@@ -179,8 +179,8 @@ public class FindClipClustersMT  {
 			}
 			filterThreads.shutdown();            
 
-			logger.info("waiting for  threads to finish (max wait will be 60 hours)");
-			filterThreads.awaitTermination(60, TimeUnit.HOURS);
+			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+			filterThreads.awaitTermination(100, TimeUnit.HOURS);
 
 			if (readQueue.size() != 0) {
 				throw new Exception(
@@ -232,7 +232,7 @@ public class FindClipClustersMT  {
 						.currentThread(), overlapLatch));
 			}
 			overlapThreads.shutdown();
-			overlapThreads.awaitTermination(60, TimeUnit.HOURS);
+			overlapThreads.awaitTermination(100, TimeUnit.HOURS);
 		} catch (Exception e) {
 			logger.error("Setting exit status in 1 as exception caught: "
 					+ QSVUtil.getStrackTrace(e));
@@ -651,7 +651,7 @@ public class FindClipClustersMT  {
 			executorService.shutdown();
 
 			try {
-				executorService.awaitTermination(60, TimeUnit.HOURS);                  
+				executorService.awaitTermination(100, TimeUnit.HOURS);                  
 
 			} catch (InterruptedException e) {             
 				logger.error("Interrupted exception caught (b): "
@@ -929,7 +929,7 @@ public class FindClipClustersMT  {
 				executorService.shutdown();
 
 				try {
-					executorService.awaitTermination(60, TimeUnit.HOURS);                   
+					executorService.awaitTermination(100, TimeUnit.HOURS);                   
 
 				} catch (InterruptedException e) {             
 					logger.error("Interrupted exception caught (c): "

--- a/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
+++ b/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.util.Constants;
 import org.qcmg.qsv.Chromosome;
 import org.qcmg.qsv.Options;
 import org.qcmg.qsv.QSVCluster;
@@ -180,7 +181,7 @@ public class FindClipClustersMT  {
 			filterThreads.shutdown();            
 
 			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-			filterThreads.awaitTermination(100, TimeUnit.HOURS);
+			filterThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
 			if (readQueue.size() != 0) {
 				throw new Exception(
@@ -232,7 +233,7 @@ public class FindClipClustersMT  {
 						.currentThread(), overlapLatch));
 			}
 			overlapThreads.shutdown();
-			overlapThreads.awaitTermination(100, TimeUnit.HOURS);
+			overlapThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 		} catch (Exception e) {
 			logger.error("Setting exit status in 1 as exception caught: "
 					+ QSVUtil.getStrackTrace(e));
@@ -651,7 +652,7 @@ public class FindClipClustersMT  {
 			executorService.shutdown();
 
 			try {
-				executorService.awaitTermination(100, TimeUnit.HOURS);                  
+				executorService.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);                  
 
 			} catch (InterruptedException e) {             
 				logger.error("Interrupted exception caught (b): "
@@ -929,7 +930,7 @@ public class FindClipClustersMT  {
 				executorService.shutdown();
 
 				try {
-					executorService.awaitTermination(100, TimeUnit.HOURS);                   
+					executorService.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);                   
 
 				} catch (InterruptedException e) {             
 					logger.error("Interrupted exception caught (c): "


### PR DESCRIPTION
# Description

Doubled the time that a thread can run for before being killed (from 20 hours to 40 hours).
This change has been made to multiple projects.
Only instances where the `await` time was less than 40 hours has this change been made (eg. there are a couple of instances were the `await` time has been set to over 100 hours. I did not double these times)


Fixes #116 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Existing unit test have been run. No new tests have been introduced.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
