### PR TITLE
Reduce logging in qsignature's Compare

### DIFF
--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -135,25 +135,6 @@ public class Compare {
 		
 		performComparisons(files);
 		
-		
-		for (Comparison comp : allComparisons) {
-			if (null == comp) {
-				logger.warn("Null comparison object in allComparions");
-			} else if (comp.getScore() < cutoff) {
-				suspiciousResults.add(comp.toSummaryString());
-			}
-		}
-		
-		logger.info("");
-		if (suspiciousResults.isEmpty()) {
-			logger.info("No suspicious results found");
-		} else {
-			logger.info("Suspicious results SUMMARY:");
-			for (String s : suspiciousResults) {
-				logger.info(s);
-			}
-		}
-		
 		if (outputXml != null) {
 			SignatureUtil.writeXmlOutput(fileIdsAndCounts, allComparisons, outputXml);
 		}


### PR DESCRIPTION
Removed marking of suspicious comparisons and their logging

# Description

The `Compare` class will mark as suspicious any comparison that has a score less than 0.95. While this may be valid for like vs like comparisons, it is not when comparing qsigs from different donors.
All suspicious comparisons are then logged.

Some projects have many comparisons (around 2 million), and to have them all logging to file takes up lots of space for no gain. All comparisons are available in the xml output.

And so, this PR has removed the code that collects so called suspicious comparisons and logs them.
