### PR TITLE
Qsig generator OutOfMemory fix

### DIFF
--- a/qsignature/src/org/qcmg/sig/model/BaseReadGroup.java
+++ b/qsignature/src/org/qcmg/sig/model/BaseReadGroup.java
@@ -1,5 +1,6 @@
 package org.qcmg.sig.model;
 
+@Deprecated
 public class BaseReadGroup {
 	
 	private final char base;

--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
@@ -73,31 +73,6 @@ public class SignatureGeneratorBespokeTest {
 	}
 	
 	@Test
-	public void getEncodedDistString() {
-		assertEquals(null, SignatureGeneratorBespoke.getTotalDist(null));
-		assertEquals(null, SignatureGeneratorBespoke.getEncodedDist(new ArrayList<>()));
-		
-		List<BaseReadGroup> list = new ArrayList<>();
-		list.add(new BaseReadGroup('A',""));
-		assertEquals("1-0-0-0", SignatureGeneratorBespoke.getEncodedDist(list));
-		list.add(new BaseReadGroup('A',""));
-		assertEquals("2-0-0-0", SignatureGeneratorBespoke.getEncodedDist(list));
-		list.add(new BaseReadGroup('T',""));
-		assertEquals("2-0-0-1", SignatureGeneratorBespoke.getEncodedDist(list));
-		list.add(new BaseReadGroup('T',""));
-		assertEquals("2-0-0-2", SignatureGeneratorBespoke.getEncodedDist(list));
-		list.clear();
-		list.add(new BaseReadGroup('C',""));
-		assertEquals("0-1-0-0", SignatureGeneratorBespoke.getEncodedDist(list));
-		list.clear();
-		list.add(new BaseReadGroup('G',""));
-		assertEquals("0-0-1-0", SignatureGeneratorBespoke.getEncodedDist(list));
-		list.clear();
-		list.add(new BaseReadGroup('T',""));
-		assertEquals("0-0-0-1", SignatureGeneratorBespoke.getEncodedDist(list));
-	}
-	
-	@Test
 	public void recordWithNoRG() {
 		SAMFileHeader header = SignatureGeneratorTest.getHeader(true, true, true);
 		/*

--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
@@ -10,10 +10,15 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.vcf.VcfRecord;
+import org.qcmg.common.vcf.header.VcfHeader;
+import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.sig.model.BaseReadGroup;
 import org.qcmg.vcf.VCFFileReader;
+
+import gnu.trove.map.TObjectIntMap;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
 
 public class SignatureGeneratorBespokeTest {
 	
@@ -25,12 +30,51 @@ public class SignatureGeneratorBespokeTest {
 	@Before
 	public void setup() {
 		qss = new SignatureGeneratorBespoke();
-		qss.logger = QLoggerFactory.getLogger(SignatureGeneratorBespokeTest.class);
+	}
+	
+	@Test
+	public void getDist() {
+		int[][] readGroupBasesArray = new int[4][4];
+		int[] rg1Bases = new int[]{0,0,0,0};
+		int[] rg2Bases = new int[]{10,9,8,7};
+		readGroupBasesArray[0] = rg1Bases;
+		readGroupBasesArray[1] = rg2Bases;
+		
+		assertEquals("", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 0));
+		assertEquals("10-9-8-7", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 1));
+		assertEquals("", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 2));
+		assertEquals("", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 3));
+		
+		readGroupBasesArray[2] = new int[]{100,90,80,70};
+		assertEquals("", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 0));
+		assertEquals("10-9-8-7", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 1));
+		assertEquals("100-90-80-70", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 2));
+		assertEquals("", SignatureGeneratorBespoke.getDist(readGroupBasesArray, 3));
+	}
+	
+	@Test
+	public void getTotalDist() {
+		int[][] readGroupBasesArray = new int[4][4];
+		int[] rg1Bases = new int[]{0,0,0,0};
+		int[] rg2Bases = new int[]{10,9,8,7};
+		readGroupBasesArray[0] = rg1Bases;
+		readGroupBasesArray[1] = rg2Bases;
+		
+		assertEquals("10-9-8-7", SignatureGeneratorBespoke.getTotalDist(readGroupBasesArray));
+		
+		readGroupBasesArray[0] = new int[]{1,1,1,1};
+		assertEquals("11-10-9-8", SignatureGeneratorBespoke.getTotalDist(readGroupBasesArray));
+		
+		readGroupBasesArray[3] = new int[]{1,2,3,4};
+		assertEquals("12-12-12-12", SignatureGeneratorBespoke.getTotalDist(readGroupBasesArray));
+		
+		readGroupBasesArray[2] = new int[]{10,20,30,40};
+		assertEquals("22-32-42-52", SignatureGeneratorBespoke.getTotalDist(readGroupBasesArray));
 	}
 	
 	@Test
 	public void getEncodedDistString() {
-		assertEquals(null, SignatureGeneratorBespoke.getEncodedDist(null));
+		assertEquals(null, SignatureGeneratorBespoke.getTotalDist(null));
 		assertEquals(null, SignatureGeneratorBespoke.getEncodedDist(new ArrayList<>()));
 		
 		List<BaseReadGroup> list = new ArrayList<>();
@@ -51,37 +95,197 @@ public class SignatureGeneratorBespokeTest {
 		list.clear();
 		list.add(new BaseReadGroup('T',""));
 		assertEquals("0-0-0-1", SignatureGeneratorBespoke.getEncodedDist(list));
+	}
+	
+	@Test
+	public void recordWithNoRG() {
+		SAMFileHeader header = SignatureGeneratorTest.getHeader(true, true, true);
+		/*
+		 * setup map of rgids
+		 */
+		TObjectIntMap<String> rgIds = SignatureGeneratorBespoke.getReadGroupsAsMap(header);
 		
+		/*
+		 * setup SAMRecord
+		 */
+		SAMRecord sam = new SAMRecord(header);
+		sam.setAlignmentStart(126890960);
+		sam.setReferenceName( "chr12" );
+		sam.setFlags(67);
+		sam.setReadName("HS2000-152_756:1:1215:14830:88102");
+		sam.setReadString("CCCTACCCCTACCCCTACCCCTAAAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTTACCCTAACCCTTACCCTAACC");
+		sam.setBaseQualityString("CCCFFFFFHHHHHJJIHFHJIGIHGIIJJJJIJJIIIIJJJJJIIJJJJIJJJJJJJJHHGHHFFEFCEEDD9?BABDCDDDDDDDDDDDDCDDDDDDDB");
+		sam.setMappingQuality(60);
+		sam.setCigarString("24M4D76M");
+		String rgId = null != sam.getReadGroup() ? sam.getReadGroup().getId() : null;
+		assertEquals(null, rgId);
+		assertEquals(0, rgIds.get(rgId));
+	}
+	
+	@Test
+	public void recordWithRGInList() {
+		SAMFileHeader header = SignatureGeneratorTest.getHeader(true, true, true);
+		/*
+		 * setup map of rgids
+		 */
+		TObjectIntMap<String> rgIds = SignatureGeneratorBespoke.getReadGroupsAsMap(header);
+		
+		/*
+		 * setup SAMRecord
+		 */
+		SAMRecord sam = new SAMRecord(header);
+		sam.setAlignmentStart(126890960);
+		sam.setReferenceName( "chr12" );
+		sam.setFlags(67);
+		sam.setReadName("HS2000-152_756:1:1215:14830:88102");
+		sam.setReadString("CCCTACCCCTACCCCTACCCCTAAAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTTACCCTAACCCTTACCCTAACC");
+		sam.setBaseQualityString("CCCFFFFFHHHHHJJIHFHJIGIHGIIJJJJIJJIIIIJJJJJIIJJJJIJJJJJJJJHHGHHFFEFCEEDD9?BABDCDDDDDDDDDDDDCDDDDDDDB");
+		sam.setMappingQuality(60);
+		sam.setCigarString("24M4D76M");
+		sam.setAttribute("RG", "20130325103517169");
+		String rgId = null != sam.getReadGroup() ? sam.getReadGroup().getId() : null;
+		assertEquals("20130325103517169", rgId);
+		assertEquals(1, rgIds.get(rgId));
+	}
+	
+	@Test
+	public void recordWithRGNotInList() {
+		SAMFileHeader header = SignatureGeneratorTest.getHeader(true, true, true);
+		/*
+		 * setup map of rgids
+		 */
+		TObjectIntMap<String> rgIds = SignatureGeneratorBespoke.getReadGroupsAsMap(header);
+		
+		/*
+		 * setup SAMRecord
+		 */
+		SAMRecord sam = new SAMRecord(header);
+		sam.setAlignmentStart(126890960);
+		sam.setReferenceName( "chr12" );
+		sam.setFlags(67);
+		sam.setReadName("HS2000-152_756:1:1215:14830:88102");
+		sam.setReadString("CCCTACCCCTACCCCTACCCCTAAAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTTACCCTAACCCTTACCCTAACC");
+		sam.setBaseQualityString("CCCFFFFFHHHHHJJIHFHJIGIHGIIJJJJIJJIIIIJJJJJIIJJJJIJJJJJJJJHHGHHFFEFCEEDD9?BABDCDDDDDDDDDDDDCDDDDDDDB");
+		sam.setMappingQuality(60);
+		sam.setCigarString("24M4D76M");
+		sam.setAttribute("RG", "This_is_no_in_the_list");
+		String rgId = null != sam.getReadGroup() ? sam.getReadGroup().getId() : null;
+		/*
+		 * will be null as the RG needs to be set on the record and also exist in the header
+		 */
+		assertEquals(null, rgId);
+		assertEquals(0, rgIds.get(rgId));
+	}
+	
+	@Test
+	public void rgMapReturnValueWithRGs() {
+		SAMFileHeader header = SignatureGeneratorTest.getHeader(true, true, true);
+		/*
+		 * setup map of rgids
+		 */
+		TObjectIntMap<String> rgIds = SignatureGeneratorBespoke.getReadGroupsAsMap(header);
+		
+		assertEquals(4, rgIds.size());
+		assertEquals(0, rgIds.get(null));
+		assertEquals(1, rgIds.get("20130325103517169"));
+		assertEquals(2, rgIds.get("20130325112045146"));
+		assertEquals(3, rgIds.get("20130325084856212"));
+	}
+	@Test
+	public void rgMapReturnValueNoGs() {
+		SAMFileHeader header = SignatureGeneratorTest.getHeader(true, true, false);
+		/*
+		 * setup map of rgids
+		 */
+		TObjectIntMap<String> rgIds = SignatureGeneratorBespoke.getReadGroupsAsMap(header);
+		
+		assertEquals(1, rgIds.size());
+		assertEquals(0, rgIds.get(null));
+		assertEquals(0, rgIds.get("20130325103517169"));
+		assertEquals(0, rgIds.get("20130325112045146"));
+		assertEquals(0, rgIds.get("20130325084856212"));
+		assertEquals(0, rgIds.get("Any_value_not_in_map_will_return_0"));
 	}
 	
 	@Test
     public void runProcessWithHG19BamFile() throws Exception {
-	    	final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
-	    	final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
-	    	final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
-	    	final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
-	    	final String outputFIleName = bamFile.getAbsolutePath() + ".qsig.vcf.gz";
-	    	final File outputFile = new File(outputFIleName);
+    	final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
+    	final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
+    	final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
+    	final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+    	final String outputFIleName = bamFile.getAbsolutePath() + ".qsig.vcf.gz";
+    	final File outputFile = new File(outputFIleName);
 	    	
 	//    	writeSnpChipFile(snpChipFile);
 	    SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
 	    SignatureGeneratorTest.writeIlluminaArraysDesignFile(illuminaArraysDesignFile);
 	    SignatureGeneratorTest.getBamFile(bamFile, true, false);
 	    	
-	    	final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath(),  "-illuminaArraysDesign" , illuminaArraysDesignFile.getAbsolutePath()} );
-	    	assertEquals(0, exitStatus);
-	    	
-	    	assertTrue(outputFile.exists());
-	   	
-	    	final List<VcfRecord> recs = new ArrayList<>();
-	    	try (VCFFileReader reader = new VCFFileReader(outputFile);) {    			
-		    	for (final VcfRecord rec : reader) {
-		    		recs.add(rec);
-		    		System.out.println("rec: " + rec.toString());
-		    	}
+    	final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath(),  "-illuminaArraysDesign" , illuminaArraysDesignFile.getAbsolutePath()} );
+    	assertEquals(0, exitStatus);
+    	
+    	assertTrue(outputFile.exists());
+   	
+    	final List<VcfRecord> recs = new ArrayList<>();
+    	try (VCFFileReader reader = new VCFFileReader(outputFile);) {    			
+	    	for (final VcfRecord rec : reader) {
+	    		recs.add(rec);
+	    		System.out.println("rec: " + rec.toString());
 	    	}
-	       	
-	    	assertEquals(6, recs.size());
+	    	VcfHeader header = reader.getHeader();
+//	    	header.getAllMetaRecords().stream().forEach(System.out::println);
+	    	assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg0=null")));
+    	}
+       	
+    	assertEquals(6, recs.size());
+    	assertEquals("QAF=t:0-0-0-10,rg0:0-0-0-10", recs.get(0).getInfo());
+    	assertEquals("QAF=t:20-0-0-0,rg0:20-0-0-0", recs.get(1).getInfo());
+    	assertEquals("QAF=t:0-10-0-0,rg0:0-10-0-0", recs.get(2).getInfo());
+    	assertEquals("QAF=t:0-0-0-20,rg0:0-0-0-20", recs.get(3).getInfo());
+    	assertEquals("QAF=t:0-10-0-0,rg0:0-10-0-0", recs.get(4).getInfo());
+    	assertEquals("QAF=t:0-20-0-0,rg0:0-20-0-0", recs.get(5).getInfo());
     }
+	
+	@Test
+	public void runProcessWithReadGroupsSetInHeader() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
+		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		final String outputFIleName = bamFile.getAbsolutePath() + ".qsig.vcf.gz";
+		final File outputFile = new File(outputFIleName);
+		
+		//    	writeSnpChipFile(snpChipFile);
+		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
+		SignatureGeneratorTest.writeIlluminaArraysDesignFile(illuminaArraysDesignFile);
+		SignatureGeneratorTest.getBamFile(bamFile, true, false, true);
+		
+		final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath(),  "-illuminaArraysDesign" , illuminaArraysDesignFile.getAbsolutePath()} );
+		assertEquals(0, exitStatus);
+		
+		assertTrue(outputFile.exists());
+		
+		final List<VcfRecord> recs = new ArrayList<>();
+		try (VCFFileReader reader = new VCFFileReader(outputFile);) {    			
+			for (final VcfRecord rec : reader) {
+				recs.add(rec);
+				System.out.println("rec: " + rec.toString());
+			}
+			VcfHeader header = reader.getHeader();
+	    	header.getAllMetaRecords().stream().forEach(System.out::println);
+			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg0=null")));
+			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg1=20130325103517169")));
+			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg2=20130325112045146")));
+			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg3=20130325084856212")));
+		}
+		
+		assertEquals(6, recs.size());
+		assertEquals("QAF=t:0-0-0-10,rg1:0-0-0-10", recs.get(0).getInfo());
+		assertEquals("QAF=t:20-0-0-0,rg2:20-0-0-0", recs.get(1).getInfo());
+		assertEquals("QAF=t:0-10-0-0,rg3:0-10-0-0", recs.get(2).getInfo());
+		assertEquals("QAF=t:0-0-0-20,rg2:0-0-0-20", recs.get(3).getInfo());
+		assertEquals("QAF=t:0-10-0-0,rg1:0-10-0-0", recs.get(4).getInfo());
+		assertEquals("QAF=t:0-20-0-0,rg0:0-20-0-0", recs.get(5).getInfo());
+	}
 
 }

--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorTest.java
@@ -354,8 +354,11 @@ public class SignatureGeneratorTest {
     }
 	
     static void getBamFile(File bamFile, boolean validHeader, boolean useChrs) {
-	    	final SAMFileHeader header = getHeader(validHeader, useChrs);
-	    	List<SAMRecord> data = getRecords(useChrs, header, true);
+    	getBamFile(bamFile,  validHeader,  useChrs, false);
+    }
+    static void getBamFile(File bamFile, boolean validHeader, boolean useChrs, boolean addReadGroupToHeaderAndRecords) {
+	    	final SAMFileHeader header = getHeader(validHeader, useChrs, addReadGroupToHeaderAndRecords);
+	    	List<SAMRecord> data = getRecords(useChrs, header, true, addReadGroupToHeaderAndRecords);
 	//    	if ( ! validHeader) header.setSequenceDictionary(new SAMSequenceDictionary());
 	    	final SAMOrBAMWriterFactory factory = new SAMOrBAMWriterFactory(header, false, bamFile, false);
 	    	try {
@@ -366,8 +369,10 @@ public class SignatureGeneratorTest {
 	    		factory.closeWriter();
 	    	}
     }
-    
-	private static SAMFileHeader getHeader(boolean valid, boolean useChrs) {
+    public static SAMFileHeader getHeader(boolean valid, boolean useChrs) {
+    	return getHeader(valid, useChrs, false);
+    }    
+	public static SAMFileHeader getHeader(boolean valid, boolean useChrs, boolean addReadGroups) {
 		final SAMFileHeader header = new SAMFileHeader();
 		
 		final SAMProgramRecord bwaPG = new SAMProgramRecord("bwa");
@@ -384,6 +389,11 @@ public class SignatureGeneratorTest {
 			rgRec.setAttribute("PG", "tmap");
 			header.addReadGroup(rgRec);
 		}
+		if (addReadGroups) {
+			header.addReadGroup(new SAMReadGroupRecord("20130325103517169"));
+			header.addReadGroup(new SAMReadGroupRecord("20130325112045146"));
+			header.addReadGroup(new SAMReadGroupRecord("20130325084856212"));
+		}
 		
 		// looks like we need this to be specifically defined
 		final SAMSequenceDictionary seqDict = new SAMSequenceDictionary();
@@ -397,8 +407,10 @@ public class SignatureGeneratorTest {
 		
 		return header;
 	}
-	
 	private static List<SAMRecord> getRecords(boolean useChr, SAMFileHeader header, boolean isValid) {
+		return  getRecords( useChr,  header,  isValid, false); 
+	}	
+	private static List<SAMRecord> getRecords(boolean useChr, SAMFileHeader header, boolean isValid, boolean addRG) {
 		List<SAMRecord> records = new ArrayList<>();
 //		records.add("HS2000-152_756:1:1316:11602:65138	89	chr1	9993	25	100M	=	9993	0	TCTTCCGATCTCCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTA	B@??BBCCB<>BCBB?:BAA?9-A;?2;@ECA=;7BEE?=7D9@@8.C;B8=.HGDBBBCCD::*GGD:?*FDGFCA>EIHEEBEAEFDFFC=+?DD@@@	X0:i:1	X1:i:0	ZC:i:9	MD:Z:0C0T0G6A0A89	PG:Z:MarkDuplicates	RG:Z:20130325103517169	XG:i:0	AM:i:0	NM:i:5	SM:i:25	XM:i:5	XN:i:8	XO:i:0	XT:A:U");
 		SAMRecord sam = new SAMRecord(header);
@@ -410,6 +422,9 @@ public class SignatureGeneratorTest {
 		sam.setReadString("TCTTCCGATCTCCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTA");
 		sam.setBaseQualityString("B@??BBCCB<>BCBB?:BAA?9-A;?2;@ECA=;7BEE?=7D9@@8.C;B8=.HGDBBBCCD::*GGD:?*FDGFCA>EIHEEBEAEFDFFC=+?DD@@@");
 		sam.setCigarString("100M");
+		if (addRG) {
+			sam.setAttribute("RG", "20130325103517169");
+		}
 		
 		assertEquals(true, SAMUtils.isSAMRecordValidForVariantCalling(sam, true));
 		for (int i = 0 ; i < 10; i++) records.add(sam);
@@ -423,6 +438,10 @@ public class SignatureGeneratorTest {
 		sam.setReadString("TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCCCACCCCCTACCCCACACTCACCCACCCCCTAACCTCAGCACCCC");
 		sam.setBaseQualityString("CCCFFFFFFHHHHGGIJJIIJJJJJJJJJJGEHIJJ9)?)?D))?(?BFB;CD@C#############################################");
 		sam.setCigarString("45M1I14M4D9M2D21M10S");
+		sam.setAttribute("RG", "20130325112045146");
+		if (addRG) {
+			sam.setAttribute("RG", "20130325112045146");
+		}
 		for (int i = 0 ; i < 20; i++) records.add(sam);
 		
 //		records.add("HS2000-152_757:7:1311:15321:98529	163	chr1	10002	0	100M	=	10020	118	AACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACACTAACCCTAACCCTAACCCTAACCCTAACCCTAACC	@@@FFDFFB;DFHIHIIIIJGICGGGGGGF?9CF;@?DD;BDGG2DEFGC9EDHHI@CCEEFE)=?33;6;6;@AA;=A?2<?((59(9<<((28?<?B8	X0:i:362	ZC:i:8	MD:Z:63C36	PG:Z:MarkDuplicates	RG:Z:20130325084856212	XG:i:0	AM:i:0	NM:i:1	SM:i:0	XM:i:1	XO:i:0	XT:A:R");
@@ -434,6 +453,9 @@ public class SignatureGeneratorTest {
 		sam.setReadString("AACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACACTAACCCTAACCCTAACCCTAACCCTAACCCTAACC");
 		sam.setBaseQualityString("@@@FFDFFB;DFHIHIIIIJGICGGGGGGF?9CF;@?DD;BDGG2DEFGC9EDHHI@CCEEFE)=?33;6;6;@AA;=A?2<?((59(9<<((28?<?B8");
 		sam.setCigarString("100M");
+		if (addRG) {
+			sam.setAttribute("RG", "20130325084856212");
+		}
 		for (int i = 0 ; i < 10; i++) records.add(sam);
 		
 //		records.add("HS2000-152_756:2:2306:7001:4421	99	chr1	10003	29	2S53M1I44M	=	10330	426	TGACCCTGACCCTGACCCTGACCCTGACCCTGACCCTGACCCTGACCCTGACCCTAAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAA	CCCFFFFFHHHHHIJJJJEHGIIJIHGIIJIFGIJJJGGHHIIGCDGIHI>GIIEAFGJJI@EGFDFCE@DDDE@CA=A;3;?BDB?CD@DB9ADDBA9?	ZC:i:7	MD:Z:5A5A5A5A5A5A5A5A49	PG:Z:MarkDuplicates	RG:Z:20130325112045146	XG:i:1	AM:i:29	NM:i:9	SM:i:29	XM:i:8	XO:i:1	XT:A:M");
@@ -445,6 +467,9 @@ public class SignatureGeneratorTest {
 		sam.setMappingQuality(60);
 		sam.setBaseQualityString("CCCFFFFFHHHHHIJJJJEHGIIJIHGIIJIFGIJJJGGHHIIGCDGIHI>GIIEAFGJJI@EGFDFCE@DDDE@CA=A;3;?BDB?CD@DB9ADDBA9?");
 		sam.setCigarString("2S53M1I44M");
+		if (addRG) {
+			sam.setAttribute("RG", "20130325112045146");
+		}
 		for (int i = 0 ; i < 20; i++) records.add(sam);
 		
 //		records.add("HS2000-152_756:1:1215:14830:88102	99	chr1	10004	29	24M4D76M	=	10441	537	CCCTACCCCTACCCCTACCCCTAAAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTTACCCTAACCCTTACCCTAACC	CCCFFFFFHHHHHJJIHFHJIGIHGIIJJJJIJJIIIIJJJJJIIJJJJIJJJJJJJJHHGHHFFEFCEEDD9?BABDCDDDDDDDDDDDDCDDDDDDDB	ZC:i:9	MD:Z:5A5A5A6^CCCT54A11A9	PG:Z:MarkDuplicates	RG:Z:20130325103517169	XG:i:4	AM:i:29	NM:i:9	SM:i:29	XM:i:5	XO:i:1	XT:A:M");
@@ -456,6 +481,9 @@ public class SignatureGeneratorTest {
 		sam.setBaseQualityString("CCCFFFFFHHHHHJJIHFHJIGIHGIIJJJJIJJIIIIJJJJJIIJJJJIJJJJJJJJHHGHHFFEFCEEDD9?BABDCDDDDDDDDDDDDCDDDDDDDB");
 		sam.setMappingQuality(60);
 		sam.setCigarString("24M4D76M");
+		if (addRG) {
+			sam.setAttribute("RG", "20130325103517169");
+		}
 		for (int i = 0 ; i < 10; i++) records.add(sam);
 		
 		sam = new SAMRecord(header);


### PR DESCRIPTION
# Description

When running against bams with high coverage, the existing `SignatureGeneratorBespoke` class will use lots of memory. This has caused processes to fail as the amount of memory used has exceeded what was ring-fenced for the process.

The existing method uses a `List` of `BaseReadGroup` objects to capture the coverage at a particular position. This means that if the coverage is high, then there will be a large number of `BaseReadGroup` objects in the collection. 

eg. the following (taken from a NIH FFPE bam) shows the coverage we have at one particular position:
```
QAF=t:1435-280-2610-344506,rg1:266-58-517-68624,rg2:372-70-682-82941,rg3:381-80-712-102881,rg4:416-72-699-90060
```
This is telling us that there are 348831 reads at this position.
The `SignatureGeneratorBespoke` class looks at around 1.4 million positions, and while it is highly unlikely that all of those positions will have coverage levels as high as this particular one, it is plain to see that memory usage could become very high.


The solution as proposed in this PR is to use a 2 dimensional int array rather than the `List` of `BaseReadGroup`'s to store coverage.
The top level of the array will the size of the number of readgroups present int he BAM. The second level of array will be of size 4, one for each of A, C, G, and T.
And so, it should look something like this:

```
int [][] coverageArray = new int[numberofReadGroups][4];
```

This has the huge benefit of remaining constant in size, from a memory perspective, so a bam that has coverage across all of the 1.4 million positions and average coverage (30x to 60x) will use the same amount of memory as a high coverage bam that has positions at all 1.4 million, with coverages in the millions.
This method will also significantly reduce the amount of object creation and garbage collection that the process will need to perform.
Roughly 2 GB of memory will be used using the 2-D int array, whereas the existing method threw an `OutOfMemory` error when it had 12GB allocated to it.

I have also deprecated the `BaseReadGroup` class.


Fixes #126 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have added unit tests to ensure that the new method produces the same output as the existing method.
I have also run the process against a NIH FFPE bam file, and compared the output to the existing method.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
