### PR TITLE
Qsignature add threading to Compare

### DIFF
--- a/qcommon/src/org/qcmg/common/util/ChrPositionCache.java
+++ b/qcommon/src/org/qcmg/common/util/ChrPositionCache.java
@@ -18,6 +18,7 @@ public class ChrPositionCache {
 	
 	private static ConcurrentMap<String, ChrPointPosition> cache = new ConcurrentHashMap<>();
 	private static ConcurrentMap<ChrPosition, Integer> cacheWithIndex = new ConcurrentHashMap<>();
+	private static ConcurrentMap<String, Integer> stringCacheWithIndex = new ConcurrentHashMap<>();
 	private static AtomicInteger index = new AtomicInteger();
 	
 	
@@ -37,6 +38,17 @@ public class ChrPositionCache {
 		if (null == i) {
 			i = index.incrementAndGet();
 			Integer prevI = cacheWithIndex.putIfAbsent(cp, i);
+			if (null != prevI && ! prevI.equals(i)) {
+				i = prevI;
+			}
+		}
+		return i.intValue();
+	}
+	public static int getStringIndex(String chrAndPosition) {
+		Integer i = stringCacheWithIndex.get(chrAndPosition);
+		if (null == i) {
+			i = index.incrementAndGet();
+			Integer prevI = stringCacheWithIndex.putIfAbsent(chrAndPosition, i);
 			if (null != prevI && ! prevI.equals(i)) {
 				i = prevI;
 			}

--- a/qcommon/src/org/qcmg/common/util/NumberUtils.java
+++ b/qcommon/src/org/qcmg/common/util/NumberUtils.java
@@ -55,41 +55,6 @@ public class NumberUtils {
 		}
 	}
 	
-	
-	/**
-	 * Returns the position of the value in the long array.
-	 * If it is not present, returns a negative value that corresponds to where in the array it would sit should it exist
-	 * assumes that the array is sorted.
-	 * 
-	 * Try and minimise the number of calls to Arrays.binarySearch by checking size and boundary positions
-	 * Should not be more than 500 entries in the array 
-	 * 
-	 * 
-	 * @param array
-	 * @param value
-	 * @return
-	 */
-	public static int getPositionOfLongInArray(long [] array, long value) {
-		int length = array.length;
-		if (length <= 0) {
-			return -1;
-		}
-		if (array[0] == value) {
-			return 0;
-		} else if (array[0] > value) {
-			return -1;
-		} else if (array[length - 1] == value) {
-			return length - 1;
-		} else if (array[length - 1] < value) {
-			return - length - 1;
-		} else {
-			/*
-			 * ok, time for binary search
-			 */
-			return Arrays.binarySearch(array, 1, length - 1, value);
-		}
-	}
-
 	public static long setBit(long value, int numberOfBits) {
 		return (1l << numberOfBits) + value;
 	}

--- a/qcommon/src/org/qcmg/common/util/NumberUtils.java
+++ b/qcommon/src/org/qcmg/common/util/NumberUtils.java
@@ -1,0 +1,112 @@
+package org.qcmg.common.util;
+
+import java.util.Arrays;
+
+public class NumberUtils {
+	
+	public static final int SHORT_DIVIDER = 16;
+	
+	
+	public static int getTileCount(int actualCount, int commonTileCount) {
+		return pack2IntsInto1(actualCount, commonTileCount);
+	}
+	
+	/**
+	 * 
+	 * Packs 2 ints into 1.
+	 * Assumes that both ints will fit inside a short without any overflow (note that this is not checked)
+	 * First int occupies the MSB 16 bits, and the second int occupies the LSB 16 bits.
+	 * 
+	 * @param int1
+	 * @param int2
+	 * @return
+	 */
+	public static int pack2IntsInto1(int int1, int int2) {
+		int result = (short) int1 << SHORT_DIVIDER;
+		result += (short) int2;
+		return result;
+	}
+	
+	
+	/**
+	 * splits the supplied int into 2 parts, returning an int array containing both parts
+	 * @param toSplit
+	 * @return
+	 */
+	public static int[] splitIntInto2(int toSplit) {
+		return new int[] {toSplit >> SHORT_DIVIDER, (short)toSplit};
+	}
+	
+	public static int sumPackedInt(int toSum) {
+		return sumPackedInt(toSum, SHORT_DIVIDER);
+	}
+	public static int sumPackedInt(int toSum, int divider) {
+		return (toSum >> divider) + (short) toSum;
+	}
+	
+	public static int getPartOfPackedInt(int packedInt, boolean firstPart) {
+		return getPartOfPackedInt(packedInt, firstPart, SHORT_DIVIDER);
+	}
+	public static int getPartOfPackedInt(int packedInt, boolean firstPart, int divider) {
+		if (firstPart) {
+			return packedInt >> divider;
+		} else {
+			return (short) packedInt;
+		}
+	}
+	
+	
+	/**
+	 * Returns the position of the value in the long array.
+	 * If it is not present, returns a negative value that corresponds to where in the array it would sit should it exist
+	 * assumes that the array is sorted.
+	 * 
+	 * Try and minimise the number of calls to Arrays.binarySearch by checking size and boundary positions
+	 * Should not be more than 500 entries in the array 
+	 * 
+	 * 
+	 * @param array
+	 * @param value
+	 * @return
+	 */
+	public static int getPositionOfLongInArray(long [] array, long value) {
+		int length = array.length;
+		if (length <= 0) {
+			return -1;
+		}
+		if (array[0] == value) {
+			return 0;
+		} else if (array[0] > value) {
+			return -1;
+		} else if (array[length - 1] == value) {
+			return length - 1;
+		} else if (array[length - 1] < value) {
+			return - length - 1;
+		} else {
+			/*
+			 * ok, time for binary search
+			 */
+			return Arrays.binarySearch(array, 1, length - 1, value);
+		}
+	}
+
+	public static long setBit(long value, int numberOfBits) {
+		return (1l << numberOfBits) + value;
+	}
+
+	public static long stripBitFromLong(long value, int bit) {
+			return value - (1l << bit);
+		}
+
+	public static boolean isBitSet(long value, int bit) {
+		return (value & 1l << bit) != 0;
+	}
+	
+	public static byte setBit(byte value, int numberOfBits) {
+		return (byte) ((1 << numberOfBits) + value);
+	}
+	public static boolean isBitSetOnByte(byte value, int bit) {
+		return (value & 1l << bit) != 0;
+	}
+
+}

--- a/qcommon/test/org/qcmg/common/util/NumberUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/NumberUtilsTest.java
@@ -1,0 +1,109 @@
+package org.qcmg.common.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class NumberUtilsTest {
+	
+	@Test
+	public void pack2IntsInto1() {
+		assertEquals(0, NumberUtils.pack2IntsInto1(0, 0));
+		assertEquals(1, NumberUtils.pack2IntsInto1(0, 1));
+		assertEquals(1 << 16, NumberUtils.pack2IntsInto1(1, 0));
+		assertEquals(65536, NumberUtils.pack2IntsInto1(1, 0));
+		assertEquals(65537, NumberUtils.pack2IntsInto1(1, 1));
+		assertEquals(1 << 17, NumberUtils.pack2IntsInto1(2, 0));
+		assertEquals(2 << 16, NumberUtils.pack2IntsInto1(2, 0));
+		assertEquals(851974, NumberUtils.pack2IntsInto1(13, 6));
+	}
+	
+	@Test
+	public void setBitOnByte() {
+		assertEquals(1, NumberUtils.setBit((byte)0, 0));
+		assertEquals(2, NumberUtils.setBit((byte)1, 0));
+		assertEquals(3, NumberUtils.setBit((byte)2, 0));
+		
+		assertEquals(2, NumberUtils.setBit((byte)0, 1));
+		assertEquals(4, NumberUtils.setBit((byte)0, 2));
+		assertEquals(8, NumberUtils.setBit((byte)0, 3));
+		assertEquals(16, NumberUtils.setBit((byte)0, 4));
+		assertEquals(32, NumberUtils.setBit((byte)0, 5));
+		assertEquals(64, NumberUtils.setBit((byte)0, 6));
+		assertEquals(-128, NumberUtils.setBit((byte)0, 7));
+		assertEquals(0, NumberUtils.setBit((byte)0, 8));
+		
+		assertEquals(3, NumberUtils.setBit((byte)1, 1));
+		assertEquals(3, NumberUtils.setBit((byte)2, 0));
+		assertEquals(4, NumberUtils.setBit((byte)2, 1));
+		assertEquals(6, NumberUtils.setBit((byte)2, 2));
+	}
+	
+	@Test
+	public void splitIntInto2() {
+		assertArrayEquals(new int[] {0,0}, NumberUtils.splitIntInto2(0));
+		assertArrayEquals(new int[] {0,1}, NumberUtils.splitIntInto2(1));
+		assertArrayEquals(new int[] {1,0}, NumberUtils.splitIntInto2(65536));
+		assertArrayEquals(new int[] {1,1}, NumberUtils.splitIntInto2(65537));
+		assertArrayEquals(new int[] {2,0}, NumberUtils.splitIntInto2(1 << 17));
+		assertArrayEquals(new int[] {2,2}, NumberUtils.splitIntInto2((1 << 17) + 2));
+		assertArrayEquals(new int[] {6,16}, NumberUtils.splitIntInto2(393232));
+	}
+	
+	@Test
+	public void getPartOfPackedInt() {
+		int packedInt = NumberUtils.pack2IntsInto1(10, 15);
+		assertEquals(10, NumberUtils.getPartOfPackedInt(packedInt, true));
+		assertEquals(15, NumberUtils.getPartOfPackedInt(packedInt, false));
+	}
+	
+	@Test
+	public void getPositionOfLongInArray() {
+		long [] array = new long[] {};
+		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 1));
+		
+		array = new long[] {1};
+		assertEquals(0, NumberUtils.getPositionOfLongInArray(array, 1));
+		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 2));
+		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 0));
+		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 10));
+		
+		array = new long[] {1, 10};
+		assertEquals(0, NumberUtils.getPositionOfLongInArray(array, 1));
+		assertEquals(1, NumberUtils.getPositionOfLongInArray(array, 10));
+		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 2));
+		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 0));
+		assertEquals(-3, NumberUtils.getPositionOfLongInArray(array, 11));
+		
+		array = new long[] {1, 10, 100};
+		assertEquals(0, NumberUtils.getPositionOfLongInArray(array, 1));
+		assertEquals(1, NumberUtils.getPositionOfLongInArray(array, 10));
+		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 2));
+		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 0));
+		assertEquals(-3, NumberUtils.getPositionOfLongInArray(array, 11));
+		assertEquals(2, NumberUtils.getPositionOfLongInArray(array, 100));
+		assertEquals(-4, NumberUtils.getPositionOfLongInArray(array, 101));
+	}
+	
+	@Test
+	public void sumPackedInt() {
+		assertEquals(0, NumberUtils.sumPackedInt(0));
+		assertEquals(1, NumberUtils.sumPackedInt(1));
+		assertEquals(2, NumberUtils.sumPackedInt(2));
+		assertEquals(1, NumberUtils.sumPackedInt(65536));
+		assertEquals(2, NumberUtils.sumPackedInt(65537));
+	}
+	
+	@Test
+	public void getIndexInArray() {
+		assertEquals(0, NumberUtils.getPositionOfLongInArray(new long[] {12345}, 12345));
+		assertEquals(-1, NumberUtils.getPositionOfLongInArray(new long[] {12345}, 12344));
+		assertEquals(-1, Arrays.binarySearch(new long[] {12345}, 12344));
+		assertEquals(-2, Arrays.binarySearch(new long[] {12345}, 12346));
+		assertEquals(-2, NumberUtils.getPositionOfLongInArray(new long[] {12345}, 12346));
+	}
+
+}

--- a/qcommon/test/org/qcmg/common/util/NumberUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/NumberUtilsTest.java
@@ -13,12 +13,23 @@ public class NumberUtilsTest {
 	public void pack2IntsInto1() {
 		assertEquals(0, NumberUtils.pack2IntsInto1(0, 0));
 		assertEquals(1, NumberUtils.pack2IntsInto1(0, 1));
-		assertEquals(1 << 16, NumberUtils.pack2IntsInto1(1, 0));
+		
+		assertEquals(1 << NumberUtils.SHORT_DIVIDER, NumberUtils.pack2IntsInto1(1, 0));
 		assertEquals(65536, NumberUtils.pack2IntsInto1(1, 0));
+		
+		/*
+		 * should be 65536 + 1
+		 */
+		assertEquals((1 << NumberUtils.SHORT_DIVIDER) + 1, NumberUtils.pack2IntsInto1(1, 1));
 		assertEquals(65537, NumberUtils.pack2IntsInto1(1, 1));
-		assertEquals(1 << 17, NumberUtils.pack2IntsInto1(2, 0));
-		assertEquals(2 << 16, NumberUtils.pack2IntsInto1(2, 0));
+		/*
+		 * should be 65536 * 2
+		 */
+		assertEquals(131072, NumberUtils.pack2IntsInto1(2, 0));
+		assertEquals(2 << NumberUtils.SHORT_DIVIDER, NumberUtils.pack2IntsInto1(2, 0));
+		
 		assertEquals(851974, NumberUtils.pack2IntsInto1(13, 6));
+		assertEquals(((13 << NumberUtils.SHORT_DIVIDER) + 6), NumberUtils.pack2IntsInto1(13, 6));
 	}
 	
 	@Test
@@ -61,34 +72,6 @@ public class NumberUtilsTest {
 	}
 	
 	@Test
-	public void getPositionOfLongInArray() {
-		long [] array = new long[] {};
-		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 1));
-		
-		array = new long[] {1};
-		assertEquals(0, NumberUtils.getPositionOfLongInArray(array, 1));
-		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 2));
-		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 0));
-		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 10));
-		
-		array = new long[] {1, 10};
-		assertEquals(0, NumberUtils.getPositionOfLongInArray(array, 1));
-		assertEquals(1, NumberUtils.getPositionOfLongInArray(array, 10));
-		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 2));
-		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 0));
-		assertEquals(-3, NumberUtils.getPositionOfLongInArray(array, 11));
-		
-		array = new long[] {1, 10, 100};
-		assertEquals(0, NumberUtils.getPositionOfLongInArray(array, 1));
-		assertEquals(1, NumberUtils.getPositionOfLongInArray(array, 10));
-		assertEquals(-2, NumberUtils.getPositionOfLongInArray(array, 2));
-		assertEquals(-1, NumberUtils.getPositionOfLongInArray(array, 0));
-		assertEquals(-3, NumberUtils.getPositionOfLongInArray(array, 11));
-		assertEquals(2, NumberUtils.getPositionOfLongInArray(array, 100));
-		assertEquals(-4, NumberUtils.getPositionOfLongInArray(array, 101));
-	}
-	
-	@Test
 	public void sumPackedInt() {
 		assertEquals(0, NumberUtils.sumPackedInt(0));
 		assertEquals(1, NumberUtils.sumPackedInt(1));
@@ -97,13 +80,4 @@ public class NumberUtilsTest {
 		assertEquals(2, NumberUtils.sumPackedInt(65537));
 	}
 	
-	@Test
-	public void getIndexInArray() {
-		assertEquals(0, NumberUtils.getPositionOfLongInArray(new long[] {12345}, 12345));
-		assertEquals(-1, NumberUtils.getPositionOfLongInArray(new long[] {12345}, 12344));
-		assertEquals(-1, Arrays.binarySearch(new long[] {12345}, 12344));
-		assertEquals(-2, Arrays.binarySearch(new long[] {12345}, 12346));
-		assertEquals(-2, NumberUtils.getPositionOfLongInArray(new long[] {12345}, 12346));
-	}
-
 }

--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -74,12 +74,9 @@ public class Compare {
 	private String logFile;
 	
 	private final Map<String, int[]> fileIdsAndCounts = new THashMap<>();
-//	private final List<Comparison> allComparisons = new ArrayList<>();
 	private final List<Comparison> allComparisons = new CopyOnWriteArrayList<>();
 	
-//	private final Map<File, Pair<SigMeta,TIntByteHashMap>> cache = new THashMap<>();
 	private final ConcurrentMap<File, Pair<SigMeta,TIntByteHashMap>> cache = new ConcurrentHashMap<>();
-//	private final Map<File, Pair<SigMeta,TIntShortHashMap>> cache = new THashMap<>();
 	
 	List<String> suspiciousResults = new ArrayList<>();
 	
@@ -138,52 +135,6 @@ public class Compare {
 		
 		performComparisons(files);
 		
-//		StringBuilder sb = new StringBuilder();
-//		
-//		int size = files.size();
-//		int fileCounter = 0;
-//		int compCounter = 0;
-//		
-//		for (int i = 0 ; i < size -1 ; i++) {
-//			
-//			File f1 = files.get(i);
-//			Pair<SigMeta, TIntByteHashMap> ratios1 = getSignatureData(f1);
-////			Pair<SigMeta, TIntShortHashMap> ratios1 = getSignatureData(f1);
-//			if (++fileCounter % 100 == 0) {
-//				logger.info("hit " + fileCounter + " files");
-//			}
-//			
-//			for (int j = i + 1 ; j < size ; j++) {
-//				File f2 = files.get(j);
-//				Pair<SigMeta, TIntByteHashMap> ratios2 = getSignatureData(f2);
-////				Pair<SigMeta, TIntShortHashMap> ratios2 = getSignatureData(f2);
-//				if (++fileCounter % 100 == 0) {
-//					logger.info("hit " + fileCounter + " files");
-//				}
-//				
-//				/*
-//				 * If both sig metas are valid, check to see if they are suitable for comparison (same snp positions file and have had the same filters applied).
-//				 * If one is invalid, perform comparison anyway, as we will be dealing with the traditional format here
-//				 */
-//				if ( ! ratios1.getKey().isValid() || ! ratios2.getKey().isValid() || SigMeta.suitableForComparison(ratios1.getKey(), ratios2.getKey())) {
-////					logger.info("SigMeta matches: " + ratios1.getKey() + " and " + ratios2.getKey());
-//					Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
-//					sb.append(comp.toString()).append(Constants.NEW_LINE);
-//					allComparisons.add(comp);
-//					if (++compCounter % 1000 == 0) {
-//						logger.info("hit " + compCounter + " comparisons");
-//					}
-//				} else {
-//					logger.warn("Could not compare " + f1.getAbsolutePath() + " and " + f2.getAbsolutePath() + " as their SigMeta information was not equal or not valid: " + ratios1.getKey() + " and " + ratios2.getKey());
-//				}
-//			}
-//			
-//			// can now remove f1 from the cache as it is no longer required
-//			Pair<SigMeta,TIntByteHashMap> m = cache.remove(f1);
-////			Pair<SigMeta,TIntShortHashMap> m = cache.remove(f1);
-//			m.getSecond().clear();
-//			m = null;
-//		}
 		
 		for (Comparison comp : allComparisons) {
 			if (null == comp) {
@@ -192,10 +143,6 @@ public class Compare {
 				suspiciousResults.add(comp.toSummaryString());
 			}
 		}
-		
-		
-		// flush out last donor details
-//		logger.info(sb.toString());
 		
 		logger.info("");
 		if (suspiciousResults.isEmpty()) {
@@ -215,14 +162,11 @@ public class Compare {
 	}
 	
 	Pair<SigMeta, TIntByteHashMap> getSignatureData(File f) throws IOException {
-//		Pair<SigMeta, TIntShortHashMap> getSignatureData(File f) throws IOException {
 		// check map to see if this data has already been loaded
 		// if not - load
 		Pair<SigMeta, TIntByteHashMap> result = cache.get(f);
-//		Pair<SigMeta, TIntShortHashMap> result = cache.get(f);
 		if (result == null) {
 			Pair<SigMeta, TMap<String, TIntByteHashMap>> rgResults = SignatureUtil.loadSignatureGenotype(f, minimumCoverage, minimumRGCoverage);
-//			Pair<SigMeta, TMap<String, TIntShortHashMap>> rgResults = SignatureUtil.loadSignatureGenotype(f, minimumCoverage, minimumRGCoverage);
 			
 			/*
 			 * if we have multiple rgs (more than 2 entries in map) - perform comparison on them before adding overall ratios to cache
@@ -240,11 +184,9 @@ public class Compare {
 				for (int i = 0 ; i < rgs.size() ; i++) {
 					String rg1 = rgs.get(i);
 					TIntByteHashMap r1 = rgResults.getSecond().get(rg1);
-//					TIntShortHashMap r1 = rgResults.getSecond().get(rg1);
 					for (int j = i + 1 ; j < rgs.size() ; j++) {
 						String rg2 = rgs.get(j);
 						TIntByteHashMap r2 = rgResults.getSecond().get(rg2);
-//						TIntShortHashMap r2 = rgResults.getSecond().get(rg2);
 						
 						Comparison c = ComparisonUtil.compareRatiosUsingSnpsFloat(r1, r2, new File(rg1), new File(rg2));
 						if (c.getScore() < cutoff) {

--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -121,7 +121,7 @@ public class Compare {
 		
 		
 		final int numberOfFiles = files.size();
-		final int numberOfComparisons = ((numberOfFiles * (numberOfFiles -1)) /2);
+		final int numberOfComparisons = ((numberOfFiles * (numberOfFiles - 1)) / 2);
 		logger.info("Should have " +numberOfComparisons + " comparisons, based on " + numberOfFiles + " input files");
 		
 		files.sort(FileUtils.FILE_COMPARATOR);
@@ -216,7 +216,7 @@ public class Compare {
 	private void performComparisons(List<File> files) {
 		int size = files.size();
 		AbstractQueue<Integer> queue =  new ConcurrentLinkedQueue<>();
-		for (int i = 0 ; i < size -1 ; i++) {
+		for (int i = 0 ; i < size - 1 ; i++) {
 			queue.add(i);
 		}
 		
@@ -224,9 +224,8 @@ public class Compare {
 		for (int i = 0 ; i < nThreads; i++) {
 			service.execute(() -> {
 					List<Comparison> myComps = new ArrayList<>();
-					while (true) {
-						Integer in = queue.poll();
-						if (null == in) break;
+					Integer in;
+					while ((in = queue.poll()) != null) {
 				
 						logger.info("performing comparison for : " + in.intValue());
 						
@@ -273,9 +272,8 @@ public class Compare {
 		ExecutorService service = Executors.newFixedThreadPool(nThreads);		
 		for (int i = 0 ; i < nThreads; i++) {
 			service.execute(() -> {
-					while (true) {
-						File f = queue.poll();
-						if (null == f) break;
+					File f;
+					while ((f = queue.poll()) != null) {
 				
 						logger.info("loading data from: " + f.getAbsolutePath());
 						
@@ -310,9 +308,7 @@ public class Compare {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		
 	}
-
 	
 	public static void main(String[] args) throws Exception {
 		LoadReferencedClasses.loadClasses(Compare.class);

--- a/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
+++ b/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +30,6 @@ import org.qcmg.sig.util.SignatureUtil;
 import gnu.trove.map.TMap;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TIntByteHashMap;
-import gnu.trove.map.hash.TIntShortHashMap;
 import gnu.trove.set.hash.THashSet;
 
 /**
@@ -71,7 +69,6 @@ public class CompareGenotypeBespoke {
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
 	private final Map<File, Pair<SigMeta,TIntByteHashMap>> cache = new THashMap<>();
-//	private final Map<File, Pair<SigMeta,TIntShortHashMap>> cache = new THashMap<>();
 	
 	List<String> suspiciousResults = new ArrayList<>();
 	
@@ -171,12 +168,14 @@ public class CompareGenotypeBespoke {
 			logger.info("No suspicious results found");
 		} else {
 			logger.info("Suspicious results SUMMARY:");
-			for (String s : suspiciousResults) logger.info(s);
+			for (String s : suspiciousResults) {
+				logger.info(s);
+			}
 		}
 		
-		if (outputXml != null)
+		if (outputXml != null) {
 			SignatureUtil.writeXmlOutput(fileIdsAndCounts, allComparisons, outputXml);
-//		writeXmlOutput();
+		}
 		
 		return exitStatus;
 	}
@@ -204,11 +203,9 @@ public class CompareGenotypeBespoke {
 				for (int i = 0 ; i < rgs.size() ; i++) {
 					String rg1 = rgs.get(i);
 					TIntByteHashMap r1 = rgResults.getSecond().get(rg1);
-//					TIntShortHashMap r1 = rgResults.getSecond().get(rg1);
 					for (int j = i + 1 ; j < rgs.size() ; j++) {
 						String rg2 = rgs.get(j);
 						TIntByteHashMap r2 = rgResults.getSecond().get(rg2);
-//						TIntShortHashMap r2 = rgResults.getSecond().get(rg2);
 						
 						Comparison c = ComparisonUtil.compareRatiosUsingSnpsFloat(r1, r2, new File(rg1), new File(rg2));
 						if (c.getScore() < cutoff) {
@@ -218,24 +215,12 @@ public class CompareGenotypeBespoke {
 				}
 			}
 			
-//			result = SignatureUtil.loadSignatureRatiosBespokeGenotype(f, minimumCoverage);
-			
 			if (result.getValue().size() < 1000) {
 				logger.warn("low coverage (" + result.getValue().size() + ") for file " + f.getAbsolutePath());
 			}
 			
-//			if (cache.size() < cacheSize) {
-				cache.put(f, result);
-//			}
+			cache.put(f, result);
 			fileIdsAndCounts.get(f.getAbsolutePath())[1] = result.getValue().size();
-			/*
-			 * average coverage
-			 */
-			//TODO put this back in
-//			IntSummaryStatistics iss = result.getValue().values().stream()
-//				.mapToInt(array -> (int) array[4])
-//				.summaryStatistics();
-//			fileIdsAndCounts.get(f)[2] = (int) iss.getAverage();
 		}
 		return result;
 	}
@@ -265,8 +250,9 @@ public class CompareGenotypeBespoke {
 			}
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
+		}
 		
 		System.exit(exitStatus);
 	}
@@ -317,8 +303,9 @@ public class CompareGenotypeBespoke {
 			additionalSearchStrings = options.getAdditionalSearchString();
 			logger.tool("Setting additionalSearchStrings to: " + Arrays.deepToString(additionalSearchStrings));
 			
-			if (options.hasExcludeVcfsFileOption())
+			if (options.hasExcludeVcfsFileOption()) {
 				excludeVcfsFile = options.getExcludeVcfsFile();
+			}
 			
 			logger.logInitialExecutionStats("CompareGenotypeBespoke", CompareGenotypeBespoke.class.getPackage().getImplementationVersion(), args);
 			

--- a/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
+++ b/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
@@ -30,6 +30,7 @@ import org.qcmg.sig.util.SignatureUtil;
 
 import gnu.trove.map.TMap;
 import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 import gnu.trove.map.hash.TIntShortHashMap;
 import gnu.trove.set.hash.THashSet;
 
@@ -69,7 +70,8 @@ public class CompareGenotypeBespoke {
 	private final Map<String, int[]> fileIdsAndCounts = new THashMap<>();
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
-	private final Map<File, Pair<SigMeta,TIntShortHashMap>> cache = new THashMap<>();
+	private final Map<File, Pair<SigMeta,TIntByteHashMap>> cache = new THashMap<>();
+//	private final Map<File, Pair<SigMeta,TIntShortHashMap>> cache = new THashMap<>();
 	
 	List<String> suspiciousResults = new ArrayList<>();
 	
@@ -129,11 +131,11 @@ public class CompareGenotypeBespoke {
 		for (int i = 0 ; i < size -1 ; i++) {
 			
 			File f1 = files.get(i);
-			Pair<SigMeta, TIntShortHashMap> ratios1 = getSignatureData(f1);
+			Pair<SigMeta, TIntByteHashMap> ratios1 = getSignatureData(f1);
 			
 			for (int j = i + 1 ; j < size ; j++) {
 				File f2 = files.get(j);
-				Pair<SigMeta, TIntShortHashMap> ratios2 = getSignatureData(f2);
+				Pair<SigMeta, TIntByteHashMap> ratios2 = getSignatureData(f2);
 				
 				/*
 				 * Check that the 2 files were born of the same snp positions file and have had the same filters applied
@@ -149,7 +151,7 @@ public class CompareGenotypeBespoke {
 			}
 			
 			// can now remove f1 from the cache as it is no longer required
-			Pair<SigMeta,TIntShortHashMap> m = cache.remove(f1);
+			Pair<SigMeta,TIntByteHashMap> m = cache.remove(f1);
 			m.getSecond().clear();
 			m = null;
 		}
@@ -179,12 +181,12 @@ public class CompareGenotypeBespoke {
 		return exitStatus;
 	}
 	
-	Pair<SigMeta, TIntShortHashMap> getSignatureData(File f) throws IOException {
+	Pair<SigMeta, TIntByteHashMap> getSignatureData(File f) throws IOException {
 		// check map to see if this data has already been loaded
 		// if not - load
-		Pair<SigMeta, TIntShortHashMap> result = cache.get(f);
+		Pair<SigMeta, TIntByteHashMap> result = cache.get(f);
 		if (result == null) {
-			Pair<SigMeta, TMap<String, TIntShortHashMap>> rgResults = SignatureUtil.loadSignatureRatiosBespokeGenotype(f, minimumCoverage, minimumRGCoverage);
+			Pair<SigMeta, TMap<String, TIntByteHashMap>> rgResults = SignatureUtil.loadSignatureGenotype(f, minimumCoverage, minimumRGCoverage);
 			
 			/*
 			 * if we have multiple rgs (more than 2 entries in map) - perform comparison on them before adding overall ratios to cache
@@ -201,10 +203,12 @@ public class CompareGenotypeBespoke {
 				List<String> rgs = new ArrayList<>(rgResults.getSecond().keySet());
 				for (int i = 0 ; i < rgs.size() ; i++) {
 					String rg1 = rgs.get(i);
-					TIntShortHashMap r1 = rgResults.getSecond().get(rg1);
+					TIntByteHashMap r1 = rgResults.getSecond().get(rg1);
+//					TIntShortHashMap r1 = rgResults.getSecond().get(rg1);
 					for (int j = i + 1 ; j < rgs.size() ; j++) {
 						String rg2 = rgs.get(j);
-						TIntShortHashMap r2 = rgResults.getSecond().get(rg2);
+						TIntByteHashMap r2 = rgResults.getSecond().get(rg2);
+//						TIntShortHashMap r2 = rgResults.getSecond().get(rg2);
 						
 						Comparison c = ComparisonUtil.compareRatiosUsingSnpsFloat(r1, r2, new File(rg1), new File(rg2));
 						if (c.getScore() < cutoff) {

--- a/qsignature/src/org/qcmg/sig/CompareRGGenotype.java
+++ b/qsignature/src/org/qcmg/sig/CompareRGGenotype.java
@@ -8,7 +8,7 @@ package org.qcmg.sig;
 
 import gnu.trove.map.TMap;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntShortHashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 import gnu.trove.set.hash.THashSet;
 
 import java.io.File;
@@ -70,7 +70,7 @@ public class CompareRGGenotype {
 	
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
-	private final Map<File, Pair<SigMeta, TMap<String, TIntShortHashMap>>> cache = new THashMap<>();
+	private final Map<File, Pair<SigMeta, TMap<String, TIntByteHashMap>>> cache = new THashMap<>();
 	
 	List<String> suspiciousResults = new ArrayList<String>();
 	
@@ -120,12 +120,12 @@ public class CompareRGGenotype {
 			File f = files.get(i);
 			logger.info("getting data for " + f.getAbsolutePath());
 			
-			Pair<SigMeta, TMap<String, TIntShortHashMap>> p = getSignatureData(f);
+			Pair<SigMeta, TMap<String, TIntByteHashMap>> p = getSignatureData(f);
 			
 			/*
 			 * Just intra-file checks for now - keeping data in cache will allow for inter-bam-rg comparisons at a later date.....
 			 */
-			TMap<String, TIntShortHashMap> m = p.getSecond();
+			TMap<String, TIntByteHashMap> m = p.getSecond();
 			
 			/*
 			 * Check to see if we have more than 1 entry left in the map - if we do, compare, otherwise move on
@@ -143,10 +143,10 @@ public class CompareRGGenotype {
 				for (int j = 0 ; j < rgIds.size() ; j++) {
 					
 					String rg1 = rgIds.get(j);
-					TIntShortHashMap r1 = m.get(rg1);
+					TIntByteHashMap r1 = m.get(rg1);
 					for (int k = j + 1 ; k < rgIds.size() ; k++) {
 						String rg2 = rgIds.get(k);
-						TIntShortHashMap r2 = m.get(rg2);
+						TIntByteHashMap r2 = m.get(rg2);
 						
 						Comparison c = ComparisonUtil.compareRatiosUsingSnpsFloat(r1, r2, f.getAbsolutePath() + "-" + rg1, f.getAbsolutePath() + "-" + rg2);
 						if (c.getScore() < genotypeCutoff) {
@@ -179,12 +179,12 @@ public class CompareRGGenotype {
 		return exitStatus;
 	}
 	
-	Pair<SigMeta, TMap<String, TIntShortHashMap>> getSignatureData(File f) throws Exception {
+	Pair<SigMeta, TMap<String, TIntByteHashMap>> getSignatureData(File f) throws Exception {
 		// check map to see if this data has already been loaded
 		// if not - load
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> result = cache.get(f);
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> result = cache.get(f);
 		if (result == null) {
-			result = SignatureUtil.loadSignatureRatiosBespokeGenotype(f, minimumCoverage, minimumRGCoverage);
+			result = SignatureUtil.loadSignatureGenotype(f, minimumCoverage, minimumRGCoverage);
 			
 			if (result.getValue().get("all").size() < 1000) {
 				logger.warn("low coverage (" + result.getValue().size() + ") for file " + f.getAbsolutePath());

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotype.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotype.java
@@ -7,6 +7,7 @@
 package org.qcmg.sig;
 
 import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 import gnu.trove.map.hash.TIntShortHashMap;
 
 import java.io.File;
@@ -45,17 +46,13 @@ public class SignatureCompareRelatedSimpleGenotype {
 	private static QLogger logger;
 	private int exitStatus;
 	
-	
 	private float cutoff = 0.2f;
 	private int minimumCoverage = 10;
-	
-//	private final int cacheSize = 700;
 	
 	private String outputXml;
 	private String [] paths;
 	private String [] additionalSearchStrings;
 	private String donor;
-//	private static final String QSIG_SUFFIX = ".qsig.vcf";
 	
 	private String excludeVcfsFile;
 	private List<String> excludes;
@@ -68,8 +65,7 @@ public class SignatureCompareRelatedSimpleGenotype {
 	private final Map<String, int[]> fileIdsAndCounts = new THashMap<>();
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
-//	private final Map<File, Map<ChrPosition, float[]>> cache = new THashMap<>(cacheSize * 2);
-	private final Map<File, TIntShortHashMap> cache = new THashMap<>();
+	private final Map<File, TIntByteHashMap> cache = new THashMap<>();
 	
 	List<String> suspiciousResults = new ArrayList<String>();
 	
@@ -143,23 +139,19 @@ public class SignatureCompareRelatedSimpleGenotype {
 				
 			
 			File f1 = files.get(i);
-//			Map<ChrPosition, float[]> ratios1 = getSignatureData(f1);
-			TIntShortHashMap ratios1 = getSignatureData(f1);
+			TIntByteHashMap ratios1 = getSignatureData(f1);
 			
 			for (int j = i + 1 ; j < size ; j++) {
 				File f2 = files.get(j);
-//				Map<ChrPosition, float[]> ratios2 = getSignatureData(f2);
-				TIntShortHashMap ratios2 = getSignatureData(f2);
+				TIntByteHashMap ratios2 = getSignatureData(f2);
 				
-//				Comparison comp = QSigCompareDistance.compareRatiosFloat(ratios1, ratios2, f1, f2, null);
 				Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1, ratios2, f1, f2);
 				donorSB.append(comp.toString()).append("\n");
 				allComparisons.add(comp);
 			}
 			
 			// can now remove f1 from the cache as it is no longer required
-//			Map<ChrPosition, float[]> m = cache.remove(f1);
-			TIntShortHashMap m = cache.remove(f1);
+			TIntByteHashMap m = cache.remove(f1);
 			m.clear();
 			m = null;
 		}
@@ -190,15 +182,15 @@ public class SignatureCompareRelatedSimpleGenotype {
 		return exitStatus;
 	}
 	
-	TIntShortHashMap getSignatureData(File f) throws Exception {
+	TIntByteHashMap getSignatureData(File f) throws Exception {
 		// check map to see if this data has already been loaded
 		// if not - load
-		TIntShortHashMap result = cache.get(f);
+		TIntByteHashMap result = cache.get(f);
 		if (result == null) {
 			
 			
 			
-			result = SignatureUtil.loadSignatureRatiosFloatGenotype(f, minimumCoverage, homCutoff, hetUpperCutoff, hetLowerCutoff);
+			result = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(f, minimumCoverage, homCutoff, hetUpperCutoff, hetLowerCutoff);
 			
 			if (result.size() < 1000) {
 				logger.warn("low coverage (" + result.size() + ") for file " + f.getAbsolutePath());

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
@@ -7,7 +7,7 @@
 package org.qcmg.sig;
 
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntShortHashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 
 import java.io.File;
 import java.util.AbstractQueue;
@@ -71,7 +71,7 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 	private final Map<String, int[]> fileIdsAndCounts = new THashMap<>();
 	private final List<Comparison> allComparisons = new CopyOnWriteArrayList<>();
 	
-	private final ConcurrentMap<File, TIntShortHashMap> cache = new ConcurrentHashMap<>();
+	private final ConcurrentMap<File, TIntByteHashMap> cache = new ConcurrentHashMap<>();
 	
 	List<String> suspiciousResults = new ArrayList<String>();
 	
@@ -176,11 +176,11 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 						logger.info("performing comparison for : " + in.intValue());
 						
 						File f1 = files.get(in);
-						TIntShortHashMap r1 = cache.get(f1);
+						TIntByteHashMap r1 = cache.get(f1);
 						
 						for (int j = in.intValue() + 1 ; j < size ; j ++ ) {
 							File f2 = files.get(j);
-							TIntShortHashMap r2 =  cache.get(f2);
+							TIntByteHashMap r2 =  cache.get(f2);
 							Comparison c = ComparisonUtil.compareRatiosUsingSnpsFloat(r1, r2, f1, f2);
 							myComps.add(c);
 						}
@@ -213,9 +213,9 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 				
 						logger.info("loading data from: " + f.getAbsolutePath());
 						
-						TIntShortHashMap genotypes = null;
+						TIntByteHashMap genotypes = null;
 						try {
-							genotypes = SignatureUtil.loadSignatureRatiosFloatGenotype(f, minimumCoverage, homCutoff, hetUpperCutoff, hetLowerCutoff);
+							genotypes = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(f, minimumCoverage, homCutoff, hetUpperCutoff, hetLowerCutoff);
 						} catch (Exception e) {
 							/*
 							 * set exit status, log exception and re-throw
@@ -228,7 +228,7 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 								e1.printStackTrace();
 							}
 						}
-						TIntShortHashMap prevGenotypes = cache.putIfAbsent(f, genotypes);
+						TIntByteHashMap prevGenotypes = cache.putIfAbsent(f, genotypes);
 						if (null != prevGenotypes) {
 							logger.warn("already genotypes associated with file: " + f.getAbsolutePath());
 						}

--- a/qsignature/src/org/qcmg/sig/SignatureWTFExomes.java
+++ b/qsignature/src/org/qcmg/sig/SignatureWTFExomes.java
@@ -4,14 +4,13 @@
 package org.qcmg.sig;
 
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntShortHashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -55,7 +54,6 @@ public class SignatureWTFExomes {
 	private static QLogger logger;
 	private int exitStatus;
 	
-	
 	private float cutoff = 0.2f;
 	private int minimumCoverage = 10;
 	
@@ -65,7 +63,6 @@ public class SignatureWTFExomes {
 	private String [] paths;
 	private String [] additionalSearchStrings;
 	private String donor;
-//	private static final String QSIG_SUFFIX = ".qsig.vcf";
 	
 	private String excludeVcfsFile;
 	private List<String> excludes;
@@ -74,7 +71,7 @@ public class SignatureWTFExomes {
 	private final Map<File, int[]> fileIdsAndCounts = new THashMap<>();
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
-	private final Map<File, TIntShortHashMap> cache = new THashMap<>(cacheSize * 2);
+	private final Map<File, TIntByteHashMap> cache = new THashMap<>(cacheSize * 2);
 	
 	List<String> suspiciousResults = new ArrayList<String>();
 	
@@ -106,8 +103,6 @@ public class SignatureWTFExomes {
 			logger.warn("No files left after removing exlcuded files");
 			return 0;
 		}
-		
-		
 		
 		
 		/*
@@ -142,11 +137,11 @@ public class SignatureWTFExomes {
 		
 		
 		int size = files.size();
-		List<TIntShortHashMap> ratios = new ArrayList<>();
+		List<TIntByteHashMap> ratios = new ArrayList<>();
 		for (int i = 0 ; i < size ; i++) {
 			
 			File f1 = files.get(i);
-			TIntShortHashMap ratios1 = getSignatureData(f1);
+			TIntByteHashMap ratios1 = getSignatureData(f1);
 			ratios.add(ratios1);
 		}
 		
@@ -175,21 +170,6 @@ public class SignatureWTFExomes {
 		allComparisons.add(comp3);
 		
 		
-//			for (int j = i + 1 ; j < size ; j++) {
-//				File f2 = files.get(j);
-//				TIntShortHashMap ratios2 = getSignatureData(f2);
-//				
-//				Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1, ratios2, f1, f2);
-//				donorSB.append(comp.toString()).append("\n");
-//				allComparisons.add(comp);
-//			}
-//			
-//			// can now remove f1 from the cache as it is no longer required
-//			TIntShortHashMap m = cache.remove(f1);
-//			m.clear();
-//			m = null;
-//		}
-		
 		for (Comparison comp : allComparisons) {
 			if (comp.getScore() > cutoff) {
 				suspiciousResults.add(donor + "\t" + comp.toSummaryString());
@@ -214,12 +194,12 @@ public class SignatureWTFExomes {
 		return exitStatus;
 	}
 	
-	TIntShortHashMap getSignatureData(File f) throws Exception {
+	TIntByteHashMap getSignatureData(File f) throws Exception {
 		// check map to see if this data has already been loaded
 		// if not - load
-		TIntShortHashMap result = cache.get(f);
+		TIntByteHashMap result = cache.get(f);
 		if (result == null) {
-			result = SignatureUtil.loadSignatureRatiosFloatGenotype(f);
+			result = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(f);
 		}
 			
 		if (result.size() < 1000) {
@@ -241,31 +221,6 @@ public class SignatureWTFExomes {
 //		}
 		return result;
 	}
-//	Map<ChrPosition, float[]> getSignatureData(File f) throws Exception {
-//		// check map to see if this data has already been loaded
-//		// if not - load
-//		Map<ChrPosition, float[]> result = cache.get(f);
-//		if (result == null) {
-//			result = SignatureUtil.loadSignatureRatiosFloat(f, minimumCoverage);
-//			
-//			if (result.size() < 1000) {
-//				logger.warn("low coverage (" + result.size() + ") for file " + f.getAbsolutePath());
-//			}
-//			
-//			if (cache.size() < cacheSize) {
-//				cache.put(f, result);
-//			}
-//			fileIdsAndCounts.get(f)[1] = result.size();
-//			/*
-//			 * average coverage
-//			 */
-//			IntSummaryStatistics iss = result.values().stream()
-//					.mapToInt(array -> (int) array[4])
-//					.summaryStatistics();
-//			fileIdsAndCounts.get(f)[2] = (int) iss.getAverage();
-//		}
-//		return result;
-//	}
 	
 	private void writeXmlOutput() throws ParserConfigurationException, TransformerException {
 		DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
@@ -307,9 +262,6 @@ public class SignatureWTFExomes {
 			compE.setAttribute("file2", id2 + "");
 			compE.setAttribute("score", comp.getScore() + "");
 			compE.setAttribute("overlap", comp.getOverlapCoverage() + "");
-//			compE.setAttribute("calcs", comp.getNumberOfCalculations() + "");
-//			compE.setAttribute("f1AveCovAtOverlaps", comp.getMainAveCovAtOverlaps() + "");
-//			compE.setAttribute("f2AveCovAtOverlaps", comp.getTestAveCovAtOverlaps() + "");
 			compsE.appendChild(compE);
 		}
 		

--- a/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
@@ -6,6 +6,7 @@
  */
 package org.qcmg.sig.util;
 
+import gnu.trove.map.hash.TIntByteHashMap;
 import gnu.trove.map.hash.TIntShortHashMap;
 
 import java.io.File;
@@ -169,6 +170,48 @@ public class ComparisonUtil {
 					if (s == s2) {
 						match.incrementAndGet();
 					}
+					totalCompared.incrementAndGet();
+				}
+			}
+			return true;
+		});
+		
+		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), match.get(), totalCompared.get());
+		return comp;
+	}
+	public static Comparison compareRatiosUsingSnpsFloat(TIntByteHashMap file1Ratios,TIntByteHashMap file2Ratios, File file1, File file2) {
+		return compareRatiosUsingSnpsFloat(file1Ratios,file2Ratios, file1.getAbsolutePath(), file2.getAbsolutePath()); 
+	}
+	public static Comparison compareRatiosUsingSnpsFloat(TIntByteHashMap file1Ratios,TIntByteHashMap file2Ratios, String file1, String file2) {
+		if (null == file1Ratios || null == file2Ratios) {
+			throw new IllegalArgumentException("null maps passed to compareRatios");
+		}
+		if (null == file1 || null == file2) {
+			throw new IllegalArgumentException("null files passed to compareRatios");
+		}
+		if (file1Ratios.isEmpty() || file2Ratios.isEmpty()) {
+			return  new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), 0, 0);
+		}
+		
+		if (file1.equals(file2)) {
+			return  new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), 0, file1Ratios.size());
+		}
+		AtomicInteger match = new AtomicInteger();
+		AtomicInteger totalCompared = new AtomicInteger();
+		/*
+		 * find the map with the smaller number of entries and iterate over that one - save some cycles
+		 */
+		boolean useFirst = file1Ratios.size() < file2Ratios.size();
+		TIntByteHashMap iter = useFirst ? file1Ratios : file2Ratios;
+		TIntByteHashMap lookup = useFirst ? file2Ratios : file1Ratios;
+		
+		iter.forEachEntry((int a, byte b) -> {
+			if (SignatureUtil.isCodedGenotypeValid(b)) {
+				byte b2 = lookup.get(a);
+				if (b == b2) {
+					match.incrementAndGet();
+				}
+				if (SignatureUtil.isCodedGenotypeValid(b2)) {
 					totalCompared.incrementAndGet();
 				}
 			}

--- a/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
@@ -94,6 +94,20 @@ public class SignatureUtil {
 	public static final NumberFormat nf = new DecimalFormat("0.####");
 	public static final QLogger logger = QLoggerFactory.getLogger(SignatureUtil.class);
 	
+	/*
+	 * byte values representing the available genotypes
+	 */
+	public static final byte HOM_A = 16;
+	public static final byte HOM_C = 32;
+	public static final byte HOM_G = 64;
+	public static final byte HOM_T = -128;
+	public static final byte HET_AC = 3;
+	public static final byte HET_AG = 5;
+	public static final byte HET_AT = 9;
+	public static final byte HET_CG = 6;
+	public static final byte HET_CT = 10;
+	public static final byte HET_GT = 12;
+	
 	
 	public static final String MD_5_SUM = "##positions_md5sum";
 	public static final String POSITIONS_COUNT = "##positions_count";
@@ -350,8 +364,6 @@ public class SignatureUtil {
 				 * should be quicker than a full tokenise...
 				 */
 				
-//				String[] params = TabTokenizer.tokenize(line);
-//				String coverage = params[7];
 				int lastIndex = line.lastIndexOf(Constants.TAB_STRING);
 				String coverage = line.substring(lastIndex);
 				/*
@@ -528,8 +540,7 @@ public class SignatureUtil {
 				byte genotype1 = getCodedGenotypeAsByte(f);
 				
 				if (isCodedGenotypeValid(genotype1)) {
-					cachePosition.set(ChrPositionCache.getStringIndex(params[0] + "\t" + params[1]));
-//					cachePosition.set(ChrPositionCache.getChrPositionIndex(params[0], Integer.parseInt(params[1])));
+					cachePosition.set(ChrPositionCache.getStringIndex(params[0] + Constants.TAB + params[1]));
 					ratios.put(cachePosition.get(), genotype1);
 					/*
 					 * Get rg data if we have more than 1 rg
@@ -571,7 +582,7 @@ public class SignatureUtil {
 	/**
 	 * Convert float array containing allele percentages for ACGT bases into a byte.
 	 * 
-	 * If over 90% in A, then will return 1000000 (binary form)
+	 * If over 90% in A, then will return 1000000 (binary form)		HOM_A
 	 * If over 90% in C, then will return 0100000
 	 * If over 90% in G, then will return 0010000
 	 * If over 90% in T, then will return 0001000
@@ -609,31 +620,31 @@ public class SignatureUtil {
 	
 	/**
 	 * the following values are considered to be valid:
-	 * 10000000		-128
-	 * 01000000		64
-	 * 00100000		32
-	 * 00010000		16
-	 * 00001100		12
-	 * 00001010		10
-	 * 00001001		9
-	 * 00000110		6
-	 * 00000101		5
-	 * 00000011		3
+	 * 10000000		-128	HOM_A
+	 * 01000000		64		HOM_C
+	 * 00100000		32		HOM_G
+	 * 00010000		16		HOM_T
+	 * 00001100		12		HET_GT
+	 * 00001010		10		HET_CT
+	 * 00001001		9		HET_AT
+	 * 00000110		6		HET_CG
+	 * 00000101		5		HET_AG
+	 * 00000011		3		HET_AC
 	 * 
 	 * @param b
 	 * @return
 	 */
 	public static boolean isCodedGenotypeValid(byte b) {
-		return b == 3
-				|| b == 5
-				|| b == 6
-				|| b == 9
-				|| b == 10
-				|| b == 12
-				|| b == 16
-				|| b == 32
-				|| b == 64
-				|| b == -128;
+		return b == HET_AC
+				|| b == HET_AG
+				|| b == HET_CG
+				|| b == HET_AT
+				|| b == HET_CT
+				|| b == HET_GT
+				|| b == HOM_T
+				|| b == HOM_G
+				|| b == HOM_C
+				|| b == HOM_A;
 	}
 	
 	

--- a/qsignature/test/org/qcmg/sig/CompareTest.java
+++ b/qsignature/test/org/qcmg/sig/CompareTest.java
@@ -17,6 +17,7 @@ import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.commandline.Executor;
 import org.qcmg.sig.util.SignatureUtilTest;
 
+
 public class CompareTest {
 	
 	@Rule

--- a/qsignature/test/org/qcmg/sig/CompareTest.java
+++ b/qsignature/test/org/qcmg/sig/CompareTest.java
@@ -42,7 +42,7 @@ public class CompareTest {
 		writeVcfFile(f2);
 		
 		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + f1.getParent() + " -o " + o.getAbsolutePath());
-		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(0, exec.getErrCode());		// all ok
 		assertEquals(true, o.exists());
 		assertEquals(10, Files.readAllLines(Paths.get(o.getAbsolutePath())).size());		// 10 lines means 1 comparison
 	}
@@ -58,7 +58,7 @@ public class CompareTest {
 		writeVcfFile(f2, "##positions_md5sum=d18c99f481afbe04294d11deeb418890XXX\n");
 		
 		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + f1.getParent() + " -o " + o.getAbsolutePath());
-		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(0, exec.getErrCode());		// all ok
 		assertEquals(true, o.exists());
 		assertEquals(8, Files.readAllLines(Paths.get(o.getAbsolutePath())).size());		// 8 lines means 0 comparison
 	}
@@ -88,11 +88,11 @@ public class CompareTest {
 		writeDataToFile(tradData, trad);
 		
 		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + bespoke.getParent() + " -o " + o.getAbsolutePath());
-		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(0, exec.getErrCode());		// all ok
 		assertEquals(true, o.exists());
 		List<String> outputData = Files.readAllLines(Paths.get(o.getAbsolutePath()));
 		assertEquals(10, outputData.size());		// 10 lines means 1 comparison
-		assertEquals(true, outputData.contains("<comparison file1=\"1\" file2=\"2\" overlap=\"4\" score=\"1.0\"/>"));
+		assertEquals("<comparison file1=\"1\" file2=\"2\" overlap=\"4\" score=\"1.0\"/>", outputData.get(7));
 	}
 	
 	@Test
@@ -122,7 +122,7 @@ public class CompareTest {
 		writeDataToFile(trad2Data, trad2);
 		
 		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + trad1.getParent() + " -o " + o.getAbsolutePath());
-		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(0, exec.getErrCode());		// all ok
 		assertEquals(true, o.exists());
 		List<String> outputData = Files.readAllLines(Paths.get(o.getAbsolutePath()));
 		assertEquals(10, outputData.size());		// 10 lines means 1 comparison
@@ -152,7 +152,7 @@ public class CompareTest {
 		writeDataToFile(bespoke2Data, bespoke2);
 		
 		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + bespoke1.getParent() + " -o " + o.getAbsolutePath());
-		assertTrue(0 == exec.getErrCode());		// all ok
+		assertEquals(0, exec.getErrCode());		// all ok
 		assertEquals(true, o.exists());
 		List<String> outputData = Files.readAllLines(Paths.get(o.getAbsolutePath()));
 		assertEquals(10, outputData.size());		// 10 lines means 1 comparison
@@ -199,7 +199,7 @@ public class CompareTest {
 		}
 	}
 	
-	private void writeDataToFile(List<String> data, File f) throws IOException {
+	public static void writeDataToFile(List<String> data, File f) throws IOException {
 		try (FileWriter w = new FileWriter(f);){
 			for (String d : data) {
 				w.write(d + "\n");

--- a/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
+++ b/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
@@ -87,37 +87,7 @@ public class SignatureUtilTest {
 		assertEquals("UNKNOWN", SignatureUtil.getPatientFromFile(new File("/path/project/AAAA_33/SNP_array/5555.txt")));
 	}
 	
-	@Ignore
-	public void processTraditionalFile() throws IOException {
-		List<String> trad1Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER_OLD_SKOOL);
-		File testVcf = testFolder.newFile("test.vcf");
-		String evenData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49\t";
-		String oddData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:0,N:0,TOTAL:0;NOVELCOV=A:0,C:0,G:0,T:0,N:0,TOTAL:0\t";
-		for (int i = 0 ; i < 2000000 ; i++ ) {
-			trad1Data.add("chr1\t" + i + (i % 2 == 0 ? evenData : oddData));
-		}
-		
-		CompareTest.writeDataToFile(trad1Data, testVcf);
-		
-		long start = System.currentTimeMillis();
-		TIntByteHashMap map = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
-		System.out.println("existing time taken to load ratios: " + (System.currentTimeMillis() - start));
-		start = System.currentTimeMillis();
-		TIntByteHashMap byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
-		System.out.println("new time taken to load ratios: " + (System.currentTimeMillis() - start));
-		start = System.currentTimeMillis();
-		map = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
-		System.out.println("existing time taken to load ratios: " + (System.currentTimeMillis() - start));
-		start = System.currentTimeMillis();
-		byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
-		System.out.println("new time taken to load ratios: " + (System.currentTimeMillis() - start));
-		start = System.currentTimeMillis();
-		map = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
-		System.out.println("existing time taken to load ratios: " + (System.currentTimeMillis() - start));
-	}
-	
 	@Test
-
 	public void getGenotypesAsByte() throws IOException {
 		List<String> trad1Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER_OLD_SKOOL);
 		File testVcf = testFolder.newFile("test.vcf");
@@ -128,6 +98,13 @@ public class SignatureUtilTest {
 		}
 		CompareTest.writeDataToFile(trad1Data, testVcf);
 		TIntByteHashMap byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
+		assertEquals(10, byteMap.size());
+		/*
+		 * values in map will be either HOM_G or HET_AG
+		 */
+		for (int i = 1 ; i <= 10 ; i++) {
+			assertEquals((i % 2 == 0 ? SignatureUtil.HET_AG : SignatureUtil.HOM_G), byteMap.get(i));
+		}
 	}
 	
 	@Test
@@ -336,7 +313,6 @@ public class SignatureUtilTest {
 		createBamVcfFile(f);
 		
 		Pair<SigMeta, TMap<String, TIntByteHashMap>> p = SignatureUtil.loadSignatureGenotype(f, 10, 10);
-//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p = SignatureUtil.loadSignatureRatiosBespokeGenotype(f, 10, 10);
 		assertEquals(7, p.getSecond().get("all").size());
 		assertEquals(3, p.getSecond().get("rg1").size());
 		assertEquals(2, p.getSecond().get("rg2").size());
@@ -393,12 +369,8 @@ public class SignatureUtilTest {
 		createBamVcfFile(f2);
 		Pair<SigMeta, TMap<String, TIntByteHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
 		Pair<SigMeta, TMap<String, TIntByteHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
-//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
-//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
 		Pair<SigMeta, TIntByteHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
 		Pair<SigMeta, TIntByteHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
-//		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
-//		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
 		Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
 		assertEquals(1.0, comp.getScore(), 0.0001d);
 		assertEquals(7, comp.getOverlapCoverage());	// 7 of the 11 have coverage over 10
@@ -411,12 +383,8 @@ public class SignatureUtilTest {
 		createSnpChipVcfFile(f2);
 		Pair<SigMeta, TMap<String, TIntByteHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
 		Pair<SigMeta, TMap<String, TIntByteHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
-//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
-//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
 		Pair<SigMeta, TIntByteHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
 		Pair<SigMeta, TIntByteHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
-//		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
-//		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
 		Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
 		assertEquals(1.0, comp.getScore(), 0.0001d);
 		assertEquals(11, comp.getOverlapCoverage());	// 7 of the 11 have coverage over 10
@@ -429,12 +397,8 @@ public class SignatureUtilTest {
 		createSnpChipVcfFile(f2);
 		Pair<SigMeta, TMap<String, TIntByteHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
 		Pair<SigMeta, TMap<String, TIntByteHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
-//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
-//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
 		Pair<SigMeta, TIntByteHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
 		Pair<SigMeta, TIntByteHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
-//		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
-//		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
 		Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
 		assertEquals(0.0, comp.getScore(), 0.0001d);
 		assertEquals(7, comp.getOverlapCoverage());	// 7 of the 11 have coverage over 10
@@ -497,31 +461,33 @@ public class SignatureUtilTest {
 		/*
 		 * AAs and BBs
 		 */
-		//10000
-		assertEquals(16, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.91f,0.0f,0.0f,0.09f}));
+		//10000 or HOM_A
+		assertEquals(SignatureUtil.HOM_A, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.91f,0.0f,0.0f,0.09f}));
 		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.91f,0.0f,0.0f,0.09f})));
 		//100000
-		assertEquals(32, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.99f,0.0f,0.00f}));
+		assertEquals(SignatureUtil.HOM_C, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.99f,0.0f,0.00f}));
 		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.99f,0.0f,0.00f})));
 		//1000000
-		assertEquals(64, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.09f,0.909f,0.00f}));
+		assertEquals(SignatureUtil.HOM_G, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.09f,0.909f,0.00f}));
 		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.09f,0.909f,0.00f})));
 		//10000000
-		assertEquals(-128, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.0f,1.0f}));
+		assertEquals(SignatureUtil.HOM_T, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.0f,1.0f}));
 		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.0f,1.0f})));
 		
 		/*
 		 * ABs
 		 */
-		assertEquals("11",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.5f,0.0f,0.0f})));
+		assertEquals(SignatureUtil.HET_AC, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.5f,0.0f,0.0f}));
 		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.5f,0.0f,0.0f})));
-		assertEquals("1001",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.0f,0.4f})));
+		assertEquals(SignatureUtil.HET_AT, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.0f,0.4f}));
 		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.0f,0.4f})));
-		assertEquals("1010",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.0f,0.4f})));
+		assertEquals(SignatureUtil.HET_CT, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.0f,0.4f}));
 		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.0f,0.4f})));
-		assertEquals("1100",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.59f})));
+		assertEquals(SignatureUtil.HET_CG, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.6f,0.0f}));
+		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.6f,0.0f})));
+		assertEquals(SignatureUtil.HET_GT, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.59f}));
 		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.59f})));
-		assertEquals("101",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.5f,0.0f})));
+		assertEquals(SignatureUtil.HET_AG, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.5f,0.0f}));
 		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.5f,0.0f})));
 		
 		/*
@@ -542,31 +508,6 @@ public class SignatureUtilTest {
 		assertEquals("100", Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.0f})));
 		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.0f})));
 	}
-	
-//	@Test
-//	public void validCodedGenotype() {
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 2000));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 200));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 20));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 2));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1100));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1010));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1001));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 101));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 110));
-//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 11));
-//		
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 1));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 10));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 100));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 1000));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 10000));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 111));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 22));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2020));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2001));
-//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2222));
-//	}
 	
 	@Test
 	public void testGetCoverageStringFromCharsAndInts() {
@@ -666,8 +607,9 @@ public class SignatureUtilTest {
 		assertEquals("excludesFile1excludesFile2", SignatureUtil.getEntriesFromExcludesFile(excludesFile.getAbsolutePath()).get(0));
 		
 		try (FileWriter writer = new FileWriter(excludesFile, true);){
-			for (int i = 3 ; i <= 10 ; i++)
+			for (int i = 3 ; i <= 10 ; i++) {
 				writer.append("\nexcludesFile" + i);
+			}
 		}
 		
 		assertEquals(9, SignatureUtil.getEntriesFromExcludesFile(excludesFile.getAbsolutePath()).size());

--- a/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
+++ b/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
@@ -2,6 +2,7 @@ package org.qcmg.sig.util;
 
 import static org.junit.Assert.assertEquals;
 import gnu.trove.map.TMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 import gnu.trove.map.hash.TIntShortHashMap;
 
 import java.io.File;
@@ -16,9 +17,11 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.math3.util.Pair;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.illumina.IlluminaRecord;
+import org.qcmg.sig.CompareTest;
 import org.qcmg.sig.model.Comparison;
 import org.qcmg.sig.model.SigMeta;
 import org.qcmg.tab.TabbedHeader;
@@ -82,6 +85,49 @@ public class SignatureUtilTest {
 		assertEquals("AAAA_9999", SignatureUtil.getPatientFromFile(new File("/path/project/AAAA_9999/SNP_array/5555.txt")));
 		assertEquals("AAAA_333", SignatureUtil.getPatientFromFile(new File("/path/project/AAAA_333/SNP_array/5555.txt")));
 		assertEquals("UNKNOWN", SignatureUtil.getPatientFromFile(new File("/path/project/AAAA_33/SNP_array/5555.txt")));
+	}
+	
+	@Ignore
+	public void processTraditionalFile() throws IOException {
+		List<String> trad1Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER_OLD_SKOOL);
+		File testVcf = testFolder.newFile("test.vcf");
+		String evenData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49\t";
+		String oddData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:0,T:0,N:0,TOTAL:0;NOVELCOV=A:0,C:0,G:0,T:0,N:0,TOTAL:0\t";
+		for (int i = 0 ; i < 2000000 ; i++ ) {
+			trad1Data.add("chr1\t" + i + (i % 2 == 0 ? evenData : oddData));
+		}
+		
+		CompareTest.writeDataToFile(trad1Data, testVcf);
+		
+		long start = System.currentTimeMillis();
+		TIntByteHashMap map = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
+		System.out.println("existing time taken to load ratios: " + (System.currentTimeMillis() - start));
+		start = System.currentTimeMillis();
+		TIntByteHashMap byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
+		System.out.println("new time taken to load ratios: " + (System.currentTimeMillis() - start));
+		start = System.currentTimeMillis();
+		map = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
+		System.out.println("existing time taken to load ratios: " + (System.currentTimeMillis() - start));
+		start = System.currentTimeMillis();
+		byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
+		System.out.println("new time taken to load ratios: " + (System.currentTimeMillis() - start));
+		start = System.currentTimeMillis();
+		map = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
+		System.out.println("existing time taken to load ratios: " + (System.currentTimeMillis() - start));
+	}
+	
+	@Test
+
+	public void getGenotypesAsByte() throws IOException {
+		List<String> trad1Data = new ArrayList<>(SignatureUtilTest.BAM_HEADER_OLD_SKOOL);
+		File testVcf = testFolder.newFile("test.vcf");
+		String evenData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49\t";
+		String oddData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:20,C:0,G:35,T:0,N:0,TOTAL:55;NOVELCOV=A:20,C:0,G:29,T:0,N:0,TOTAL:49\t";
+		for (int i = 0 ; i < 10 ; i++ ) {
+			trad1Data.add("chr1\t" + i + (i % 2 == 0 ? evenData : oddData));
+		}
+		CompareTest.writeDataToFile(trad1Data, testVcf);
+		TIntByteHashMap byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
 	}
 	
 	@Test
@@ -195,7 +241,7 @@ public class SignatureUtilTest {
 		
 		int [] indicies = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17};
 		List<Optional<float[]>> oeso_0031Floats = oeso_0031CovArray.stream().map(s -> SignatureUtil.getValuesFromCoverageStringFloat(s)).collect(Collectors.toList());
-		List<Short> oeso_0031Shorts = oeso_0031Floats.stream().map(of -> SignatureUtil.getCodedGenotype(of.get())).collect(Collectors.toList());
+		List<Byte> oeso_0031Shorts = oeso_0031Floats.stream().map(of -> SignatureUtil.getCodedGenotypeAsByte(of.get())).collect(Collectors.toList());
 		oeso_0031Shorts.stream().forEach(System.out::println);
 		
 		List<String> oeso_0050CovArray = Arrays.asList("A:25,C:0,G:31,T:0,N:0,TOTAL:56;NOVELCOV",
@@ -217,7 +263,7 @@ public class SignatureUtilTest {
 "A:18,C:0,G:10,T:0,N:0,TOTAL:28;NOVELCOV");
 		
 		List<Optional<float[]>> oeso_0050Floats = oeso_0050CovArray.stream().map(s -> SignatureUtil.getValuesFromCoverageStringFloat(s)).collect(Collectors.toList());
-		List<Short> oeso_0050Shorts = oeso_0050Floats.stream().map(of -> SignatureUtil.getCodedGenotype(of.get())).collect(Collectors.toList());
+		List<Byte> oeso_0050Shorts = oeso_0050Floats.stream().map(of -> SignatureUtil.getCodedGenotypeAsByte(of.get())).collect(Collectors.toList());
 		oeso_0050Shorts.stream().forEach(System.out::println);
 		
 		List<String> pn400007CovArray = Arrays.asList("A:70,C:1,G:0,T:0,N:0,TOTAL:71;NOVELCOV",
@@ -239,7 +285,7 @@ public class SignatureUtilTest {
 "A:0,C:0,G:50,T:0,N:0,TOTAL:50;NOVELCOV");
 		
 		List<Optional<float[]>> pn400007Floats = pn400007CovArray.stream().map(s -> SignatureUtil.getValuesFromCoverageStringFloat(s)).collect(Collectors.toList());
-		List<Short> pn400007Shorts = pn400007Floats.stream().map(of -> SignatureUtil.getCodedGenotype(of.get())).collect(Collectors.toList());
+		List<Byte> pn400007Shorts = pn400007Floats.stream().map(of -> SignatureUtil.getCodedGenotypeAsByte(of.get())).collect(Collectors.toList());
 		pn400007Shorts.stream().forEach(System.out::println);
 		
 		TIntShortHashMap oeso_0031Map = new TIntShortHashMap();
@@ -289,7 +335,8 @@ public class SignatureUtilTest {
 		File f = testFolder.newFile();
 		createBamVcfFile(f);
 		
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> p = SignatureUtil.loadSignatureRatiosBespokeGenotype(f, 10, 10);
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> p = SignatureUtil.loadSignatureGenotype(f, 10, 10);
+//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p = SignatureUtil.loadSignatureRatiosBespokeGenotype(f, 10, 10);
 		assertEquals(7, p.getSecond().get("all").size());
 		assertEquals(3, p.getSecond().get("rg1").size());
 		assertEquals(2, p.getSecond().get("rg2").size());
@@ -298,7 +345,7 @@ public class SignatureUtilTest {
 		 * adjust the rg min coverage value
 		 * Note that the minCov value will be used first for the total value before the rg specific value is used for the individual rgs
 		 */
-		 p = SignatureUtil.loadSignatureRatiosBespokeGenotype(f, 10, 5);
+		 p = SignatureUtil.loadSignatureGenotype(f, 10, 5);
 		assertEquals(7, p.getSecond().get("all").size());
 		assertEquals(7, p.getSecond().get("rg1").size());
 		assertEquals(5, p.getSecond().get("rg2").size());
@@ -344,10 +391,14 @@ public class SignatureUtilTest {
 		File f2 = testFolder.newFile();
 		createBamVcfFile(f1);
 		createBamVcfFile(f2);
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureRatiosBespokeGenotype(f1,10,10);
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureRatiosBespokeGenotype(f2,10,10);
-		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
-		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
+//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
+//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
+		Pair<SigMeta, TIntByteHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
+		Pair<SigMeta, TIntByteHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
+//		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
+//		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
 		Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
 		assertEquals(1.0, comp.getScore(), 0.0001d);
 		assertEquals(7, comp.getOverlapCoverage());	// 7 of the 11 have coverage over 10
@@ -358,10 +409,14 @@ public class SignatureUtilTest {
 		File f2 = testFolder.newFile();
 		createSnpChipVcfFile(f1);
 		createSnpChipVcfFile(f2);
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureRatiosBespokeGenotype(f1,10,10);
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureRatiosBespokeGenotype(f2,10,10);
-		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
-		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
+//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
+//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
+		Pair<SigMeta, TIntByteHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
+		Pair<SigMeta, TIntByteHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
+//		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
+//		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
 		Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
 		assertEquals(1.0, comp.getScore(), 0.0001d);
 		assertEquals(11, comp.getOverlapCoverage());	// 7 of the 11 have coverage over 10
@@ -372,10 +427,14 @@ public class SignatureUtilTest {
 		File f2 = testFolder.newFile();
 		createBamVcfFile(f1);
 		createSnpChipVcfFile(f2);
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureRatiosBespokeGenotype(f1,10,10);
-		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureRatiosBespokeGenotype(f2,10,10);
-		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
-		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
+		Pair<SigMeta, TMap<String, TIntByteHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
+//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p1 = SignatureUtil.loadSignatureGenotype(f1,10,10);
+//		Pair<SigMeta, TMap<String, TIntShortHashMap>> p2 = SignatureUtil.loadSignatureGenotype(f2,10,10);
+		Pair<SigMeta, TIntByteHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
+		Pair<SigMeta, TIntByteHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
+//		Pair<SigMeta, TIntShortHashMap> ratios1 = new Pair<>(p1.getKey(), p1.getSecond().get("all"));
+//		Pair<SigMeta, TIntShortHashMap> ratios2 = new Pair<>(p2.getKey(), p2.getSecond().get("all"));
 		Comparison comp = ComparisonUtil.compareRatiosUsingSnpsFloat(ratios1.getValue(), ratios2.getValue(), f1, f2);
 		assertEquals(0.0, comp.getScore(), 0.0001d);
 		assertEquals(7, comp.getOverlapCoverage());	// 7 of the 11 have coverage over 10
@@ -403,59 +462,111 @@ public class SignatureUtilTest {
 		assertEquals(5055, SignatureUtil.getFloatAsShort(50.55f));
 	}
 	
+//	@Test
+//	public void genotypeShort() {
+//		/*
+//		 * AAs and BBs
+//		 */
+//		assertEquals(2000, SignatureUtil.getCodedGenotype(new float[]{0.91f,0.0f,0.0f,0.09f}));
+//		assertEquals(200, SignatureUtil.getCodedGenotype(new float[]{0.01f,0.99f,0.0f,0.00f}));
+//		assertEquals(20, SignatureUtil.getCodedGenotype(new float[]{0.01f,0.09f,0.909f,0.00f}));
+//		assertEquals(2, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.0f,1.0f}));
+//		
+//		/*
+//		 * ABs
+//		 */
+//		assertEquals(1100, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.5f,0.0f,0.0f}));
+//		assertEquals(1001, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.0f,0.0f,0.4f}));
+//		assertEquals(101, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.4f,0.0f,0.4f}));
+//		assertEquals(11, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.59f,0.59f}));
+//		assertEquals(1010, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.0f,0.5f,0.0f}));
+//		
+//		/*
+//		 * invalid
+//		 */
+//		assertEquals(1000, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.0f,0.0f,0.0f}));
+//		assertEquals(1111, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.5f,0.5f,0.5f}));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotype(new float[]{0.32f,0.32f,0.32f,0.05f})));
+//		assertEquals(1, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.0f,0.4f}));
+//		assertEquals(100, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.4f,0.0f,0.0f}));
+//		assertEquals(10, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.59f,0.0f}));
+//	}
+	
 	@Test
-	public void genotypeShort() {
+	public void genotypeAsByte() {
 		/*
 		 * AAs and BBs
 		 */
-		assertEquals(2000, SignatureUtil.getCodedGenotype(new float[]{0.91f,0.0f,0.0f,0.09f}));
-		assertEquals(200, SignatureUtil.getCodedGenotype(new float[]{0.01f,0.99f,0.0f,0.00f}));
-		assertEquals(20, SignatureUtil.getCodedGenotype(new float[]{0.01f,0.09f,0.909f,0.00f}));
-		assertEquals(2, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.0f,1.0f}));
+		//10000
+		assertEquals(16, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.91f,0.0f,0.0f,0.09f}));
+		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.91f,0.0f,0.0f,0.09f})));
+		//100000
+		assertEquals(32, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.99f,0.0f,0.00f}));
+		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.99f,0.0f,0.00f})));
+		//1000000
+		assertEquals(64, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.09f,0.909f,0.00f}));
+		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.01f,0.09f,0.909f,0.00f})));
+		//10000000
+		assertEquals(-128, SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.0f,1.0f}));
+		assertEquals(true, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.0f,1.0f})));
 		
 		/*
 		 * ABs
 		 */
-		assertEquals(1100, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.5f,0.0f,0.0f}));
-		assertEquals(1001, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.0f,0.0f,0.4f}));
-		assertEquals(101, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.4f,0.0f,0.4f}));
-		assertEquals(11, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.59f,0.59f}));
-		assertEquals(1010, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.0f,0.5f,0.0f}));
+		assertEquals("11",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.5f,0.0f,0.0f})));
+		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.5f,0.0f,0.0f})));
+		assertEquals("1001",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.0f,0.4f})));
+		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.0f,0.4f})));
+		assertEquals("1010",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.0f,0.4f})));
+		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.0f,0.4f})));
+		assertEquals("1100",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.59f})));
+		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.59f})));
+		assertEquals("101",  Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.5f,0.0f})));
+		assertEquals(true,  SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.5f,0.0f})));
 		
 		/*
 		 * invalid
 		 */
-		assertEquals(1000, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.0f,0.0f,0.0f}));
-		assertEquals(1111, SignatureUtil.getCodedGenotype(new float[]{0.5f,0.5f,0.5f,0.5f}));
-		assertEquals(1, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.0f,0.4f}));
-		assertEquals(100, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.4f,0.0f,0.0f}));
-		assertEquals(10, SignatureUtil.getCodedGenotype(new float[]{0.0f,0.0f,0.59f,0.0f}));
+		// this is 3 lots of 0.32 - invalid
+		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.32f,0.32f,0.32f,0.0f})));
+		
+		
+		assertEquals("1", Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.0f,0.0f})));
+		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.0f,0.0f,0.0f})));
+		assertEquals("1111", Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.5f,0.5f,0.5f})));
+		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.5f,0.5f,0.5f,0.5f})));
+		assertEquals("1000", Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.0f,0.4f})));
+		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.0f,0.4f})));
+		assertEquals("10", Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.0f,0.0f})));
+		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.4f,0.0f,0.0f})));
+		assertEquals("100", Integer.toBinaryString(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.0f})));
+		assertEquals(false, SignatureUtil.isCodedGenotypeValid(SignatureUtil.getCodedGenotypeAsByte(new float[]{0.0f,0.0f,0.59f,0.0f})));
 	}
 	
-	@Test
-	public void validCodedGenotype() {
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 2000));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 200));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 20));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 2));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1100));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1010));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1001));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 101));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 110));
-		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 11));
-		
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 1));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 10));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 100));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 1000));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 10000));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 111));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 22));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2020));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2001));
-		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2222));
-	}
+//	@Test
+//	public void validCodedGenotype() {
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 2000));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 200));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 20));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 2));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1100));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1010));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 1001));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 101));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 110));
+//		assertEquals(true, SignatureUtil.isCodedGenotypeValid((short) 11));
+//		
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 1));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 10));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 100));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 1000));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 10000));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 111));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 22));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2020));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2001));
+//		assertEquals(false, SignatureUtil.isCodedGenotypeValid((short) 2222));
+//	}
 	
 	@Test
 	public void testGetCoverageStringFromCharsAndInts() {


### PR DESCRIPTION


# Description

The primary use case for the `Compare` class is to compare our `qsignature` vcf files across each study on a regular basis.
Some of our larger studies (hello melanoma) have so many files that to perform the compare in a single-threaded way would take hours.
Fortunately, the components of `qsignatures`'s `Compare` (ie. reading in vcf files and comparing them) scale relatively well when run with multiple threads.

And so, I have incorporated the existing `noOfThreads` option into the `Compare` class.
This creates thread pools of the specified size, enabling additional threads to both read in `qsignature` vcf files and also to perform the comparisons.

Also changed is the collection used to store the genotype values. It was previously `trove`'s `TIntShortMap` and it has now changed to `trove`'s `TIntByteMap`
The motivation for this change was to try and reduce the memory footprint when comparing large numbers of files.
It is possible to store all the different genotype states within a byte primitive and it uses half the bits of a short.

If the user wishes to run this class in a single-threaded way, this is possible by either leaving out the `noOfThreads` option (ensuring backwards compatibility) or by setting the `noOfThreads` option to 1.
 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have added additional unit tests to check that using a byte gives the same results as using a short to store the genotype information.
I've run in multi-treaded mode against the same data set multiple times and the outputs have been identical. Have also run single-threaded against the same data set with resulted in the same output.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
