### PR TITLE
Qsig Compare - reduce logging

### DIFF
--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -180,9 +180,6 @@ public class Compare {
 			if (result.getValue().size() < 1000) {
 				logger.warn("low coverage (" + result.getValue().size() + ") for file " + f.getAbsolutePath());
 			}
-			
-			cache.put(f, result);
-			fileIdsAndCounts.get(f.getAbsolutePath())[1] = result.getValue().size();
 		}
 		return result;
 	}
@@ -277,6 +274,7 @@ public class Compare {
 						if (null != prevGenotypes) {
 							logger.warn("already genotypes associated with file: " + f.getAbsolutePath());
 						}
+						fileIdsAndCounts.get(f.getAbsolutePath())[1] = genotypes.getValue().size();
 					}
 				});
 		}

--- a/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
@@ -512,7 +512,7 @@ public class SignatureUtil {
 	public static void getDataFromBespolkeLayout(File file, int minCoverage, int minRGCoverage, TIntByteHashMap ratios,
 			TMap<String, TIntByteHashMap> rgRatios, Map<String, String> rgIds, TabbedFileReader reader) {
 		int noOfRGs = rgIds.size();
-		logger.info("Number of rgs for  " + file.getAbsolutePath() + " is " + noOfRGs);
+		logger.debug("Number of rgs for  " + file.getAbsolutePath() + " is " + noOfRGs);
 		
 		String line;
 		


### PR DESCRIPTION
# Description

There is currently lots on logging generated when running `qsignature`'s `Compare` class.
Most of it is not particularly informative, and so I have reduced the logging level from `info` to `debug` for one line.

A bug was also discovered when undergoing this work -> data was being added to a map twice (resulting in extra logging!)
This bug was fixed.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
