### PR TITLE
Qsig SignatureGeneratorBespoke output options

### DIFF
--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
@@ -13,7 +13,6 @@ import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;
-import org.qcmg.sig.model.BaseReadGroup;
 import org.qcmg.vcf.VCFFileReader;
 
 import gnu.trove.map.TObjectIntMap;
@@ -261,6 +260,99 @@ public class SignatureGeneratorBespokeTest {
 		assertEquals("QAF=t:0-0-0-20,rg2:0-0-0-20", recs.get(3).getInfo());
 		assertEquals("QAF=t:0-10-0-0,rg1:0-10-0-0", recs.get(4).getInfo());
 		assertEquals("QAF=t:0-20-0-0,rg0:0-20-0-0", recs.get(5).getInfo());
+	}
+	
+	@Test
+	public void runProcessWithNoOutputOption() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
+		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		
+		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
+		
+		/*
+		 * no output or dir option specified
+		 * output will live next to input
+		 */
+		int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), 
+				"-snpPositions" , positionsOfInterestFile.getAbsolutePath(), 
+				"-i" , bamFile.getAbsolutePath(),  
+				"-illuminaArraysDesign" , illuminaArraysDesignFile.getAbsolutePath()} );
+		assertEquals(0, exitStatus);
+		assertTrue(new File(bamFile.getAbsolutePath() + ".qsig.vcf.gz").exists());
+		assertTrue(new File(bamFile.getAbsolutePath() + ".qsig.vcf.gz").length() > 0);
+	}
+		
+		
+	@Test
+	public void runProcessWithOutputOptionFile() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
+		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		
+		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
+		/*
+		 * and now with the output option pointing to a file
+		 */
+		String outputFile = testFolder.newFile("output_file").getAbsolutePath();
+		int exitStatus = qss.setup(new String[] {"--log", logFile.getAbsolutePath(), 
+				"-snpPositions", positionsOfInterestFile.getAbsolutePath(), 
+				"-i", bamFile.getAbsolutePath(),  
+				"-output", outputFile,  
+				"-illuminaArraysDesign", illuminaArraysDesignFile.getAbsolutePath()} );
+		assertEquals(0, exitStatus);
+		assertTrue(new File(outputFile).exists());
+		assertTrue(new File(outputFile).length() > 0);
+	}
+		
+	
+	@Test
+	public void runProcessWithOutputOptionDir() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
+		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		
+		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
+		/*
+		 * and now with the output option pointing to a folder
+		 * this means the output will be in the form : folder/input_name.qsig.vcf.gz
+		 */
+		String outputFolder = testFolder.newFolder("output_folder").getAbsolutePath();
+		int exitStatus = qss.setup(new String[] {"--log", logFile.getAbsolutePath(), 
+				"-snpPositions", positionsOfInterestFile.getAbsolutePath(), 
+				"-i", bamFile.getAbsolutePath(),  
+				"-output", outputFolder,  
+				"-illuminaArraysDesign", illuminaArraysDesignFile.getAbsolutePath()} );
+		assertEquals(0, exitStatus);
+		assertTrue(new File(outputFolder + File.separator + bamFile.getName() + ".qsig.vcf.gz").exists());
+		assertTrue(new File(outputFolder + File.separator + bamFile.getName() + ".qsig.vcf.gz").length() > 0);
+	}
+		
+		
+	@Test
+	public void runProcessWithDirOption() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
+		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		
+		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
+		/*
+		 * and now with the dir option pointing to a folder
+		 * this means the output will be in the form : dir/input_name.qsig.vcf.gz
+		 */
+		String dir = testFolder.newFolder("output_dir").getAbsolutePath();
+		int exitStatus = qss.setup(new String[] {"--log", logFile.getAbsolutePath(), 
+				"-snpPositions", positionsOfInterestFile.getAbsolutePath(), 
+				"-i", bamFile.getAbsolutePath(),  
+				"-d", dir,  
+				"-illuminaArraysDesign", illuminaArraysDesignFile.getAbsolutePath()} );
+		assertEquals(0, exitStatus);
+		assertEquals(true, new File(dir + File.separator + bamFile.getName() + ".qsig.vcf.gz").exists());
+		assertTrue(new File(dir + File.separator + bamFile.getName() + ".qsig.vcf.gz").length() > 0);
 	}
 
 }


### PR DESCRIPTION
# Description

`Qsignature`'s `SignatureGeneratorBespoke` has been updated so that the `output` option is recognised and acted upon.

- If the user specifies an `output` that is not a directory, then the generated output will be put there.

- If the user specifies an `output` that is a directory, then the generated output will be put into that directory but will take the name of the input with the appropriate extension (`.qsig.vcf.gz`)

- If the user specifies the `dir` option then the generated output will be put into that directory but will take the name of the input with the appropriate extension (`.qsig.vcf.gz`) **NOTE** that this is the current behaviour

- If the user specifies neither the `dir` option not the `output` option, then the generated output will be live next to the input file and will have the name of the input with the appropriate extension (`.qsig.vcf.gz`) **NOTE** that this is the current behaviour

Fixes #138 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Additional unit tests have been added to check that this works as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
