### PR TITLE
Qsv change test so that is just looks at the year in the analysis id

### DIFF
--- a/qsv/test/org/qcmg/qsv/util/QSVUtilTest.java
+++ b/qsv/test/org/qcmg/qsv/util/QSVUtilTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
+import java.util.Locale;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -168,9 +169,11 @@ public class QSVUtilTest {
 	}
 
 	@Test 
-	public void testGetAnalysisId() {    	
-		assertEquals("qSV_test_20121511_1544", QSVUtil.getAnalysisId(false, "test", new Date(1352958269803L)));
-//		assertTrue(QSVUtil.getAnalysisId(false, "test", new Date(1352958269803L)).contains("qSV_test_20121511_1544"));
+	public void testGetAnalysisId() {
+		/*
+		 * Due to timezone differences, it is safest just to dictate which year we expect the analysis id to start with
+		 */
+		assertEquals(true, QSVUtil.getAnalysisId(false, "test", new Date(1352958269803L)).startsWith("qSV_test_2012"));
 		assertTrue(QSVUtil.getAnalysisId(true, "test", new Date(1352958269803L)).length() == 36);
 	}
 


### PR DESCRIPTION
# Description

There is a `junit` test in `QSVUTilTest` that uses a `long` to generate a `Date` object.
We then test that the output of the `QSVUtil.getAnalysisId` method returns a specific data and time.
This is great when we are all in the same timezone.
When we are not in the same timezone, however, the test fails as a different time (and possible day of month) is returned.

This was in fact reported in issue #119 


I think that the purpose of the test is to check that the analysis id returned is of the form `qSV_test_<date>` and that it is not really concerned what date is returned.
And so, I've modified the test so that it checks that the correct year (2012) is returned and doesn't check the remainder of the `Date` string that is returned.


Fixes #119 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I set my timezone to something non-aussie using the following command to confirm that the test failed:
```
System.setProperty("user.timezone", "GMT-12");
```
The test was then modified to check for just the year, and it passes in both my default timezone, and `GMT-12`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
