### PR TITLE
Qprofile qname index bug

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
@@ -167,9 +167,9 @@ static final int MAX_POOL_SIZE = 500;
 				yPos = parts[4].substring(0, pos);
 			}
 			pos = yPos.lastIndexOf("#");				
-			if(pos > 0) { 
-				yPos = yPos.substring(0, pos);					
-				index = yPos.substring(pos);//put index				 
+			if(pos > 0) { 								
+				index = yPos.substring(pos);//put index	
+				yPos = yPos.substring(0, pos);	//then change yPos value
 			}
 			
 			for(int i = 0; i < 4; i ++) { 

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
@@ -2,7 +2,6 @@ package org.qcmg.qprofiler2.summarise;
 
 import static org.junit.Assert.assertTrue;
 
-import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.qcmg.common.util.Constants;
 import org.qcmg.qprofiler2.summarise.ReadIDSummary.RNPattern;
@@ -143,7 +142,7 @@ public class ReadIDSummaryTest {
 	}
 	
 	@Test
-	public void indexTest() throws ParserConfigurationException {
+	public void indexTest() {
 		 
 		String name = "HWI-ST567_0239:1:7:20610:49360#0";
 		

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
@@ -4,10 +4,14 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.junit.Test;
 import org.qcmg.common.util.Constants;
+import org.qcmg.common.util.XmlElementUtils;
 import org.qcmg.qprofiler2.summarise.ReadIDSummary.RNPattern;
 import org.qcmg.qprofiler2.util.XmlUtils;
+import org.w3c.dom.Element;
 
 public class ReadIDSummaryTest {
 		
@@ -53,7 +57,9 @@ public class ReadIDSummaryTest {
 //		FourColon_OlderIllumina("<instrument_id>:<lane>:<tile>:<x-pos>:<y-pos><#index></pair>"),
 		pa =  idSummary.getPattern(idSummary.splitElements("HWI-ST797_0059:3:2205:20826:152489#CTTGTA"));
 		assertTrue(pa.equals(RNPattern.FourColon_OlderIllumina ));
-		
+		pa =  idSummary.getPattern(idSummary.splitElements("HWI-ST797_0059:3:2205:20826:152489#0/1"));
+		assertTrue(pa.equals(RNPattern.FourColon_OlderIllumina ));
+				
 //		FourColon_OlderIlluminaWithoutIndex("<instrument_id>:<lane>:<tile>:<x-pos>:<y-pos>"),
 		pa =  idSummary.getPattern(idSummary.splitElements("HWI-EAS282-R_100802:2:14:7444:1268"));	
 		assertTrue(pa.equals(RNPattern.FourColon_OlderIlluminaWithoutIndex));
@@ -138,6 +144,25 @@ public class ReadIDSummaryTest {
 		assertTrue( idSummary.tileNumbers.get("C017R99").get() == 1 );
 		assertTrue( idSummary.tileNumbers.get(XmlUtils.OTHER).get() == 100 );
 		assertTrue( idSummary.tileNumbers.size() == 101 );
+	}
+	
+	@Test
+	public void indexTest() throws ParserConfigurationException {
+		 
+		String name = "HWI-ST567_0239:1:7:20610:49360#0";
+		
+		ReadIDSummary idSummary = new ReadIDSummary();
+		idSummary.parseReadId(name);
+		idSummary.parseReadId(name+"c");
+				
+		assertTrue( idSummary.indexes.size() == 2 );
+		assertTrue( idSummary.indexes.get("#0").get()== 1 );
+		assertTrue( idSummary.indexes.get("#0c").get()== 1 );
+		
+		idSummary.parseReadId(name+"/1");
+		assertTrue( idSummary.indexes.size() == 2 );
+		assertTrue( idSummary.pairs.size() == 1);
+		assertTrue( idSummary.pairs.get("/1").get()== 1 );	
 	}
 
 }

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
@@ -2,16 +2,12 @@ package org.qcmg.qprofiler2.summarise;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.junit.Test;
 import org.qcmg.common.util.Constants;
-import org.qcmg.common.util.XmlElementUtils;
 import org.qcmg.qprofiler2.summarise.ReadIDSummary.RNPattern;
 import org.qcmg.qprofiler2.util.XmlUtils;
-import org.w3c.dom.Element;
+
 
 public class ReadIDSummaryTest {
 		


### PR DESCRIPTION
# Description

Fix a bug in qprofiler2.  There was a bug in previous code: 
if(pos > 0) { 								      
	yPos = yPos.substring(0, pos);	
	index = yPos.substring(pos);//put index	
}
eg. input = "1234#AT", and we expect to get value "yPos=1234" and "index=#AT".  
However we got result are  "yPos=1234" and "index=". 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
 
# How Has This Been Tested?
Code is updated, related unit tests are added. 

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
