### PR TITLE
allow zero child for variableGroup

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
+++ b/qprofiler2/src/org/qcmg/qprofiler2/qprofiler2.xsd
@@ -90,13 +90,13 @@
    <xs:complexType name="groupType">
 	   <xs:choice>
 			<xs:sequence> 
-				<xs:element ref="value"  maxOccurs="unbounded"/>	
+				<xs:element ref="value"  maxOccurs="unbounded" minOccurs="0"/>	
 			</xs:sequence>
 			<xs:sequence> 
-				<xs:element ref="tally"  maxOccurs="unbounded"/>	
+				<xs:element ref="tally"  maxOccurs="unbounded" minOccurs="0"/>	
 			</xs:sequence>
 			<xs:sequence> 
-				<xs:element ref="closedBin"  maxOccurs="unbounded"/>	
+				<xs:element ref="closedBin"  maxOccurs="unbounded" minOccurs="0"/>	
 			</xs:sequence>			
 			<xs:element name="baseCycle" maxOccurs="unbounded" type="cycleType"/>
 		</xs:choice>


### PR DESCRIPTION
# Description

Sometimes there are no reads from one of readGroup mapped to a contig. We have to allow zero child element under tag \<variableGroup\>. 

Fixes # (issue)

## Type of change
minor changes, just adjust one parameter in XSD file

# How Has This Been Tested?
There was an xml can't be validated by previous XSD file, but is passed by this updated XSD file. 
 

# Checklist:
- [x] New and existing unit tests pass locally with my changes
