### PR TITLE
update xsd, let it accept zero child node under <readGroup>

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
+++ b/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
@@ -135,7 +135,7 @@
 			 	 <xs:element name="readGroup" minOccurs="1" maxOccurs="unbounded">
 				 	 <xs:complexType>
 					 	 <xs:sequence>
-						 	 <xs:element name="sequenceMetrics" minOccurs="1" maxOccurs="unbounded" type="SequenceMetricsType"/>
+						 	 <xs:element name="sequenceMetrics" minOccurs="0" maxOccurs="unbounded" type="SequenceMetricsType"/>
 					 	 </xs:sequence>
 					 	 <xs:attribute type="xs:string" name="name" use="required"/> 	 	 
 				 	 </xs:complexType>


### PR DESCRIPTION
# Description

We found several BAMs contains unpaired reads, that means there is no TLEN value under that readGroup.  So we have to update our XSD file, let it accept zero child node under <readGroup> tag. 

Please delete options that are not relevant.
- [x ] New feature (non-breaking change which adds functionality)
 

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] My changes generate no new warnings

