### PR TITLE
Allowing longer shot gun reads for kmers analysis

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -314,7 +314,7 @@ public class BamSummaryReport2 extends SummaryReport {
 	 * Parse a SAMRecord Collate various pieces of info from the SAMRecord ready for the summariser to retrieve
 	 * @param record SAMRecord next row in file
 	 */
-	public void parseRecord( final SAMRecord record ) throws IllegalArgumentException{
+	public void parseRecord( final SAMRecord record ) {
  		updateRecordsInputed();
  				
 		String readGroup = XmlUtils.UNKNOWN_READGROUP;

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -314,7 +314,7 @@ public class BamSummaryReport2 extends SummaryReport {
 	 * Parse a SAMRecord Collate various pieces of info from the SAMRecord ready for the summariser to retrieve
 	 * @param record SAMRecord next row in file
 	 */
-	public void parseRecord( final SAMRecord record ) {
+	public void parseRecord( final SAMRecord record ) throws Exception{
  		updateRecordsInputed();
  				
 		String readGroup = XmlUtils.UNKNOWN_READGROUP;

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -167,7 +167,7 @@ public class BamSummaryReport2 extends SummaryReport {
 		for(int order = 0; order < 3; order++) {
 			counts += seqByCycle[order].getInputCounts();
 		}
-		Pair rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, counts);
+		Pair<String, Number> rcPair = new Pair<>(ReadGroupSummary.READ_COUNT, counts);
 		
 		//sequenceBase	
 		Element ele = XmlUtils.createMetricsNode( parent,  XmlUtils.SEQ_BASE,  rcPair );	
@@ -207,7 +207,7 @@ public class BamSummaryReport2 extends SummaryReport {
 		for(int order = 0; order < 3; order++) {
 			counts += qualByCycleInteger[order].getInputCounts();
 		}
-		Pair rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, counts);
+		Pair<String, Number> rcPair = new Pair<>(ReadGroupSummary.READ_COUNT, counts);
 		
 		//"count on quality base",
 		Element ele = XmlUtils.createMetricsNode( parent,  XmlUtils.QUAL_BASE,  rcPair); 
@@ -314,7 +314,7 @@ public class BamSummaryReport2 extends SummaryReport {
 	 * Parse a SAMRecord Collate various pieces of info from the SAMRecord ready for the summariser to retrieve
 	 * @param record SAMRecord next row in file
 	 */
-	public void parseRecord( final SAMRecord record ) throws Exception{
+	public void parseRecord( final SAMRecord record ) throws IllegalArgumentException{
  		updateRecordsInputed();
  				
 		String readGroup = XmlUtils.UNKNOWN_READGROUP;

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -107,7 +107,7 @@ public class FastqSummaryReport extends SummaryReport {
 	 * 
 	 * @return next row in file
 	 */
-	public void parseRecord(FastqRecord record) throws IllegalArgumentException {
+	public void parseRecord(FastqRecord record) {
 		if( null == record ) return;
 		 			
 		updateRecordsInputed();

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -107,7 +107,7 @@ public class FastqSummaryReport extends SummaryReport {
 	 * 
 	 * @return next row in file
 	 */
-	public void parseRecord(FastqRecord record) {
+	public void parseRecord(FastqRecord record) throws Exception {
 		if( null == record ) return;
 		 			
 		updateRecordsInputed();

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -66,7 +66,7 @@ public class FastqSummaryReport extends SummaryReport {
 		for(int order = 0; order < 3; order++) {
 			counts += seqByCycle.getInputCounts();
 		}
-		Pair rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, counts);
+		Pair<String, Number> rcPair = new Pair<>(ReadGroupSummary.READ_COUNT, counts);
 		Element ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_BASE , rcPair); 
 		seqByCycle.toXml( ele, XmlUtils.SEQ_BASE,seqByCycle.getInputCounts());	
 		
@@ -107,7 +107,7 @@ public class FastqSummaryReport extends SummaryReport {
 	 * 
 	 * @return next row in file
 	 */
-	public void parseRecord(FastqRecord record) throws Exception {
+	public void parseRecord(FastqRecord record) throws IllegalArgumentException {
 		if( null == record ) return;
 		 			
 		updateRecordsInputed();

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
@@ -18,7 +18,8 @@ import org.w3c.dom.Element;
 
 public class KmersSummary {
 		
-	int cycleNo = 0 ; //init 0, eventially store the biggest cycle number
+	//init 0, eventially store the biggest cycle number
+	private int cycleNo ; 
 
 	//unpaired, firstOfPair, secondOfPair
 	private final QCMGAtomicLongArray[] tally = new QCMGAtomicLongArray[3] ;
@@ -39,6 +40,8 @@ public class KmersSummary {
 	private final String[] mersStrList; 
 	
 	public KmersSummary( int length ) {	
+		cycleNo = 0 ; //init 0, eventially store the biggest cycle number
+		
 		if(length > maxKmers ){ 			
 			System.err.println("array size exceed Integer.MAX_VALUE/2! please reduce kmers length below 6. ");
 			System.exit(1);
@@ -64,8 +67,8 @@ public class KmersSummary {
 		
 		for(int i = 0; i < 3; i ++){
 			//array capacity for kmers. eg. kmer=6, base=1000mers ,  
-			//maxCapacity = 4^6 * 1000 = 4096,000 incase of excludes 'N' 
-			//maxCapacity = 5^6 * 1000 = 15625,000 incase of includes 'N'
+			//maxCapacity = 4^6 * 1000 = 4096,000 in case of excludes 'N' 
+			//maxCapacity = 5^6 * 1000 = 15625,000 in case of includes 'N'
 			tally[i] =  new QCMGAtomicLongArray( (int) ( iniCycleNo * mersStrList.length ),  (int) ( maxCycleNo * mersStrList.length ));	
 			parsedCount[i] = new AtomicLong();
 		}
@@ -236,7 +239,7 @@ public class KmersSummary {
 	Set<String> getPopularKmerString(final int popularNo, final int kLength, final boolean includeN, final int flagFristRead){
 	 
 		String[] possibleMers = getPossibleKmerString(kLength, false);
-		//incase empty input bam
+		//in case empty input bam
 		if(cycleNo == 0 || possibleMers.length <= popularNo    ) 
 			return new HashSet<String>(Arrays.asList(possibleMers) );
 	 	

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
@@ -106,7 +106,7 @@ public class KmersSummary {
 		String str1 = producer( k, "", includeN );			
 		return str1.split(Constants.COMMA_STRING);
 	}	
-	public void parseKmers( byte[] readString, boolean reverse , int flagFirstOfPair) throws IllegalArgumentException{
+	public void parseKmers( byte[] readString, boolean reverse , int flagFirstOfPair) {
 		 if( readString.length > maxCycleNo ) {
 			 throw new IllegalArgumentException("Can't handle large read sequence, which length is greater than " + maxCycleNo + "!");
 			 

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
@@ -106,9 +106,9 @@ public class KmersSummary {
 		String str1 = producer( k, "", includeN );			
 		return str1.split(Constants.COMMA_STRING);
 	}	
-	public void parseKmers( byte[] readString, boolean reverse , int flagFirstOfPair) throws Exception{
+	public void parseKmers( byte[] readString, boolean reverse , int flagFirstOfPair) throws IllegalArgumentException{
 		 if( readString.length > maxCycleNo ) {
-			 throw new Exception("Can't handle large read sequence, which length is greater than " + maxCycleNo + "!");
+			 throw new IllegalArgumentException("Can't handle large read sequence, which length is greater than " + maxCycleNo + "!");
 			 
 		 }
 		 //get the biggest cycle

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
@@ -18,14 +18,17 @@ import org.w3c.dom.Element;
 
 public class KmersSummary {
 		
-	private int cycleNo = 0 ; //init 0, eventially store the biggest cycle number
-	
+	int cycleNo = 0 ; //init 0, eventially store the biggest cycle number
+
 	//unpaired, firstOfPair, secondOfPair
 	private final QCMGAtomicLongArray[] tally = new QCMGAtomicLongArray[3] ;
 	private final AtomicLong[] parsedCount = new AtomicLong[3]; 
+			
+	//here we can only handle read length smaller than 1000
+    static final int maxCycleNo = 1000;	
+	private static final int iniCycleNo = 126;
 	
-	private static final int iniCycleNo = 126;	
-	public static final int maxKmers = 6; 
+	public static final int maxKmers = 6; 	
 	public static final String atgc = "ATGC";  //make sure letter on same order
 	public static final String atgcn = "ATGCN";  //make sure letter on same order
 	public static final char[] atgcCharArray = new char[]{'A','T','G','C'};
@@ -60,7 +63,10 @@ public class KmersSummary {
 		}	
 		
 		for(int i = 0; i < 3; i ++){
-			tally[i] =  new QCMGAtomicLongArray( (int) ( iniCycleNo * mersStrList.length ) );	
+			//array capacity for kmers. eg. kmer=6, base=1000mers ,  
+			//maxCapacity = 4^6 * 1000 = 4096,000 incase of excludes 'N' 
+			//maxCapacity = 5^6 * 1000 = 15625,000 incase of includes 'N'
+			tally[i] =  new QCMGAtomicLongArray( (int) ( iniCycleNo * mersStrList.length ),  (int) ( maxCycleNo * mersStrList.length ));	
 			parsedCount[i] = new AtomicLong();
 		}
 		
@@ -97,7 +103,11 @@ public class KmersSummary {
 		String str1 = producer( k, "", includeN );			
 		return str1.split(Constants.COMMA_STRING);
 	}	
-	public void parseKmers( byte[] readString, boolean reverse , int flagFirstOfPair){
+	public void parseKmers( byte[] readString, boolean reverse , int flagFirstOfPair) throws Exception{
+		 if( readString.length > maxCycleNo ) {
+			 throw new Exception("Can't handle large read sequence, which length is greater than " + maxCycleNo + "!");
+			 
+		 }
 		 //get the biggest cycle
 		 int c = readString.length - merLength + 1;	
 		 if(c > cycleNo) cycleNo = c; 
@@ -127,7 +137,7 @@ public class KmersSummary {
 		return cycle * mersStrList.length +  pos;
 	}
 	
-	
+	//just for fast caculate, the return value is not position of mers in QCMGArray
 	private int getEntry(byte[] mers){
 		int entry = 0; 
 		for(int i = 0, j = mers.length-1; i < mers.length; i ++, j-- ){
@@ -222,7 +232,8 @@ public class KmersSummary {
 		}			
 	}	
 	
-	public Set<String> getPopularKmerString(final int popularNo, final int kLength, final boolean includeN, final int flagFristRead){
+	//set to package access level due for unit test
+	Set<String> getPopularKmerString(final int popularNo, final int kLength, final boolean includeN, final int flagFristRead){
 	 
 		String[] possibleMers = getPossibleKmerString(kLength, false);
 		//incase empty input bam

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -124,7 +124,7 @@ public class KmersSummaryTest {
 	}
 	
 	@Test
-	public void toXmlFastqTest() throws IllegalArgumentException, ParserConfigurationException {
+	public void toXmlFastqTest() throws  ParserConfigurationException {
 		
 		final String base1 = "CAGNGTTAGGTTTTT";
 		final String base2 = "CCCCGTTAGGTTTTTT";
@@ -156,7 +156,7 @@ public class KmersSummaryTest {
 	}
 
 	@Test
-	public void toXmlTest() throws IllegalArgumentException, ParserConfigurationException, IOException {		
+	public void toXmlTest() throws ParserConfigurationException, IOException {		
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
  		try( SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);){
  			for (SAMRecord record : reader){ 		
@@ -212,7 +212,7 @@ public class KmersSummaryTest {
 	
 	
 	@Test
-	public void bothForwardTest() throws IllegalArgumentException, IOException {
+	public void bothForwardTest() throws  IOException {
 		
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
  		try( SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);){
@@ -263,7 +263,7 @@ public class KmersSummaryTest {
 	 * here we set the base to more the 15 base
 	 * @throws ParserConfigurationException
 	 */
-	public void bothFirstTest() throws IllegalArgumentException {
+	public void bothFirstTest() {
 						
 		final String base1 = "CAGNGTTAGGTTTTT";
 		final String base2 = "CCCCGTTAGGTTTTTT";
@@ -320,7 +320,7 @@ public class KmersSummaryTest {
 	}
 		 
 	@Test
-	public void maxLengthTest() throws IllegalArgumentException {	
+	public void maxLengthTest() {	
 		final String bases = "ATGC";
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
 		

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -349,10 +349,6 @@ public class KmersSummaryTest {
 			//expected exception due to large seq 
 			assertTrue(true);
 		}				
-	}
-	
+	}	
 }
-
-
-
 

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -98,7 +100,7 @@ public class KmersSummaryTest {
 	}
 	
 	@Test
-	public void bothReversedTest() throws Exception {		
+	public void bothReversedTest() throws IllegalArgumentException, IOException {		
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
  		try( SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);){
  			for (SAMRecord record : reader){ 
@@ -122,7 +124,7 @@ public class KmersSummaryTest {
 	}
 	
 	@Test
-	public void toXmlFastqTest() throws Exception {
+	public void toXmlFastqTest() throws IllegalArgumentException, ParserConfigurationException {
 		
 		final String base1 = "CAGNGTTAGGTTTTT";
 		final String base2 = "CCCCGTTAGGTTTTTT";
@@ -154,7 +156,7 @@ public class KmersSummaryTest {
 	}
 
 	@Test
-	public void toXmlTest() throws Exception {		
+	public void toXmlTest() throws IllegalArgumentException, ParserConfigurationException, IOException {		
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
  		try( SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);){
  			for (SAMRecord record : reader){ 		
@@ -210,7 +212,7 @@ public class KmersSummaryTest {
 	
 	
 	@Test
-	public void bothForwardTest() throws Exception {
+	public void bothForwardTest() throws IllegalArgumentException, IOException {
 		
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
  		try( SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);){
@@ -261,7 +263,7 @@ public class KmersSummaryTest {
 	 * here we set the base to more the 15 base
 	 * @throws ParserConfigurationException
 	 */
-	public void bothFirstTest() throws Exception {
+	public void bothFirstTest() throws IllegalArgumentException {
 						
 		final String base1 = "CAGNGTTAGGTTTTT";
 		final String base2 = "CCCCGTTAGGTTTTTT";
@@ -318,7 +320,7 @@ public class KmersSummaryTest {
 	}
 		 
 	@Test
-	public void maxLengthTest() throws Exception {	
+	public void maxLengthTest() throws IllegalArgumentException {	
 		final String bases = "ATGC";
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
 		
@@ -345,7 +347,7 @@ public class KmersSummaryTest {
 			summary.parseKmers(sb.toString().getBytes(), false, 1);	
 			//must fail if no exception happen
 			assertFalse(true);
-		}catch(Exception e) {
+		}catch(IllegalArgumentException e) {
 			//expected exception due to large seq 
 			assertTrue(true);
 		}				

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -10,13 +10,9 @@ import java.io.PrintWriter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
@@ -28,7 +24,6 @@ import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.XmlElementUtils;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qprofiler2.util.XmlUtils;
-import org.w3c.dom.DOMException;
 import org.w3c.dom.Element;
 
 import htsjdk.samtools.SAMRecord;
@@ -335,7 +330,7 @@ public class KmersSummaryTest {
 			summary.parseKmers(sb.toString().getBytes(), false, 1);	
 		}
 		
-		//reach maximum 1000base
+		//reach maximum 1000 base
 		for(int i = 0; i < (KmersSummary.maxCycleNo/bases.length() -200); i ++) sb.append(bases);		
 		assertTrue(sb.length() == KmersSummary.maxCycleNo);
 		summary.parseKmers(sb.toString().getBytes(), false, 1);	

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -100,7 +100,7 @@ public class KmersSummaryTest {
 	}
 	
 	@Test
-	public void bothReversedTest() throws IllegalArgumentException, IOException {		
+	public void bothReversedTest() throws IOException {		
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
  		try( SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);){
  			for (SAMRecord record : reader){ 


### PR DESCRIPTION
# Description

qProfiler2 used the default hardcoded value (MAX_CAPACITY = 2048 * 2048) as the maximum value for QCMGArray size. It works fine for reads less than 267 bases. Recently the shotgun sequence is getting longer and longer, we got three BAMs which contains read length reached 400 bases. So we have to increase the acceptable read length for Kmers calculation. Here we hardcoded the maximum read length to 1000 base, so the max_capacity for QCMGArray is 1000 * (5^6) = 15,625,000. 

Regarding issue#123, this tool is designed for shotgun sequence, which length is less than 500 as we saw. It does not need to be bigger than 1000. We believe 1000 is conservative enough!

Fixes #123 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I added a related unit test to test read sequence around the boundary value (mers=1000)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
