### PR TITLE
new Compare class that performs comparison regardless of underlying v…

### DIFF
--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -6,72 +6,70 @@
  */
 package org.qcmg.sig;
 
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntShortHashMap;
-
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-
+import org.apache.commons.math3.util.Pair;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
-import org.qcmg.common.util.DonorUtils;
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
 import org.qcmg.common.util.LoadReferencedClasses;
 import org.qcmg.sig.model.Comparison;
+import org.qcmg.sig.model.SigMeta;
 import org.qcmg.sig.util.ComparisonUtil;
 import org.qcmg.sig.util.SignatureUtil;
+
+import gnu.trove.map.TMap;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntShortHashMap;
+import gnu.trove.set.hash.THashSet;
 
 /**
  * This class gets a list of all .qsig.vcf files from the supplied path.
  * It then performs a comparison between them all, regardless of whether they are bam or snp chip files
- * An xml output file is produced
- * If any comparison scores are less than the cutoff, they are added to a list, which is then emailed to interested parties informing them of the potential problem files
+ * 
+ * If the SigMeta for the files being compared are eligible for comparison, then they will be compared.
+ * If one (or both) of the SigMeta's is inValid, they will still be compared.
+ * If both SigMetas are valid, but not eligible for comparison, then they will not be compared.
+ * This is to get around the issue where we have some data sets sporting the 
+ * new "bespoke" vcf format, and others with the "traditional" vcf format.
+ * 
+ * An xml output file is produced.
  *  
  * @author o.holmes
- * @Deprecated use Compare instead
  *
  */
-@Deprecated
-public class SignatureCompareRelatedSimpleGenotype {
+public class Compare {
 	
 	private static QLogger logger;
 	private int exitStatus;
 	
-	
-	private float cutoff = 0.2f;
+	private float cutoff = 0.95f;
 	private int minimumCoverage = 10;
-	
-//	private final int cacheSize = 700;
+	private int minimumRGCoverage = 10;
 	
 	private String outputXml;
 	private String [] paths;
 	private String [] additionalSearchStrings;
-	private String donor;
-//	private static final String QSIG_SUFFIX = ".qsig.vcf";
 	
 	private String excludeVcfsFile;
 	private List<String> excludes;
 	private String logFile;
 	
-	private float homCutoff = SignatureUtil.HOM_CUTOFF;
-	private float hetUpperCutoff = SignatureUtil.HET_UPPER_CUTOFF;
-	private float hetLowerCutoff = SignatureUtil.HET_LOWER_CUTOFF;
-	
 	private final Map<String, int[]> fileIdsAndCounts = new THashMap<>();
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
-//	private final Map<File, Map<ChrPosition, float[]>> cache = new THashMap<>(cacheSize * 2);
-	private final Map<File, TIntShortHashMap> cache = new THashMap<>();
+	private final Map<File, Pair<SigMeta,TIntShortHashMap>> cache = new THashMap<>();
 	
-	List<String> suspiciousResults = new ArrayList<String>();
+	List<String> suspiciousResults = new ArrayList<>();
 	
 	private int engage() throws Exception {
 		
@@ -79,9 +77,9 @@ public class SignatureCompareRelatedSimpleGenotype {
 		logger.info("Retrieving excludes list from: " + excludeVcfsFile);
 		excludes = SignatureUtil.getEntriesFromExcludesFile(excludeVcfsFile);
 		
-		// get qsig vcf files for this donor
+		// get qsig vcf files
 		logger.info("Retrieving qsig vcf files from: " + Arrays.stream(paths).collect(Collectors.joining(",")));
-		Set<File> uniqueFiles = new HashSet<>();
+		Set<File> uniqueFiles = new THashSet<>();
 		for (String path : paths) {
 			uniqueFiles.addAll(FileUtils.findFilesEndingWithFilterNIO(path, SignatureUtil.QSIG_VCF));
 		}
@@ -102,9 +100,6 @@ public class SignatureCompareRelatedSimpleGenotype {
 			return 0;
 		}
 		
-		
-		
-		
 		/*
 		 * Match files on additionalSearchStrings
 		 */
@@ -116,64 +111,57 @@ public class SignatureCompareRelatedSimpleGenotype {
 		}
 		
 		
-		logger.info("Should have " + (files.size() -1) + " + " + (files.size() -2) + " ...  comparisons");
+		final int numberOfFiles = files.size();
+		final int numberOfComparisons = ((numberOfFiles * (numberOfFiles -1)) /2);
+		logger.info("Should have " +numberOfComparisons + " comparisons, based on " + numberOfFiles + " input files");
 		
 		files.sort(FileUtils.FILE_COMPARATOR);
 		
 		// add files to map
 		addFilesToMap(files);
 		
-		if (donor == null) {
-			donor = DonorUtils.getDonorFromFilename(files.get(0).getAbsolutePath());
-			if (null == donor) {
-				logger.warn("Could not get donor information from file: " + files.get(0).getAbsolutePath());
-			}
-		}
-		
-		StringBuilder donorSB = new StringBuilder(donor + "\n");
-		
+		StringBuilder sb = new StringBuilder();
 		
 		int size = files.size();
 		
 		for (int i = 0 ; i < size -1 ; i++) {
 			
-			if (i % 10 == 0) {
-				logger.info("Have loaded data from " + i + " files");
-			}
-				
-			
 			File f1 = files.get(i);
-//			Map<ChrPosition, float[]> ratios1 = getSignatureData(f1);
-			TIntShortHashMap ratios1 = getSignatureData(f1);
+			Pair<SigMeta, TIntShortHashMap> ratios1 = getSignatureData(f1);
 			
 			for (int j = i + 1 ; j < size ; j++) {
 				File f2 = files.get(j);
-//				Map<ChrPosition, float[]> ratios2 = getSignatureData(f2);
-				TIntShortHashMap ratios2 = getSignatureData(f2);
+				Pair<SigMeta, TIntShortHashMap> ratios2 = getSignatureData(f2);
 				
-//				Comparison comp = QSigCompareDistance.compareRatiosFloat(ratios1, ratios2, f1, f2, null);
-				Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1, ratios2, f1, f2);
-				donorSB.append(comp.toString()).append("\n");
-				allComparisons.add(comp);
+				/*
+				 * If both sig metas are valid, check to see if they are suitable for comparison (same snp positions file and have had the same filters applied).
+				 * If one is invalid, perform comparison anyway, as we will be dealing with the traditional format here
+				 */
+				if ( ! ratios1.getKey().isValid() || ! ratios2.getKey().isValid() || SigMeta.suitableForComparison(ratios1.getKey(), ratios2.getKey())) {
+//					logger.info("SigMeta matches: " + ratios1.getKey() + " and " + ratios2.getKey());
+					Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
+					sb.append(comp.toString()).append(Constants.NEW_LINE);
+					allComparisons.add(comp);
+				} else {
+					logger.warn("Could not compare " + f1.getAbsolutePath() + " and " + f2.getAbsolutePath() + " as their SigMeta information was not equal or not valid: " + ratios1.getKey() + " and " + ratios2.getKey());
+				}
 			}
 			
 			// can now remove f1 from the cache as it is no longer required
-//			Map<ChrPosition, float[]> m = cache.remove(f1);
-			TIntShortHashMap m = cache.remove(f1);
-			m.clear();
+			Pair<SigMeta,TIntShortHashMap> m = cache.remove(f1);
+			m.getSecond().clear();
 			m = null;
 		}
-		logger.info("Loaded data for " + size + " (all) files");
 		
 		for (Comparison comp : allComparisons) {
-			if (comp.getScore() > cutoff) {
-				suspiciousResults.add(donor + "\t" + comp.toSummaryString());
+			if (comp.getScore() < cutoff) {
+				suspiciousResults.add(comp.toSummaryString());
 			}
 		}
 		
 		
 		// flush out last donor details
-		logger.info(donorSB.toString());
+		logger.info(sb.toString());
 		
 		logger.info("");
 		if (suspiciousResults.isEmpty()) {
@@ -190,32 +178,47 @@ public class SignatureCompareRelatedSimpleGenotype {
 		return exitStatus;
 	}
 	
-	TIntShortHashMap getSignatureData(File f) throws Exception {
+	Pair<SigMeta, TIntShortHashMap> getSignatureData(File f) throws IOException {
 		// check map to see if this data has already been loaded
 		// if not - load
-		TIntShortHashMap result = cache.get(f);
+		Pair<SigMeta, TIntShortHashMap> result = cache.get(f);
 		if (result == null) {
+			Pair<SigMeta, TMap<String, TIntShortHashMap>> rgResults = SignatureUtil.loadSignatureGenotype(f, minimumCoverage, minimumRGCoverage);
 			
-			
-			
-			result = SignatureUtil.loadSignatureRatiosFloatGenotype(f, minimumCoverage, homCutoff, hetUpperCutoff, hetLowerCutoff);
-			
-			if (result.size() < 1000) {
-				logger.warn("low coverage (" + result.size() + ") for file " + f.getAbsolutePath());
+			/*
+			 * if we have multiple rgs (more than 2 entries in map) - perform comparison on them before adding overall ratios to cache
+			 * 
+			 */
+			if ( rgResults.getSecond().size() == 2) {
+				result = new Pair<>(rgResults.getKey(), rgResults.getSecond().get("all"));
+			} else {
+				/*
+				 * remove all from map
+				 */
+				result =new Pair<>(rgResults.getKey(), rgResults.getSecond().remove("all"));
+				
+				List<String> rgs = new ArrayList<>(rgResults.getSecond().keySet());
+				for (int i = 0 ; i < rgs.size() ; i++) {
+					String rg1 = rgs.get(i);
+					TIntShortHashMap r1 = rgResults.getSecond().get(rg1);
+					for (int j = i + 1 ; j < rgs.size() ; j++) {
+						String rg2 = rgs.get(j);
+						TIntShortHashMap r2 = rgResults.getSecond().get(rg2);
+						
+						Comparison c = ComparisonUtil.compareRatiosUsingSnpsFloat(r1, r2, new File(rg1), new File(rg2));
+						if (c.getScore() < cutoff) {
+							logger.warn("rgs don't match!: " + c.toString());
+						}
+					}
+				}
 			}
 			
-//			if (cache.size() < cacheSize) {
-				cache.put(f, result);
-//			}
-			fileIdsAndCounts.get(f.getAbsolutePath())[1] = result.size();
-			/*
-			 * average coverage
-			 */
-			//TODO put this back in
-//			IntSummaryStatistics iss = result.values().stream()
-//				.mapToInt(array -> (int) array[4])
-//				.summaryStatistics();
-//			fileIdsAndCounts.get(f)[2] = (int) iss.getAverage();
+			if (result.getValue().size() < 1000) {
+				logger.warn("low coverage (" + result.getValue().size() + ") for file " + f.getAbsolutePath());
+			}
+			
+			cache.put(f, result);
+			fileIdsAndCounts.get(f.getAbsolutePath())[1] = result.getValue().size();
 		}
 		return result;
 	}
@@ -229,18 +232,18 @@ public class SignatureCompareRelatedSimpleGenotype {
 
 	
 	public static void main(String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(SignatureCompareRelatedSimpleGenotype.class);
+		LoadReferencedClasses.loadClasses(Compare.class);
 		
-		SignatureCompareRelatedSimpleGenotype sp = new SignatureCompareRelatedSimpleGenotype();
+		Compare sp = new Compare();
 		int exitStatus = 0;
 		try {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 2;
 			if (null != logger)
-				logger.error("Exception caught whilst running SignatureCompareRelatedSimple:", e);
+				logger.error("Exception caught whilst running Compare:", e);
 			else {
-				System.err.println("Exception caught whilst running SignatureCompareRelatedSimple: " + e.getMessage());
+				System.err.println("Exception caught whilst running Compare: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
 		}
@@ -271,7 +274,7 @@ public class SignatureCompareRelatedSimpleGenotype {
 		} else {
 			// configure logging
 			logFile = options.getLog();
-			logger = QLoggerFactory.getLogger(SignatureCompareRelatedSimpleGenotype.class, logFile, options.getLogLevel());
+			logger = QLoggerFactory.getLogger(Compare.class, logFile, options.getLogLevel());
 			
 			
 			String [] cmdLineOutputFiles = options.getOutputFileNames();
@@ -282,20 +285,16 @@ public class SignatureCompareRelatedSimpleGenotype {
 			if (null != paths && paths.length > 0) {
 				this.paths = paths;
 			}
-			if (null == paths) throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			if (null == paths || paths.length == 0) throw new QSignatureException("MISSING_DIRECTORY_OPTION");
 			
-			if (options.hasCutoff())
+			if (options.hasCutoff()) {
 				cutoff = options.getCutoff();
+			}
 			
 			options.getMinCoverage().ifPresent(i -> {minimumCoverage = i.intValue();});
+			options.getMinRGCoverage().ifPresent(i -> {minimumRGCoverage = i.intValue();});
 			logger.tool("Setting minumim coverage to: " + minimumCoverage);
-			
-			options.getHomCutoff().ifPresent(i -> {homCutoff = i.floatValue();});
-			logger.tool("Setting homozygous cutoff to: " + homCutoff);
-			options.getHetUpperCutoff().ifPresent(i -> {hetUpperCutoff = i.floatValue();});
-			logger.tool("Setting heterozygous upper cutoff to: " + hetUpperCutoff);
-			options.getHetLowerCutoff().ifPresent(i -> {hetLowerCutoff = i.floatValue();});
-			logger.tool("Setting heterozygous lower cutoff to: " + hetLowerCutoff);
+			logger.tool("Setting minumim RG coverage to: " + minimumRGCoverage);
 			
 			additionalSearchStrings = options.getAdditionalSearchString();
 			logger.tool("Setting additionalSearchStrings to: " + Arrays.deepToString(additionalSearchStrings));
@@ -303,7 +302,7 @@ public class SignatureCompareRelatedSimpleGenotype {
 			if (options.hasExcludeVcfsFileOption())
 				excludeVcfsFile = options.getExcludeVcfsFile();
 			
-			logger.logInitialExecutionStats("SignatureCompareRelatedSimpleGenotype", SignatureCompareRelatedSimpleGenotype.class.getPackage().getImplementationVersion(), args);
+			logger.logInitialExecutionStats("Compare", Compare.class.getPackage().getImplementationVersion(), args);
 			
 			return engage();
 		}

--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -1,5 +1,4 @@
 /**
- * © Copyright The University of Queensland 2010-2014.
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
  *
  * This code is released under the terms outlined in the included LICENSE file.

--- a/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
+++ b/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
@@ -36,12 +36,19 @@ import gnu.trove.set.hash.THashSet;
 /**
  * This class gets a list of all .qsig.vcf files from the supplied path.
  * It then performs a comparison between them all, regardless of whether they are bam or snp chip files
+ * It will also perform comparisons for old and new styled qsig xml files.
+ * In doing so, it will forgo the sigmeta check where there is no sigmeta data for one of the comparisons.
+ * Where both files have valid sigmeta data, the check will still be performed. Make sense? 
+ * 
  * An xml output file is produced
  * If any comparison scores are less than the cutoff, they are added to a list, which is then emailed to interested parties informing them of the potential problem files
  *  
  * @author o.holmes
+ * 
+ *  @Deprecated use Compare instead
  *
  */
+@Deprecated
 public class CompareGenotypeBespoke {
 	
 	private static QLogger logger;

--- a/qsignature/src/org/qcmg/sig/messages.properties
+++ b/qsignature/src/org/qcmg/sig/messages.properties
@@ -1,5 +1,5 @@
 USAGE = usage: qsignature [org.qcmg.sig.SignatureGeneratorBespoke | org.qcmg.sig.CompareGenotypeBespoke] [-options]
-COMPARE_USAGE = usage: qsignature org.qcmg.sig.CompareGenotypeBespoke -log <log_file> -dir <directory in which to search for .qsig.xml files> -output <output xml file>
+COMPARE_USAGE = usage: qsignature org.qcmg.sig.Compare -log <log_file> -dir <directory in which to search for .qsig.xml files> -output <output xml file>
 GENERATOR_USAGE = usage: qsignature org.qcmg.sig.SignatureGeneratorBespoke -snpPositions <file containing positions of interest> -illuminaArraysDesign <Illumina arrays design document - contains list of snp ids and whether they should be complemented> -input <bam or snp chip file, or folder containing bams or snp chip files> -output <output directory where qsig.xml files will be written to> -log <log_file>
 MISSING_INPUT_OPTIONS = You must specify at least one -i option
 MISSING_DIRECTORY_OPTION = You must specify a -d option indicating the path to be used to find signature files

--- a/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
@@ -22,23 +22,21 @@ import org.qcmg.sig.model.Comparison;
 public class ComparisonUtil {
 	
 	public static final int MINIMUM_NO_OF_CALCULATIONS = 25000;
-	
 	private static final QLogger logger = QLoggerFactory.getLogger(ComparisonUtil.class);
 	
 	
 	public static String getComparisonsBody(List<Comparison> comparisons) {
-		if (null == comparisons || comparisons.isEmpty()) throw new IllegalArgumentException("null or empty list of comparisons to headerise");
+		if (null == comparisons || comparisons.isEmpty()) {
+			throw new IllegalArgumentException("null or empty list of comparisons to headerise");
+		}
 		
 		StringBuilder sb = new StringBuilder();
 		String mainFile = comparisons.get(0).getMain();
-		if (null != mainFile)
+		if (null != mainFile) {
 			sb.append(mainFile).append('\t');
+		}
 		
 		for (Comparison comp : comparisons) {
-			
-//			sb.append(SignatureUtil.nf.format(comp.getScore())).append("[").append(comp.getOverlapCoverage())
-//				.append(",").append(comp.getNumberOfCalculations()).append("],");
-			
 			sb.append(SignatureUtil.nf.format(comp.getScore())).append("[").append(comp.getOverlapCoverage())
 			.append("],");
 		}
@@ -49,7 +47,9 @@ public class ComparisonUtil {
 	}
 	
 	public static boolean containsDodgyComparisons(List<Comparison> comparisons, double cutoff) {
-		if (null == comparisons || comparisons.isEmpty()) throw new IllegalArgumentException("null or empty list of comparisons to examine");
+		if (null == comparisons || comparisons.isEmpty()) {
+			throw new IllegalArgumentException("null or empty list of comparisons to examine");
+		}
 		
 		for (Comparison comp : comparisons) {
 			// only care about comparisons that had a large number of calculations
@@ -63,12 +63,12 @@ public class ComparisonUtil {
 	public static Comparison compareRatiosUsingSnps(final Map<ChrPosition, double[]> file1Ratios,
 				final Map<ChrPosition, double[]> file2Ratios, File file1, File file2, Map<ChrPosition, ChrPosition> positionsOfInterest) {
 			
-			if (null == file1Ratios || null == file2Ratios)
+			if (null == file1Ratios || null == file2Ratios) {
 				throw new IllegalArgumentException("null maps passed to compareRatios");
-			
-			if (null == file1 || null == file2)
+			}
+			if (null == file1 || null == file2) {
 				throw new IllegalArgumentException("null files passed to compareRatios");
-			
+			}
 			if (file1Ratios.isEmpty() || file2Ratios.isEmpty()) {
 				return  new Comparison(file1.getAbsolutePath(), file1Ratios.size(), file2.getAbsolutePath(), file2Ratios.size(), 0, 0);
 			}
@@ -82,8 +82,6 @@ public class ComparisonUtil {
 			
 			int match = 0;
 			int totalCompared = 0;
-//			long f1TotalCov = 0;
-//			long f2TotalCov = 0;
 			for (Entry<ChrPosition, double[]> file1RatiosEntry : file1Ratios.entrySet()) {
 				
 				// check to see if position is in the list of desired positions, if not continue
@@ -133,9 +131,6 @@ public class ComparisonUtil {
 								match++;
 							}
 							totalCompared++;
-							
-//							f1TotalCov += file1Ratio[4];
-//							f2TotalCov += file2Ratio[4];
 						}
 					}
 				}
@@ -151,12 +146,12 @@ public class ComparisonUtil {
 		return compareRatiosUsingSnpsFloat(file1Ratios,file2Ratios, file1.getAbsolutePath(), file2.getAbsolutePath()); 
 	}
 	public static Comparison compareRatiosUsingSnpsFloat(TIntShortHashMap file1Ratios,TIntShortHashMap file2Ratios, String file1, String file2) {
-		if (null == file1Ratios || null == file2Ratios)
+		if (null == file1Ratios || null == file2Ratios) {
 			throw new IllegalArgumentException("null maps passed to compareRatios");
-		
-		if (null == file1 || null == file2)
+		}
+		if (null == file1 || null == file2) {
 			throw new IllegalArgumentException("null files passed to compareRatios");
-		
+		}
 		if (file1Ratios.isEmpty() || file2Ratios.isEmpty()) {
 			return  new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), 0, 0);
 		}
@@ -182,7 +177,5 @@ public class ComparisonUtil {
 		
 		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), match.get(), totalCompared.get());
 		return comp;
-		
 	}
-			
 }

--- a/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
@@ -161,8 +161,9 @@ public class SignatureUtil {
 		
 		Pattern p = Pattern.compile(pattern);
 		Matcher m = p.matcher(string);
-		if (m.find())
+		if (m.find()) {
 			return m.group();
+		}
 		return UNKNOWN;
 	}
 
@@ -212,9 +213,6 @@ public class SignatureUtil {
 		}
 		return updatedVcfs;
 		
-//		return vcfs.stream()
-//				.map(f -> (Character.isDigit(f.getChrPosition().getChromosome().charAt(0)) ? "chr" + f : f))
-//				.collect(Collectors.toList());
 	}
 
 	public static Map<File, Map<ChrPosition, double[]>> getDonorSnpChipData(String donor, List<File> files) throws IOException {
@@ -330,13 +328,19 @@ public class SignatureUtil {
 			
 			for (TabbedRecord vcfRecord : reader) {
 				line = vcfRecord.getData();
-				if (line.startsWith(Constants.HASH_STRING)) continue;
+				if (line.startsWith(Constants.HASH_STRING)) {
+					continue;
+				}
 				//do a brute force search for the empty coverage string before passing to tokenizer
 				// only populate ratios with non-zero values
 				// attempt to keep memory usage down...
-				if (line.indexOf(SHORT_CUT_EMPTY_COVERAGE) > -1) continue;
+				if (line.indexOf(SHORT_CUT_EMPTY_COVERAGE) > -1) {
+					continue;
+				}
 				// ignore entries that have nan in there
-				if (line.indexOf(NAN) > -1) continue;
+				if (line.indexOf(NAN) > -1) {
+					continue;
+				}
 				
 				String[] params = TabTokenizer.tokenize(line);
 				String coverage = params[7];
@@ -408,18 +412,11 @@ public class SignatureUtil {
 				int [] counts = decipherCoverageString(info);
 				
 				if (counts[4] >= 1) {
-				boolean passesCoverage = counts[4] >= minCoverage;
-				
-//				if (counts[4] >= minCoverage) {
+					boolean passesCoverage = counts[4] >= minCoverage;
 					
 					String ref = vcf.getRef();
 					short vafAsShort = getFloatAsShort(getVAF(counts, ref));
-//					if (vafAsShort == 25) {
-//						logger.info("vaf = 25, info: " + info + ", ref: " + ref);
-//					}
-//					dist.adjustOrPutValue(vafAsShort, 1, 1);
 					dist.computeIfAbsent(Short.valueOf(vafAsShort), v -> new int[2])[passesCoverage ? 0 : 1] += 1;
-					
 				}
 			}
 		}
@@ -671,7 +668,9 @@ public class SignatureUtil {
 	 */
 	public static List<File> removeExcludedFilesFromList(List<File> originalList, List<String> filesToExclude) {
 		
-		if (null == filesToExclude || filesToExclude.isEmpty()) return originalList;
+		if (null == filesToExclude || filesToExclude.isEmpty()) {
+			return originalList;
+		}
 		
 		List<File> keepers = new ArrayList<>();
 		for (File f : originalList) {
@@ -685,8 +684,11 @@ public class SignatureUtil {
 				}
 			}
 			
-			if (includeFile) keepers.add(f);
-			else logger.info("ignoring " + fName + " as it is in the excludes file");
+			if (includeFile) {
+				keepers.add(f);
+			} else {
+				logger.info("ignoring " + fName + " as it is in the excludes file");
+			}
 			
 		}
 		return keepers;
@@ -694,7 +696,9 @@ public class SignatureUtil {
 	
 	public static List<File> removeClosedProjectFilesFromList(List<File> originalList, List<String> closedProjects) {
 		
-		if (null == closedProjects || closedProjects.isEmpty()) return originalList;
+		if (null == closedProjects || closedProjects.isEmpty()) {
+			return originalList;
+		}
 		
 		List<File> keepers = new ArrayList<>();
 		for (File f : originalList) {
@@ -761,7 +765,9 @@ public class SignatureUtil {
 	 * @param f
 	 */
 	public static void addFileToCollection(List<File> collection, List<String> excludes, File f) {
-		if (null == collection || null == f) return;		// don't proceed if collection or file is null
+		if (null == collection || null == f) {
+			return;		// don't proceed if collection or file is null
+		}
 		
 		boolean inExcludes = false;
 		if (null != excludes) {
@@ -774,7 +780,9 @@ public class SignatureUtil {
 				}
 			}
 		}
-		if ( ! inExcludes) collection.add(f);
+		if ( ! inExcludes) {
+			collection.add(f);
+		}
 	}
 	
 	
@@ -891,14 +899,16 @@ public class SignatureUtil {
 	 * @return
 	 */
 	public static int[] decipherCoverageString(String info) {
-		if (StringUtils.isNullOrEmpty(info))
+		if (StringUtils.isNullOrEmpty(info)) {
 			throw new IllegalArgumentException("Invalid coverage string passed to decipherCoverageString: " + info);
+		}
 		// strip out the pertinent bits
 		// total
 		final int totalIndex = info.indexOf("TOTAL:");
 		
-		if (totalIndex == -1)
+		if (totalIndex == -1) {
 			throw new IllegalArgumentException("Invalid coverage string passed to decipherCoverageString: " + info);
+		}
 		
 		final int total = Integer.parseInt(info.substring(totalIndex + 6, info.indexOf("NOVELCOV") - 1));
 		
@@ -938,8 +948,9 @@ public class SignatureUtil {
 	 * @return
 	 */
 	public static Optional<int[]> decipherCoverageStringBespoke(String info) {
-		if (StringUtils.isNullOrEmpty(info))
+		if (StringUtils.isNullOrEmpty(info)) {
 			throw new IllegalArgumentException("Invalid coverage string passed to decipherCoverageStringBespoke: " + info);
+		}
 		
 		String [] data = TabTokenizer.tokenize(info, Constants.MINUS);
 		if (data.length == 4) {
@@ -961,7 +972,9 @@ public class SignatureUtil {
 		
 		int[] baseCoverages = decipherCoverageString(coverage);
 		int total = baseCoverages[4];
-		if (total < minimumCoverage) return null;
+		if (total < minimumCoverage) {
+			return null;
+		}
 		
 		double aFrac = (double) baseCoverages[0] / total;
 		double cFrac = (double) baseCoverages[1] / total;
@@ -1003,7 +1016,9 @@ public class SignatureUtil {
 		
 		int[] baseCoverages = decipherCoverageString(coverage);
 		int total = baseCoverages[4];
-		if (total < minimumCoverage) return Optional.empty();
+		if (total < minimumCoverage) {
+			return Optional.empty();
+		}
 		
 		return Optional.of(new float[] { (float) baseCoverages[0] / total, 
 				(float) baseCoverages[1] / total,

--- a/qsignature/test/org/qcmg/sig/CompareTest.java
+++ b/qsignature/test/org/qcmg/sig/CompareTest.java
@@ -1,0 +1,214 @@
+package org.qcmg.sig;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.sig.util.SignatureUtilTest;
+
+public class CompareTest {
+	
+	@Rule
+	public  TemporaryFolder testFolder = new TemporaryFolder();
+	
+	@Test
+	public void singleEmptyInputFile() throws Exception {
+		File logF = testFolder.newFile();
+		File inputF = testFolder.newFile("blah.qsig.vcf.gz");
+		
+		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + inputF.getParent());
+		assertEquals(0, exec.getErrCode());		// all ok
+	}
+	
+	@Test
+	public void nonEmptyInputFiles() throws Exception {
+		File logF = testFolder.newFile();
+		File f1 = testFolder.newFile("blah.qsig.vcf");
+		File f2 = testFolder.newFile("blah2.qsig.vcf");
+		File o = testFolder.newFile();
+		
+		writeVcfFile(f1);
+		writeVcfFile(f2);
+		
+		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + f1.getParent() + " -o " + o.getAbsolutePath());
+		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(true, o.exists());
+		assertEquals(10, Files.readAllLines(Paths.get(o.getAbsolutePath())).size());		// 10 lines means 1 comparison
+	}
+	
+	@Test
+	public void diffMd5InputFiles() throws Exception {
+		File logF = testFolder.newFile();
+		File f1 = testFolder.newFile("blah.qsig.vcf");
+		File f2 = testFolder.newFile("blah2.qsig.vcf");
+		File o = testFolder.newFile();
+		
+		writeVcfFile(f1, "##positions_md5sum=d18c99f481afbe04294d11deeb418890\n");
+		writeVcfFile(f2, "##positions_md5sum=d18c99f481afbe04294d11deeb418890XXX\n");
+		
+		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + f1.getParent() + " -o " + o.getAbsolutePath());
+		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(true, o.exists());
+		assertEquals(8, Files.readAllLines(Paths.get(o.getAbsolutePath())).size());		// 8 lines means 0 comparison
+	}
+	
+	@Test
+	public void bespokeVsTraditionalBAM() throws IOException, InterruptedException {
+		File logF = testFolder.newFile();
+		File bespoke = testFolder.newFile("bespoke.qsig.vcf");
+		File trad = testFolder.newFile("traditional.qsig.vcf");
+		File o = testFolder.newFile();
+		List<String> tradData = new ArrayList<>(SignatureUtilTest.BAM_HEADER_OLD_SKOOL);
+		tradData.addAll(Arrays.asList("chr1\t99236\t cnvi0131297\t T\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:101,N:0,TOTAL:101;NOVELCOV=A:0,C:0,G:0,T:71,N:0,TOTAL:71",
+						"chr1\t100622\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49",
+						"chr1\t101095\tcnvi0133071\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:49,N:0,TOTAL:49;NOVELCOV=A:0,C:0,G:0,T:42,N:0,TOTAL:42",
+						"chr1\t102954\tcnvi0120648\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:337,N:0,TOTAL:337;NOVELCOV=A:0,C:0,G:0,T:167,N:0,TOTAL:167",
+						"chr1\t104813\tcnvi0124605\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:86,T:1,N:0,TOTAL:87;NOVELCOV=A:0,C:0,G:60,T:1,N:0,TOTAL:61",
+						"chr1\t106222\tcnvi0146646\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:1,T:32,N:0,TOTAL:33;NOVELCOV=A:0,C:0,G:1,T:29,N:0,TOTAL:30",
+						"chr1\t113422\tcnvi0147530\tT\t.\t.\t.\tFULLCOV=A:0,C:1,G:0,T:158,N:0,TOTAL:159;NOVELCOV=A:0,C:1,G:0,T:112,N:0,TOTAL:113"));
+		List<String> bespokeData = new ArrayList<>(SignatureUtilTest.BAM_HEADER);
+		bespokeData.addAll(Arrays.asList("chr1\t99236\t.\tT\t.\t.\t.\tQAF=t:0-0-0-34,rg1:0-0-0-20,rg2:0-0-0-14",
+						"chr1\t101095\t.\tT\t.\t.\t.\tQAF=t:0-0-0-20,rg1:0-0-0-14,rg2:0-0-0-6",
+						"chr1\t102954\t.\tT\t.\t.\t.\tQAF=t:0-0-1-161,rg1:0-0-1-71,rg2:0-0-0-90",
+						"chr1\t104813\t.\tG\t.\t.\t.\tQAF=t:0-0-9-0,rg1:0-0-4-0,rg2:0-0-5-0",
+						"chr1\t113422\t.\tT\t.\t.\t.\tQAF=t:0-0-0-13,rg1:0-0-0-7,rg2:0-0-0-6"));
+		
+		writeDataToFile(bespokeData, bespoke);
+		writeDataToFile(tradData, trad);
+		
+		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + bespoke.getParent() + " -o " + o.getAbsolutePath());
+		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(true, o.exists());
+		List<String> outputData = Files.readAllLines(Paths.get(o.getAbsolutePath()));
+		assertEquals(10, outputData.size());		// 10 lines means 1 comparison
+		assertEquals(true, outputData.contains("<comparison file1=\"1\" file2=\"2\" overlap=\"4\" score=\"1.0\"/>"));
+	}
+	
+	@Test
+	public void traditionalVsTraditionalBAM() throws IOException, InterruptedException {
+		File logF = testFolder.newFile();
+		File trad1 = testFolder.newFile("trad1.qsig.vcf");
+		File trad2 = testFolder.newFile("trad2.qsig.vcf");
+		File o = testFolder.newFile();
+		List<String> trad1Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER_OLD_SKOOL);
+		trad1Data.addAll(Arrays.asList("chr1\t99236\t cnvi0131297\t T\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:101,N:0,TOTAL:101;NOVELCOV=A:0,C:0,G:0,T:71,N:0,TOTAL:71",
+				"chr1\t100622\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49",
+				"chr1\t101095\tcnvi0133071\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:49,N:0,TOTAL:49;NOVELCOV=A:0,C:0,G:0,T:42,N:0,TOTAL:42",
+				"chr1\t102954\tcnvi0120648\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:337,N:0,TOTAL:337;NOVELCOV=A:0,C:0,G:0,T:167,N:0,TOTAL:167",
+				"chr1\t104813\tcnvi0124605\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:86,T:1,N:0,TOTAL:87;NOVELCOV=A:0,C:0,G:60,T:1,N:0,TOTAL:61",
+				"chr1\t106222\tcnvi0146646\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:1,T:32,N:0,TOTAL:33;NOVELCOV=A:0,C:0,G:1,T:29,N:0,TOTAL:30",
+				"chr1\t113422\tcnvi0147530\tT\t.\t.\t.\tFULLCOV=A:0,C:1,G:0,T:158,N:0,TOTAL:159;NOVELCOV=A:0,C:1,G:0,T:112,N:0,TOTAL:113"));
+		List<String> trad2Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER_OLD_SKOOL);
+		trad2Data.addAll(Arrays.asList("chr1\t99236\t cnvi0131297\t T\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:101,N:0,TOTAL:101;NOVELCOV=A:0,C:0,G:0,T:71,N:0,TOTAL:71",
+				"chr1\t100622\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49",
+				"chr1\t101095\tcnvi0133071\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:49,N:0,TOTAL:49;NOVELCOV=A:0,C:0,G:0,T:42,N:0,TOTAL:42",
+				"chr1\t102954\tcnvi0120648\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:337,N:0,TOTAL:337;NOVELCOV=A:0,C:0,G:0,T:167,N:0,TOTAL:167",
+				"chr1\t104813\tcnvi0124605\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:86,T:1,N:0,TOTAL:87;NOVELCOV=A:0,C:0,G:60,T:1,N:0,TOTAL:61",
+				"chr1\t106222\tcnvi0146646\tT\t.\t.\t.\tFULLCOV=A:0,C:0,G:1,T:32,N:0,TOTAL:33;NOVELCOV=A:0,C:0,G:1,T:29,N:0,TOTAL:30",
+				"chr1\t113422\tcnvi0147530\tT\t.\t.\t.\tFULLCOV=A:0,C:1,G:0,T:158,N:0,TOTAL:159;NOVELCOV=A:0,C:1,G:0,T:112,N:0,TOTAL:113"));
+		
+		writeDataToFile(trad1Data, trad1);
+		writeDataToFile(trad2Data, trad2);
+		
+		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + trad1.getParent() + " -o " + o.getAbsolutePath());
+		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(true, o.exists());
+		List<String> outputData = Files.readAllLines(Paths.get(o.getAbsolutePath()));
+		assertEquals(10, outputData.size());		// 10 lines means 1 comparison
+		assertEquals(true, outputData.contains("<comparison file1=\"1\" file2=\"2\" overlap=\"7\" score=\"1.0\"/>"));
+	}
+	
+	@Test
+	public void bespokeVsBespokeBAM() throws IOException, InterruptedException {
+		File logF = testFolder.newFile();
+		File bespoke1 = testFolder.newFile("bespoke1.qsig.vcf");
+		File bespoke2 = testFolder.newFile("bespoke2.qsig.vcf");
+		File o = testFolder.newFile();
+		List<String> bespoke1Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER);
+		bespoke1Data.addAll(Arrays.asList("chr1\t99236\t.\tT\t.\t.\t.\tQAF=t:0-0-0-34,rg1:0-0-0-20,rg2:0-0-0-14",
+				"chr1\t101095\t.\tT\t.\t.\t.\tQAF=t:0-0-0-20,rg1:0-0-0-14,rg2:0-0-0-6",
+				"chr1\t102954\t.\tT\t.\t.\t.\tQAF=t:0-0-1-161,rg1:0-0-1-71,rg2:0-0-0-90",
+				"chr1\t104813\t.\tG\t.\t.\t.\tQAF=t:0-0-19-0,rg1:0-0-14-0,rg2:0-0-5-0",
+				"chr1\t113422\t.\tT\t.\t.\t.\tQAF=t:0-0-0-23,rg1:0-0-0-17,rg2:0-0-0-6"));
+		List<String> bespoke2Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER);
+		bespoke2Data.addAll(Arrays.asList("chr1\t99236\t.\tT\t.\t.\t.\tQAF=t:0-0-0-34,rg1:0-0-0-20,rg2:0-0-0-14",
+				"chr1\t101095\t.\tT\t.\t.\t.\tQAF=t:0-0-0-20,rg1:0-0-0-14,rg2:0-0-0-6",
+				"chr1\t102954\t.\tT\t.\t.\t.\tQAF=t:0-0-1-161,rg1:0-0-1-71,rg2:0-0-0-90",
+				"chr1\t104813\t.\tG\t.\t.\t.\tQAF=t:0-0-19-0,rg1:0-0-14-0,rg2:0-0-5-0",
+				"chr1\t113422\t.\tT\t.\t.\t.\tQAF=t:0-0-0-23,rg1:0-0-0-17,rg2:0-0-0-6"));
+		
+		writeDataToFile(bespoke1Data, bespoke1);
+		writeDataToFile(bespoke2Data, bespoke2);
+		
+		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + bespoke1.getParent() + " -o " + o.getAbsolutePath());
+		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(true, o.exists());
+		List<String> outputData = Files.readAllLines(Paths.get(o.getAbsolutePath()));
+		assertEquals(10, outputData.size());		// 10 lines means 1 comparison
+		assertEquals(true, outputData.contains("<comparison file1=\"1\" file2=\"2\" overlap=\"5\" score=\"1.0\"/>"));
+	}
+	
+	private void writeVcfFile(File f) throws IOException {
+		writeVcfFile(f, "##positions_md5sum=d18c99f481afbe04294d11deeb418890\n");
+	}
+	
+	private void writeVcfFile(File f, String md5) throws IOException {
+		try (FileWriter w = new FileWriter(f);){
+			w.write("##fileformat=VCFv4.2\n");
+			w.write("##datetime=2016-08-17T14:44:30.088\n");
+			w.write("##program=SignatureGeneratorBespoke\n");
+			w.write("##version=1.0 (1230)\n");
+			w.write("##java_version=1.8.0_71\n");
+			w.write("##run_by_os=Linux\n");
+			w.write("##run_by_user=oliverH\n");
+			w.write("##positions=/software/genomeinfo/configs/qsignature/qsignature_positions.txt\n");
+			w.write(md5);
+			w.write("##positions_count=1456203\n");
+			w.write("##filter_base_quality=10\n");
+			w.write("##filter_mapping_quality=10\n");
+			w.write("##illumina_array_design=/software/genomeinfo/configs/qsignature/Illumina_arrays_design.txt\n");
+			w.write("##cmd_line=SignatureGeneratorBespoke -i /software/genomeinfo/configs/qsignature/qsignature_positions.txt -illumina /software/genomeinfo/configs/qsignature/Illumina_arrays_design.txt -i /mnt/lustre/working/genomeinfo/share/mapping/aws/argsBams/dd625894-d1e3-4938-8d92-3a9f57c23e08.bam -d /mnt/lustre/home/oliverH/qsignature/bespoke/ -log /mnt/lustre/home/oliverH/qsignature/bespoke/siggen.log\n");
+			w.write("##INFO=<ID=QAF,Number=.,Type=String,Description=\"Lists the counts of As-Cs-Gs-Ts for each read group, along with the total\">\n");
+			w.write("##input=/mnt/lustre/working/genomeinfo/share/mapping/aws/argsBams/dd625894-d1e3-4938-8d92-3a9f57c23e08.bam\n");
+			w.write("##id:readgroup\n");
+			w.write("##rg1:143b8c38-62cb-414a-aac3-ea3a940cc6bb\n");
+			w.write("##rg2:65a79904-ee91-4f53-9a94-c02e23e071ef\n");
+			w.write("#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO\n");
+			w.write("chr1	47851\t.\tC\t.\t.\t.\tQAF=t:0-120-0-0,rg1:0-90-0-0,rg2:0-30-0-0\n");
+			w.write("chr1	50251\t.\tT\t.\t.\t.\tQAF=t:0-0-0-110,rg1:0-0-0-90,rg2:0-0-0-20\n");
+			w.write("chr1\t51938	.\tT\t.\t.\t.\tQAF=t:0-0-0-90,rg1:0-0-0-50,rg2:0-0-0-40\n");
+			w.write("chr1\t52651	.\tT\t.\t.\t.\tQAF=t:0-0-0-30,rg1:0-0-0-10,rg2:0-0-0-20\n");
+			w.write("chr1\t64251	.\tA\t.\t.\t.\tQAF=t:90-0-0-0,rg1:50-0-0-0,rg2:40-0-0-0\n");
+			w.write("chr1\t98222	.\tC\t.\t.\t.\tQAF=t:0-120-0-0,rg1:0-50-0-0,rg2:0-70-0-0\n");
+			w.write("chr1\t99236	.\tT\t.\t.\t.\tQAF=t:0-0-0-220,rg1:0-0-0-120,rg2:0-0-0-100\n");
+			w.write("chr1\t101095	.\tT\t.\t.\t.\tQAF=t:0-0-0-100,rg1:0-0-0-50,rg2:0-0-0-50\n");
+			w.write("chr1\t102954	.\tT\t.\t.\t.\tQAF=t:0-0-10-640,rg1:0-0-0-360,rg2:0-0-10-280\n");
+			w.write("chr1\t104813	.\tG\t.\t.\t.\tQAF=t:0-10-170-0,rg1:0-10-100-0,rg2:0-0-70-0\n");
+			w.write("chr1\t106222	.\tT\t.\t.\t.\tQAF=t:0-0-0-40,rg1:0-0-0-10,rg2:0-0-0-30\n");
+		}
+	}
+	
+	private void writeDataToFile(List<String> data, File f) throws IOException {
+		try (FileWriter w = new FileWriter(f);){
+			for (String d : data) {
+				w.write(d + "\n");
+			}
+		}
+	}
+	
+	private Executor execute(final String command) throws IOException, InterruptedException {
+		return new Executor(command, "org.qcmg.sig.Compare");
+	}
+
+}

--- a/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
+++ b/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
@@ -3,7 +3,6 @@ package org.qcmg.sig.util;
 import static org.junit.Assert.assertEquals;
 import gnu.trove.map.TMap;
 import gnu.trove.map.hash.TIntShortHashMap;
-import gnu.trove.map.hash.TShortIntHashMap;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -49,6 +48,17 @@ public class SignatureUtilTest {
 			"##rg2=14989e3c-e669-46c2-866d-a8c504679743",
 			"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO");
 	
+	public static final List<String> BAM_HEADER_OLD_SKOOL = Arrays.asList("##fileformat=VCFv4.2",
+			"##fileDate=20171206",
+			"##qUUID=389f2b7f-68f9-4393-8053-76ba54fb16ce",
+			"##bam_file=/mnt/lustre/working/genomeinfo/sample/f/9/f92864a0-42c8-4f11-895e-5766e1e008c7/aligned_read_group_set/b141eb5f-b556-4d3b-a2e3-b7ea39d56e00.bam",
+			"##snp_file=/software/genomeinfo/configs/qsignature/qsignature_positions.txt",
+			"##FILTER=<ID=MAPPING_QUALITY,Description=\"Mapping quality < 10\">",
+			"##FILTER=<ID=BASE_QUALITY,Description=\"Base quality < 10\">",
+			"##INFO=<ID=NOVELCOV,Number=-1,Type=String,Description=\"bases at position from reads with novel starts\">",
+			"##INFO=<ID=FULLCOV,Number=-1,Type=String,Description=\"all bases at position\">",
+			"#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO");
+	
 	public static final List<String> SNP_CHIP_HEADER = Arrays.asList("##fileformat=VCFv4.2",
 			"##datetime=2018-04-17T16:03:13.028",
 			"##program=SignatureGeneratorBespoke",
@@ -74,6 +84,14 @@ public class SignatureUtilTest {
 		assertEquals("UNKNOWN", SignatureUtil.getPatientFromFile(new File("/path/project/AAAA_33/SNP_array/5555.txt")));
 	}
 	
+	@Test
+	public void doesOldStyleHeaderReturnASigMeta() {
+		TabbedHeader h = new TabbedHeader(BAM_HEADER_OLD_SKOOL);
+		Optional<Pair<SigMeta, Map<String, String>>> optional = SignatureUtil.getSigMetaAndRGsFromHeader(h);
+		assertEquals(true, optional.isPresent());
+		SigMeta sm = optional.get().getKey();
+		assertEquals(false, sm.isValid());
+	}
 	
 	@Test
 	public void doContigsStartWithDigit() {

--- a/qsv/test/org/qcmg/qsv/util/QSVUtilTest.java
+++ b/qsv/test/org/qcmg/qsv/util/QSVUtilTest.java
@@ -169,7 +169,8 @@ public class QSVUtilTest {
 
 	@Test 
 	public void testGetAnalysisId() {    	
-		assertTrue(QSVUtil.getAnalysisId(false, "test", new Date(1352958269803L)).contains("qSV_test_20121511_1544"));
+		assertEquals("qSV_test_20121511_1544", QSVUtil.getAnalysisId(false, "test", new Date(1352958269803L)));
+//		assertTrue(QSVUtil.getAnalysisId(false, "test", new Date(1352958269803L)).contains("qSV_test_20121511_1544"));
 		assertTrue(QSVUtil.getAnalysisId(true, "test", new Date(1352958269803L)).length() == 36);
 	}
 


### PR DESCRIPTION
…cf type (traditional or bespoke)

# Description

- Addition of a new `Compare` `qsignature` class that is vcf agnostic.

This class will handle the comparisons for both "traditional" and "bespoke" vcf files

- Deprecation of existing classes to compare the "traditional" and "bespoke" `qsignature` vcf files.



Fixes #120 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Additional unit tests have been written to check that the Compare class handles traditional vs traditional, bespoke vs bespoke, and traditional vs bespoke.
I have also checked that the results produced by the new Compare tool produce the same output as the existing tools.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
