### PR TITLE
re-jig test so that it will not fail if other tests in the class are run before it

### DIFF
--- a/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
+++ b/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.util.ChrPositionCache;
 import org.qcmg.illumina.IlluminaRecord;
 import org.qcmg.sig.CompareTest;
 import org.qcmg.sig.model.Comparison;
@@ -94,7 +95,7 @@ public class SignatureUtilTest {
 		String evenData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49\t";
 		String oddData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:20,C:0,G:35,T:0,N:0,TOTAL:55;NOVELCOV=A:20,C:0,G:29,T:0,N:0,TOTAL:49\t";
 		for (int i = 0 ; i < 10 ; i++ ) {
-			trad1Data.add("chr1\t" + i + (i % 2 == 0 ? evenData : oddData));
+			trad1Data.add("chr1\t1" + i + (i % 2 == 0 ? evenData : oddData));
 		}
 		CompareTest.writeDataToFile(trad1Data, testVcf);
 		TIntByteHashMap byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
@@ -102,8 +103,15 @@ public class SignatureUtilTest {
 		/*
 		 * values in map will be either HOM_G or HET_AG
 		 */
-		for (int i = 1 ; i <= 10 ; i++) {
-			assertEquals((i % 2 == 0 ? SignatureUtil.HET_AG : SignatureUtil.HOM_G), byteMap.get(i));
+		
+		
+		/*
+		 * need to use ChrPositionCache.getStringIndex to get the index in the cache for the position.
+		 * This test used to just use 0-9, but if the test was run after other tests that put entries into the cache, then it would fail.
+		 * This fix should remove the 'Flaky' nature of this test 
+		 */
+		for (int i = 0 ; i < 10 ; i++ ) {
+			assertEquals(i % 2 == 0 ? SignatureUtil.HOM_G : SignatureUtil.HET_AG, byteMap.get(ChrPositionCache.getStringIndex("chr1\t1" + i)));
 		}
 	}
 	

--- a/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
+++ b/qsignature/test/org/qcmg/sig/util/SignatureUtilTest.java
@@ -95,7 +95,7 @@ public class SignatureUtilTest {
 		String evenData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:0,C:0,G:55,T:0,N:0,TOTAL:55;NOVELCOV=A:0,C:0,G:49,T:0,N:0,TOTAL:49\t";
 		String oddData = "\tcnvi0147523\tG\t.\t.\t.\tFULLCOV=A:20,C:0,G:35,T:0,N:0,TOTAL:55;NOVELCOV=A:20,C:0,G:29,T:0,N:0,TOTAL:49\t";
 		for (int i = 0 ; i < 10 ; i++ ) {
-			trad1Data.add("chr1\t1" + i + (i % 2 == 0 ? evenData : oddData));
+			trad1Data.add("chr1\t" + i + (i % 2 == 0 ? evenData : oddData));
 		}
 		CompareTest.writeDataToFile(trad1Data, testVcf);
 		TIntByteHashMap byteMap = SignatureUtil.loadSignatureRatiosFloatGenotypeNew(testVcf);
@@ -111,7 +111,7 @@ public class SignatureUtilTest {
 		 * This fix should remove the 'Flaky' nature of this test 
 		 */
 		for (int i = 0 ; i < 10 ; i++ ) {
-			assertEquals(i % 2 == 0 ? SignatureUtil.HOM_G : SignatureUtil.HET_AG, byteMap.get(ChrPositionCache.getStringIndex("chr1\t1" + i)));
+			assertEquals(i % 2 == 0 ? SignatureUtil.HOM_G : SignatureUtil.HET_AG, byteMap.get(ChrPositionCache.getStringIndex("chr1\t" + i)));
 		}
 	}
 	


### PR DESCRIPTION
# Description

So test [`SignatureUtilTest.getGenotypesAsByte`](http://bionode05.adqimr.ad.lan:8111/project.html?projectId=AdamaJava&tab=testDetails&testNameId=714643023026225746#analysis) is causing intermittent failures.

It has a success rate of 87%

Turns out that this is due to the use of a static cache that is used by the `SignatureUtil` class.
If that flaky test is run before any other tests that use the cache is run, then it will succeed. If the flaky test is run after any other tests that use the cache have run, it fails.

This is because the flaky test uses values 0 to 9 to get entries from the map (it assumes that the cache only contains the 10 entries that the test has inserted into it).

If the test uses the cache to get the index that should be used (as the fix in this PR does), then it works as expected.

## Type of change

- [x] Bug fix in test (non-breaking change which fixes an issue)

# How Has This Been Tested?

To test this, I introduced an identical test to the flaky test with a positional offset (of 10).
I then ran the whole test class and one of the tests would fail. It would be either the original or the copy with the offset that would fail, depending on which was run second.

Once the fix was in place, both tests pass.
