### PR TITLE
update help and usage message

### DIFF
--- a/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
+++ b/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
@@ -250,7 +250,7 @@ public class CompareGenotypeBespoke {
 				logger.error("Exception caught whilst running CompareGenotypeBespoke:", e);
 			else {
 				System.err.println("Exception caught whilst running CompareGenotypeBespoke: " + e.getMessage());
-				System.err.println(Messages.USAGE);
+				System.err.println(Messages.COMPARE_USAGE);
 			}
 		}
 		
@@ -263,20 +263,21 @@ public class CompareGenotypeBespoke {
 	protected int setup(String args[]) throws Exception{
 		int returnStatus = 1;
 		if (null == args || args.length == 0) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			System.exit(1);
 		}
 		Options options = new Options(args);
 
 		if (options.hasHelpOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			options.displayHelp();
 			returnStatus = 0;
 		} else if (options.hasVersionOption()) {
 			System.err.println(Messages.getVersionMessage());
 			returnStatus = 0;
 		} else if ( ! options.hasLogOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
+			options.displayHelp();
 		} else {
 			// configure logging
 			logFile = options.getLog();

--- a/qsignature/src/org/qcmg/sig/CompareIlluminaData.java
+++ b/qsignature/src/org/qcmg/sig/CompareIlluminaData.java
@@ -221,22 +221,24 @@ public class CompareIlluminaData {
 	protected int setup(String args[]) throws Exception{
 		int returnStatus = 1;
 		if (null == args || args.length == 0) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			System.exit(1);
 		}
 		Options options = new Options(args);
 
 		if (options.hasHelpOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			options.displayHelp();
 			returnStatus = 0;
 		} else if (options.hasVersionOption()) {
 			System.err.println(Messages.getVersionMessage());
 			returnStatus = 0;
 		} else if (options.getInputFileNames().length < 1) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
+			options.displayHelp();
 		} else if ( ! options.hasLogOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
+			options.displayHelp();
 		} else {
 			// configure logging
 			logFile = options.getLog();

--- a/qsignature/src/org/qcmg/sig/CompareRGGenotype.java
+++ b/qsignature/src/org/qcmg/sig/CompareRGGenotype.java
@@ -280,7 +280,7 @@ public class CompareRGGenotype {
 				logger.error("Exception caught whilst running CompareRGGenotype:", e);
 			else {
 				System.err.println("Exception caught whilst running CompareRGGenotype: " + e.getMessage());
-				System.err.println(Messages.USAGE);
+				System.err.println(Messages.COMPARE_USAGE);
 			}
 		}
 		
@@ -293,20 +293,21 @@ public class CompareRGGenotype {
 	protected int setup(String args[]) throws Exception{
 		int returnStatus = 1;
 		if (null == args || args.length == 0) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			System.exit(1);
 		}
 		Options options = new Options(args);
 
 		if (options.hasHelpOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			options.displayHelp();
 			returnStatus = 0;
 		} else if (options.hasVersionOption()) {
 			System.err.println(Messages.getVersionMessage());
 			returnStatus = 0;
 		} else if ( ! options.hasLogOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
+			options.displayHelp();
 		} else {
 			// configure logging
 			logFile = options.getLog();

--- a/qsignature/src/org/qcmg/sig/Messages.java
+++ b/qsignature/src/org/qcmg/sig/Messages.java
@@ -11,6 +11,7 @@ final class Messages {
 			.getBundle("org.qcmg.sig.messages");
 	static final String ERROR_PREFIX = getProgramName() + ": ";
 	static final String USAGE = getMessage("USAGE");
+	static final String COMPARE_USAGE = getMessage("COMPARE_USAGE");
 
 	static String getMessage(final String identifier) {
 		return messages.getString(identifier);

--- a/qsignature/src/org/qcmg/sig/Messages.java
+++ b/qsignature/src/org/qcmg/sig/Messages.java
@@ -12,6 +12,7 @@ final class Messages {
 	static final String ERROR_PREFIX = getProgramName() + ": ";
 	static final String USAGE = getMessage("USAGE");
 	static final String COMPARE_USAGE = getMessage("COMPARE_USAGE");
+	static final String GENERATOR_USAGE = getMessage("GENERATOR_USAGE");
 
 	static String getMessage(final String identifier) {
 		return messages.getString(identifier);

--- a/qsignature/src/org/qcmg/sig/Options.java
+++ b/qsignature/src/org/qcmg/sig/Options.java
@@ -103,7 +103,7 @@ final class Options {
 				.describedAs("Additional Search string");
 		parser.accepts("excludeString", "Qsig vcf filenames that contain the suppled excludes string will be excluded").withRequiredArg().ofType(String.class)
 				.describedAs("Excluded strings");
-		parser.accepts("illuminaArraysDesign", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("illuminaArraysDesign", "Illumina arrays design document - contains list of snp ids and whether they should be complemented").withRequiredArg().ofType(String.class)
 				.describedAs("Illumina Arrays Design file");
 		parser.accepts("email", "email address to send output to").withRequiredArg().ofType(String.class)
 				.describedAs("email");

--- a/qsignature/src/org/qcmg/sig/Options.java
+++ b/qsignature/src/org/qcmg/sig/Options.java
@@ -84,35 +84,35 @@ final class Options {
 			.describedAs("minBaseQuality");
 		parser.accepts("cutoff", CUT_OFF_OPTION_DESCRIPTION).withRequiredArg().ofType(Float.class)
 			.describedAs("cutoff");
-		parser.accepts("homCutoff", CUT_OFF_OPTION_DESCRIPTION).withRequiredArg().ofType(Float.class)
+		parser.accepts("homCutoff", "Cutoff for homozygous positions (defaults to 0.9)").withRequiredArg().ofType(Float.class)
 		.describedAs("homCutoff");
-		parser.accepts("hetUpperCutoff", CUT_OFF_OPTION_DESCRIPTION).withRequiredArg().ofType(Float.class)
+		parser.accepts("hetUpperCutoff", "Cutoff for upper heterozygous positions (defaults to 0.7). Position will be considered a heterozygous position if its VAF is between the upper and lower het cutoffs").withRequiredArg().ofType(Float.class)
 		.describedAs("hetUpperCutoff");
-		parser.accepts("hetLowerCutoff", CUT_OFF_OPTION_DESCRIPTION).withRequiredArg().ofType(Float.class)
+		parser.accepts("hetLowerCutoff", "Cutoff for upper heterozygous positions (defaults to 0.3). Position will be considered a heterozygous position if its VAF is between the upper and lower het cutoffs").withRequiredArg().ofType(Float.class)
 		.describedAs("hetLowerCutoff");
 		parser.accepts("noOfThreads", NO_OF_THREADS_OPTION_DESCRIPTION).withRequiredArg().ofType(Integer.class)
 			.describedAs("noOfThreads");
 		parser.accepts("snpPositions", SNP_POSITION_DESCRIPTION).withRequiredArg().ofType(String.class)
 			.describedAs("snpPositions");
 		parser.accepts("sequential", SEQUENTIAL_OPTION_DESCRIPTION);
-		parser.accepts("searchSuffix", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("searchSuffix", "If option is specified, files must end with the supplied suffix").withRequiredArg().ofType(String.class)
 				.describedAs("Search suffix");
-		parser.accepts("snpChipSearchSuffix", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("snpChipSearchSuffix", "If option is specified, snp chip files must end with the supplied suffix").withRequiredArg().ofType(String.class)
 				.describedAs("Snp Chip Search Suffix");
-		parser.accepts("additionalSearchString", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("additionalSearchString", "qsig vcf filenames must match any strings supplied by this option. If they don't match, they will not be included in the comparison").withRequiredArg().ofType(String.class)
 				.describedAs("Additional Search string");
-		parser.accepts("excludeString", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("excludeString", "Qsig vcf filenames that contain the suppled excludes string will be excluded").withRequiredArg().ofType(String.class)
 				.describedAs("Excluded strings");
 		parser.accepts("illuminaArraysDesign", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
 				.describedAs("Illumina Arrays Design file");
-		parser.accepts("email", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("email", "email address to send output to").withRequiredArg().ofType(String.class)
 				.describedAs("email");
-		parser.accepts("emailSubject", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("emailSubject", "subject line for email").withRequiredArg().ofType(String.class)
 				.describedAs("emailSubject");
-		parser.accepts("excludeVcfsFile", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+		parser.accepts("excludeVcfsFile", "file containing a list of vcf files to ignore in the comparison").withRequiredArg().ofType(String.class)
 				.describedAs("excludeVcfsFile");
 		parser.accepts("validation", VALIDATION_STRINGENCY_OPTION_DESCRIPTION).withRequiredArg().ofType(String.class);
-		parser.acceptsAll(asList("p", "position"), INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("position");
+		parser.acceptsAll(asList("p", "position"), "File containing a list of positions that will be examined. Must be a subset of the positions in the snpPositions file").withRequiredArg().ofType(String.class).describedAs("position");
 		options = parser.parse(args);
 
 		List inputList = options.valuesOf("i");

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotype.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotype.java
@@ -239,7 +239,7 @@ public class SignatureCompareRelatedSimpleGenotype {
 				logger.error("Exception caught whilst running SignatureCompareRelatedSimple:", e);
 			else {
 				System.err.println("Exception caught whilst running SignatureCompareRelatedSimple: " + e.getMessage());
-				System.err.println(Messages.USAGE);
+				System.err.println(Messages.COMPARE_USAGE);
 			}
 		}
 		
@@ -252,20 +252,24 @@ public class SignatureCompareRelatedSimpleGenotype {
 	protected int setup(String args[]) throws Exception{
 		int returnStatus = 1;
 		if (null == args || args.length == 0) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			System.exit(1);
 		}
 		Options options = new Options(args);
 
 		if (options.hasHelpOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			options.displayHelp();
 			returnStatus = 0;
 		} else if (options.hasVersionOption()) {
 			System.err.println(Messages.getVersionMessage());
 			returnStatus = 0;
 		} else if ( ! options.hasLogOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
+			options.displayHelp();
+		} else if ( options.getDirNames().length == 0) {
+			System.err.println(Messages.COMPARE_USAGE);
+			options.displayHelp();
 		} else {
 			// configure logging
 			logFile = options.getLog();

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
@@ -216,8 +216,16 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 						try {
 							genotypes = SignatureUtil.loadSignatureRatiosFloatGenotype(f, minimumCoverage, homCutoff, hetUpperCutoff, hetLowerCutoff);
 						} catch (Exception e) {
-							// TODO Auto-generated catch block
+							/*
+							 * set exit status, log exception and re-throw
+							 */
+							exitStatus = 1;
 							e.printStackTrace();
+							try {
+								throw e;
+							} catch (Exception e1) {
+								e1.printStackTrace();
+							}
 						}
 						TIntShortHashMap prevGenotypes = cache.putIfAbsent(f, genotypes);
 						if (null != prevGenotypes) {
@@ -272,20 +280,21 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 	protected int setup(String args[]) throws Exception{
 		int returnStatus = 1;
 		if (null == args || args.length == 0) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			System.exit(1);
 		}
 		Options options = new Options(args);
 
 		if (options.hasHelpOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
 			options.displayHelp();
 			returnStatus = 0;
 		} else if (options.hasVersionOption()) {
 			System.err.println(Messages.getVersionMessage());
 			returnStatus = 0;
 		} else if ( ! options.hasLogOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.COMPARE_USAGE);
+			options.displayHelp();
 		} else {
 			// configure logging
 			logFile = options.getLog();

--- a/qsignature/src/org/qcmg/sig/SignatureGenerator.java
+++ b/qsignature/src/org/qcmg/sig/SignatureGenerator.java
@@ -695,22 +695,22 @@ public class SignatureGenerator {
 	protected int setup(String args[]) throws Exception{
 		int returnStatus = 1;
 		if (null == args || args.length == 0) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 			System.exit(1);
 		}
 		final Options options = new Options(args);
 
 		if (options.hasHelpOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 			options.displayHelp();
 			returnStatus = 0;
 		} else if (options.hasVersionOption()) {
 			System.err.println(Messages.getVersionMessage());
 			returnStatus = 0;
 		} else if (options.getInputFileNames().length < 1) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 		} else if ( ! options.hasLogOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 		} else {
 			// configure logging
 			logFile = options.getLog();

--- a/qsignature/src/org/qcmg/sig/SignatureGeneratorBespoke.java
+++ b/qsignature/src/org/qcmg/sig/SignatureGeneratorBespoke.java
@@ -643,22 +643,22 @@ public class SignatureGeneratorBespoke {
 	protected int setup(String args[]) throws Exception{
 		int returnStatus = 1;
 		if (null == args || args.length == 0) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 			System.exit(1);
 		}
 		final Options options = new Options(args);
 
 		if (options.hasHelpOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 			options.displayHelp();
 			returnStatus = 0;
 		} else if (options.hasVersionOption()) {
 			System.err.println(Messages.getVersionMessage());
 			returnStatus = 0;
 		} else if (options.getInputFileNames().length < 1) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 		} else if ( ! options.hasLogOption()) {
-			System.err.println(Messages.USAGE);
+			System.err.println(Messages.GENERATOR_USAGE);
 		} else {
 			// configure logging
 			logFile = options.getLog();

--- a/qsignature/src/org/qcmg/sig/messages.properties
+++ b/qsignature/src/org/qcmg/sig/messages.properties
@@ -1,4 +1,5 @@
 USAGE = usage: qsignature ToolName [-options] (See https://qcmg-wiki.imb.uq.edu.au/index.php/Qsignature for more details)
+COMPARE_USAGE = usage: qsignature org.qcmg.sig.<CompareTool> -log <log_file> -dir <directory in which to search for .qsig.xml files> -output <output xml file>
 MISSING_INPUT_OPTIONS = You must specify at least one -i option
 MISSING_DIRECTORY_OPTION = You must specify a -d option indicating the path to be used to find signature files
 INSUFFICIENT_INPUT_FILES = Insufficient input files
@@ -27,6 +28,6 @@ UNKNOWN_ERROR = An unknown error has occurred
 INPUT_FILE_READ_ERROR = Could not read input file {0}
 MIN_COVERAGE_OPTION_DESCRIPTION = Specifies the minimum coverage to be used in the comparison
 CUTOFF_OPTION_DESCRIPTION = Specifies the cutoff value to be used in the comparison
-NO_OF_THREADS_OPTION_DESCRIPTION = Specifies the number of threads to be used when retireving positions from bam files
+NO_OF_THREADS_OPTION_DESCRIPTION = Specifies the number of threads to be used when retrieving positions from bam files
 SEQUENTIAL_OPTION_DESCRIPTION = Specifies that bam access should be sequential rather than indexed
 VALIDATION_STRINGENCY_DESCRIPTION = How strict to be when reading a SAM or BAM. Possible values: {STRICT, LENIENT, SILENT}

--- a/qsignature/src/org/qcmg/sig/messages.properties
+++ b/qsignature/src/org/qcmg/sig/messages.properties
@@ -1,5 +1,6 @@
-USAGE = usage: qsignature ToolName [-options] (See https://qcmg-wiki.imb.uq.edu.au/index.php/Qsignature for more details)
-COMPARE_USAGE = usage: qsignature org.qcmg.sig.<CompareTool> -log <log_file> -dir <directory in which to search for .qsig.xml files> -output <output xml file>
+USAGE = usage: qsignature [org.qcmg.sig.SignatureGeneratorBespoke | org.qcmg.sig.CompareGenotypeBespoke] [-options]
+COMPARE_USAGE = usage: qsignature org.qcmg.sig.CompareGenotypeBespoke -log <log_file> -dir <directory in which to search for .qsig.xml files> -output <output xml file>
+GENERATOR_USAGE = usage: qsignature org.qcmg.sig.SignatureGeneratorBespoke -snpPositions <file containing positions of interest> -illuminaArraysDesign <Illumina arrays design document - contains list of snp ids and whether they should be complemented> -input <bam or snp chip file, or folder containing bams or snp chip files> -output <output directory where qsig.xml files will be written to> -log <log_file>
 MISSING_INPUT_OPTIONS = You must specify at least one -i option
 MISSING_DIRECTORY_OPTION = You must specify a -d option indicating the path to be used to find signature files
 INSUFFICIENT_INPUT_FILES = Insufficient input files


### PR DESCRIPTION
# Description

The help and usage information when running `qsignature` tools is not very helpful. It points you to a qcmg wiki page that is no longer accessible.
This change hopes to fix that!

eg. the output of the following command:` java -cp ~/qsignature/bin/qsignature-1.0.jar org.qcmg.sig.CompareGenotypeBespoke`

goes from :
```
usage: qsignature ToolName [-options] (See https://qcmg-wiki.imb.uq.edu.au/index.php/Qsignature for more details)
```
to
```
usage: qsignature org.qcmg.sig.<CompareTool> -log <log_file> -dir <directory in which to search for .qsig.xml files> -output <output xml file>
```

Fixes #115 

I also put in some code that propagates an exception that is thrown from a thread. Previously, the program would return an exit code of `0` even when a thread encountered a problem and threw an exception causing the overall program to fail.
The program now returns a non-zero (`1`) return code when a thread encounters a problem and throws an exception.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

An updated jar file has been built and run, and the output has been examined

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
