### PR TITLE
Qannotate - added tests, organised imports, formatting

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/Main.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Main.java
@@ -8,7 +8,19 @@ package au.edu.qimr.qannotate;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 
-import au.edu.qimr.qannotate.modes.*;
+import au.edu.qimr.qannotate.modes.CCMMode;
+import au.edu.qimr.qannotate.modes.CaddMode;
+import au.edu.qimr.qannotate.modes.ConfidenceMode;
+import au.edu.qimr.qannotate.modes.DbsnpMode;
+import au.edu.qimr.qannotate.modes.GermlineMode;
+import au.edu.qimr.qannotate.modes.HomoplymersMode;
+import au.edu.qimr.qannotate.modes.IndelConfidenceMode;
+import au.edu.qimr.qannotate.modes.MakeValidMode;
+import au.edu.qimr.qannotate.modes.OverlapMode;
+import au.edu.qimr.qannotate.modes.SnpEffMode;
+import au.edu.qimr.qannotate.modes.TandemRepeatMode;
+import au.edu.qimr.qannotate.modes.Vcf2maf;
+import au.edu.qimr.qannotate.modes.Vcf2mafTmp;
 
 public class Main {
 	 

--- a/qannotate/src/au/edu/qimr/qannotate/Options.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Options.java
@@ -13,13 +13,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-
 import org.qcmg.common.log.QLogger;
 
-import au.edu.qimr.qannotate.Messages;
-import au.edu.qimr.qannotate.modes.*;
+import au.edu.qimr.qannotate.modes.HomoplymersMode;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
 /*
  * parse command line to options. 
  */
@@ -83,19 +81,19 @@ public class Options {
      * check command line and store arguments and option information
      */   
     public Options(final String[] args) throws IOException{      	
-	    	parser = new OptionParser();    	       
-	    	OptionSet options =  parseArgs(args);
-	    	
-	    	if (options.has("mode")){
-	    		String m = ((String) options.valueOf("mode")).toLowerCase();
-	    		this.mode = MODE.valueOf(m); //already checked the validation of mode
-	    	} else {
-	    		this.mode = null;
-	    	}
+    	parser = new OptionParser();    	       
+    	OptionSet options =  parseArgs(args);
+    	
+    	if (options.has("mode")){
+    		String m = ((String) options.valueOf("mode")).toLowerCase();
+    		this.mode = MODE.valueOf(m); //already checked the validation of mode
+    	} else {
+    		this.mode = null;
+    	}
     		   	
         if (options.has("h") || options.has("help")) { 
-	        	displayHelp(mode);  
-	        	System.exit(0);	
+        	displayHelp(mode);  
+        	System.exit(0);	
         }
         
        //parse parameters        
@@ -296,7 +294,7 @@ public class Options {
     	}
     	//check whether file unique
  	    inputs.addAll(outputs);
-       	for (int  i = inputs.size() -1; i > 0; i --) {
+       	for (int  i = inputs.size() - 1; i > 0; i--) {
     		for (int j = i - 1; j >= 0; j-- ){
     			if (inputs.get(i).getCanonicalFile().equals(inputs.get(j).getCanonicalFile())) {
     				throw new IllegalArgumentException( "below command line values are point to same file: \n\t" + inputs.get(i) + "\n\t" + inputs.get(j) );
@@ -305,14 +303,30 @@ public class Options {
        	}
     }
 
-	public String getLogFileName() { return logFileName;}	
-	public String getLogLevel(){ return logLevel; }	 
-	public String getCommandLine() {	return commandLine; }	
-	public String getInputFileName(){return inputFileName;}
-	public String getOutputFileName(){return outputFileName;}
-	public String getDatabaseFileName(){return null != databaseFiles && databaseFiles.length > 0 ? databaseFiles[0] : null;}	
-	public String[] getDatabaseFiles(){ return (mode.equals(MODE.cadd) || mode.equals(MODE.overlap)) ? databaseFiles : null;}
-    public MODE getMode(){	return  mode; }
+	public String getLogFileName() { 
+		return logFileName;
+	}	
+	public String getLogLevel(){ 
+		return logLevel; 
+	}	 
+	public String getCommandLine() {	
+		return commandLine; 
+	}	
+	public String getInputFileName(){
+		return inputFileName;
+	}
+	public String getOutputFileName(){
+		return outputFileName;
+	}
+	public String getDatabaseFileName(){
+		return null != databaseFiles && databaseFiles.length > 0 ? databaseFiles[0] : null;
+	}	
+	public String[] getDatabaseFiles(){ 
+		return (mode.equals(MODE.cadd) || mode.equals(MODE.overlap)) ? databaseFiles : null;
+	}
+    public MODE getMode(){	
+    	return  mode; 
+    }
    
     private void displayHelp(MODE mode) throws IOException {   
         String mess = Messages.getMessage("USAGE");  
@@ -339,28 +353,52 @@ public class Options {
     }   
         
     //vcf2maf confidence
-	public String getTestSample(){  return testSample; }
-	public String getControlSample(){  return controlSample; }
+	public String getTestSample(){  
+		return testSample; 
+	}
+	public String getControlSample(){  
+		return controlSample; 
+	}
 	
 	//vcf2maf
-	public String getCenter(){  return ( mode == (MODE.vcf2maf))? center: null; }
-	public String getSequencer(){  return ( mode == (MODE.vcf2maf))? sequencer: null; }
-	public String getOutputDir(){return ( mode == (MODE.vcf2maf))? outputDir:null;}
-	public String getDonorId(){return ( mode == (MODE.vcf2maf))? donorId :null; }
+	public String getCenter(){  
+		return ( mode == (MODE.vcf2maf))? center: null; 
+	}
+	public String getSequencer(){  
+		return ( mode == (MODE.vcf2maf))? sequencer: null; 
+	}
+	public String getOutputDir(){
+		return ( mode == (MODE.vcf2maf))? outputDir:null;
+	}
+	public String getDonorId(){
+		return ( mode == (MODE.vcf2maf))? donorId :null; 
+	}
 	 
 	 //snpEff
-	public String getSummaryFileName(){ return  (mode == MODE.snpeff)? summaryFileName : null; }		
-	public String getGenesFileName(){ return  (mode == MODE.snpeff)? outputFileName + ".snpEff_genes.txt" : null; 	}		
+	public String getSummaryFileName(){ 
+		return  (mode == MODE.snpeff)? summaryFileName : null; 
+	}		
+	public String getGenesFileName(){ 
+		return  (mode == MODE.snpeff)? outputFileName + ".snpEff_genes.txt" : null; 	
+	}		
 	public String getConfigFileName() { 
 		return (MODE.snpeff == mode)? configFileName : null;
 	}
 	
-	public int getBufferSize(){ return (mode == MODE.trf)? bufferSize : -1; } //trf
-	public int getGapSize(){ return (mode == MODE.trf)? gap : -1; } //cadd
+	public int getBufferSize(){ 
+		return (mode == MODE.trf)? bufferSize : -1; 
+	} //trf
+	public int getGapSize(){ 
+		return (mode == MODE.trf)? gap : -1; 
+	} //cadd
 	
 	//hom
-	public int getHomoplymersWindow(){ return (mode == MODE.hom) ? homWindow : -1; } //trf
-	public int getHomoplymersReportSize(){ return (mode == MODE.hom) ? homReportSize : -1; } //cadd
+	public int getHomoplymersWindow(){
+		return (mode == MODE.hom) ? homWindow : -1;
+	} //trf
+	public int getHomoplymersReportSize() { 
+		return (mode == MODE.hom) ? homReportSize : -1; 
+	} //cadd
 	
 	public Optional<Integer> getNNSCount() {
 		return Optional.ofNullable(nnsCount);

--- a/qannotate/src/au/edu/qimr/qannotate/modes/CaddMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/CaddMode.java
@@ -5,8 +5,6 @@
 */
 package au.edu.qimr.qannotate.modes;
 
-import htsjdk.tribble.readers.TabixReader;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -25,6 +23,7 @@ import org.qcmg.vcf.VCFFileReader;
 import org.qcmg.vcf.VCFFileWriter;
 
 import au.edu.qimr.qannotate.Options;
+import htsjdk.tribble.readers.TabixReader;
 
 
 public class  CaddMode extends AbstractMode{

--- a/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
@@ -5,8 +5,6 @@
 */
 package au.edu.qimr.qannotate.modes;
 
-import gnu.trove.list.TShortList;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,6 +29,7 @@ import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 
 import au.edu.qimr.qannotate.Options;
+import gnu.trove.list.TShortList;
 
 /**
  * @author christix

--- a/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
@@ -5,13 +5,6 @@
 */
 package au.edu.qimr.qannotate.modes;
 
-import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.reference.FastaSequenceIndex;
-import htsjdk.samtools.reference.IndexedFastaSequenceFile;
-import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
-import htsjdk.samtools.util.IOUtil;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,6 +25,12 @@ import org.qcmg.vcf.VCFFileReader;
 import org.qcmg.vcf.VCFFileWriter;
 
 import au.edu.qimr.qannotate.Options;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.reference.FastaSequenceIndex;
+import htsjdk.samtools.reference.IndexedFastaSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.IOUtil;
 
 public class HomoplymersMode extends AbstractMode{
 	private final static QLogger logger = QLoggerFactory.getLogger(HomoplymersMode.class);

--- a/qannotate/src/au/edu/qimr/qannotate/modes/MakeValidMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/MakeValidMode.java
@@ -6,14 +6,9 @@
 package au.edu.qimr.qannotate.modes;
 
 
-import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.reference.ReferenceSequenceFile;
-import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +36,9 @@ import org.qcmg.vcf.VCFFileWriter;
 
 import au.edu.qimr.qannotate.Main;
 import au.edu.qimr.qannotate.Options;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 
 /**
  * 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/OverlapMode.java
@@ -3,9 +3,11 @@ package au.edu.qimr.qannotate.modes;
 import java.io.File;
 import java.util.AbstractQueue;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -17,11 +19,10 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.model.ChrPositionComparator;
-
+import org.qcmg.common.util.Constants;
 import org.qcmg.common.vcf.VcfFormatFieldRecord;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
-import org.qcmg.common.util.Constants;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qbamfilter.query.QueryExecutor;
 
@@ -30,7 +31,6 @@ import au.edu.qimr.qannotate.utils.ContigPileup;
 import au.edu.qimr.qannotate.utils.VariantPileup;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SamReader;
-import java.util.Arrays;
 
 public class OverlapMode extends AbstractMode{
 
@@ -136,11 +136,12 @@ public class OverlapMode extends AbstractMode{
 			return new ConcurrentLinkedQueue<VcfRecord>(); 	
 				  
 		List<VcfRecord> list = new ArrayList<> ();	
-		for(ChrPosition pos : positionRecordMap.keySet()){
+		for(Entry<ChrPosition, List<VcfRecord>> entry : positionRecordMap.entrySet()){
 			//get variants from same contig
-			if(contig != null && !pos.getChromosome().equals(contig.getSequenceName())  )
-				continue; 
-			list.addAll(positionRecordMap.get(pos));
+			if (contig != null && ! entry.getKey().getChromosome().equals(contig.getSequenceName()) ) {
+				continue;
+			}
+			list.addAll(entry.getValue());
 		}
 
 		// lambda expression to replace abstract method			 				 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
@@ -11,6 +11,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.qcmg.common.log.QLogger;
@@ -21,7 +22,6 @@ import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.vcf.VCFFileReader;
 import org.qcmg.vcf.VCFFileWriter;
 
-import java.util.Arrays;
 import au.edu.qimr.qannotate.Options;
 import ca.mcgill.mcb.pcingola.snpEffect.commandLine.SnpEff;
 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/TandemRepeatMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/TandemRepeatMode.java
@@ -5,14 +5,28 @@
 */
 package au.edu.qimr.qannotate.modes;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
-import org.qcmg.common.util.*;
+import org.qcmg.common.util.Constants;
+import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.util.IndelUtils.SVTYPE;
-import org.qcmg.common.vcf.*;
+import org.qcmg.common.vcf.VcfRecord;
+import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
@@ -50,7 +64,7 @@ public class TandemRepeatMode  extends AbstractMode{
         logger.tool("mask File: " + options.getDatabaseFileName() );
         logger.tool("output annotated records: " + options.getOutputFileName());
         logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
+        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() : options.getLogLevel()));
           
 		addAnnotation( options.getDatabaseFileName() );				
 	}	
@@ -140,11 +154,13 @@ public class TandemRepeatMode  extends AbstractMode{
 		int totalRepeat = 0; 
 		int totalBlock = 0;					
 		Map<String, BlockIndex> indexedBlock  = new HashMap<>();
-		for(String chr: repeats.keySet()){
-			 logger.debug("indexing blocks for " + chr);
-			 indexedBlock.put(chr,  makeIndexedBlock( repeats.get(chr)));
-			 totalRepeat += repeats.get(chr).size();
-			 totalBlock += indexedBlock.get(chr).index.size();	 
+		
+		for(Entry<String, HashSet<Repeat>> entry: repeats.entrySet()){
+			String chr = entry.getKey();
+			logger.debug("indexing blocks for " + chr);
+			indexedBlock.put(chr,  makeIndexedBlock(entry.getValue()));
+			totalRepeat += entry.getValue().size();
+			totalBlock += indexedBlock.get(chr).index.size();	 
 		}
 	
 		logger.info("total repeats from dbfile is " + totalRepeat);
@@ -153,7 +169,7 @@ public class TandemRepeatMode  extends AbstractMode{
 		long count = 0;
 		long repeatCount = 0; 
 		try (VCFFileReader reader = new VCFFileReader(input) ;
-            VCFFileWriter writer = new VCFFileWriter(new File(output))  ) {
+            VCFFileWriter writer = new VCFFileWriter(new File(output)) ) {
 			//reheader
 		    VcfHeader hd = 	reader.getHeader();
 		    hd = reheader(hd, commandLine ,input);			    
@@ -161,16 +177,17 @@ public class TandemRepeatMode  extends AbstractMode{
 		    hd.addFilter(VcfHeaderUtils.FILTER_TRF, VcfHeaderUtils.FILTER_TRF_DESC );
 		    
 		    for(final VcfHeaderRecord record: hd) {
-		    		writer.addHeader(record.toString());			
+		    	writer.addHeader(record.toString());			
 		    }
-			logger.info("annotating vcfs from inputs " );
+			logger.info("annotating vcfs from inputs ");
 			
-	        for (final VcfRecord vcf : reader) {   
-		        	String vcfchr =  IndelUtils.getFullChromosome(vcf.getChromosome());	         
-	 	    		if(annotate(vcf, indexedBlock.get(vcfchr)))
-	 	    			repeatCount ++; 	    			
-		    		count++;
-		    		writer.add(vcf);
+	        for (final VcfRecord vcf : reader) {
+	        	String vcfchr =  IndelUtils.getFullChromosome(vcf.getChromosome());
+ 	    		if(annotate(vcf, indexedBlock.get(vcfchr))) {
+ 	    			repeatCount ++;
+ 	    		}
+	    		count++;
+	    		writer.add(vcf);
 	        }
 		}  
 					
@@ -186,7 +203,7 @@ public class TandemRepeatMode  extends AbstractMode{
 		if(start > indexedBlock.lastBlockEnd ) return false; //not in repeat region
 						
 		SVTYPE type = IndelUtils.getVariantType(vcf.getRef(), vcf.getAlt());
-		int end = (type.equals(SVTYPE.INS))? buffer + vcf.getPosition() + vcf.getAlt().length()-1 : buffer + vcf.getChrPosition().getEndPosition();
+		int end = (type.equals(SVTYPE.INS)) ? buffer + vcf.getPosition() + vcf.getAlt().length() - 1 : buffer + vcf.getChrPosition().getEndPosition();
 		if(end < indexedBlock.firstBlockStart) return false; //not in repeat region
 				
 		List<Block> coveredBlocks = new ArrayList<>();	
@@ -252,22 +269,23 @@ public class TandemRepeatMode  extends AbstractMode{
 		String tRF_info = ""; //"TRF=" + coveredRepeats.get(0).printMark();
 		for(int i = 0; i < coveredRepeats.size(); i++){
 			Repeat rep = coveredRepeats.get(i);
-			tRF_info +="," + rep.printMark();	
+			tRF_info += "," + rep.printMark();	
 			
 			//once find one TRF satisfied, the filter will be marked as TRF
 			if(tRF_filter) continue; 
 			
 			//discard TRF inside indel(DEL) region that is smaller than DEL size			
 			if(rep.start >= vcf.getPosition() && rep.end <= vcf.getChrPosition().getEndPosition() && 
-					(rep.end - rep.start) < (vcf.getRef().length()-1))
+					(rep.end - rep.start) < (vcf.getRef().length()-1)) {
 				tRF_filter = false;
-			else if( rep.patternLength < 6 && rep.patternLength > 1 && rep.patternNo > 10)				
+			} else if( rep.patternLength < 6 && rep.patternLength > 1 && rep.patternNo > 10) {				
 				tRF_filter = true; //high frequence short TRF
-			else if(rep.patternLength == 1 && rep.patternNo > 6)
+			} else if(rep.patternLength == 1 && rep.patternNo > 6) {
 				tRF_filter = true; //homoplymers
-			else if ( (rep.patternLength < 6 &&  rep.patternLength > 0) 
-					&&  (rate < 0.2 && rate >= 0 )) // must check 0 value in case the repeat or ssoi value not exist
+			} else if ( (rep.patternLength < 6 &&  rep.patternLength > 0) 
+					&&  (rate < 0.2 && rate >= 0 )) { // must check 0 value in case the repeat or ssoi value not exist
 				tRF_filter = true;  //low confidence short TRF
+			}
 		}
 		
 		vcf.appendInfo("TRF=" + tRF_info.substring(1));
@@ -295,15 +313,15 @@ public class TandemRepeatMode  extends AbstractMode{
             	/*
             	 * ignore header line
             	 */
-            		if (line.startsWith("chrom\tstart")) continue;
+        		if (line.startsWith("chrom\tstart")) continue;
             		
 	           try {
-	        	   		Repeat rep = new Repeat(line);
-	        	   		allRepeats.computeIfAbsent(rep.chr, (v) -> new HashSet<>()).add(rep);
+        	   		Repeat rep = new Repeat(line);
+        	   		allRepeats.computeIfAbsent(rep.chr, (v) -> new HashSet<>()).add(rep);
 	            } catch (NumberFormatException e) {
-		            	if (errLine ++ < MaxErrLine) {
-		            		logger.warn("can't retrive information from TRF repeat file: " + line);
-		            	}
+	            	if (errLine ++ < MaxErrLine) {
+	            		logger.warn("can't retrive information from TRF repeat file: " + line);
+	            	}
 	            }             
             }
         } 
@@ -318,76 +336,77 @@ public class TandemRepeatMode  extends AbstractMode{
 	 */
 	BlockIndex makeIndexedBlock(final Set<Repeat> repeats){
 		
-		if(repeats == null || repeats.size() == 0) return null; 
+		if(repeats == null || repeats.size() == 0) {
+			return null; 
+		}
 		 
-			//S1: get unique block edge 
-			Set<Integer> starts = new HashSet<>(); //list will be very slow
-			Set<Integer> ends = new HashSet<>(); //list will be very slow
-			for(Repeat rep : repeats){				 
-				starts.add(rep.start);				
-				ends.add(rep.end);
-			}			
-			
-			//sort and unique the elements
-		   TreeSet<Integer> sortedStartEnd = new TreeSet<>();
-		    sortedStartEnd.addAll(starts);
-		    sortedStartEnd.addAll(ends);
-		    
-		    //S2:create block for each start end but the edge may require one base shift
-			Map<Integer, Block> blockIndex = new HashMap<>(); 
-			Iterator<Integer> it = sortedStartEnd.iterator(); 
-			int start = it.next();
-			int end = start; 
-			
-		    while(it.hasNext()){
-		    	
-			    	//do nothing if exists from starts disregards whether it is in ends or not
-			    	if(!starts.contains(start))
-			    		start += 1; 
-			    	
-			    	//trim if end is some repeat start
-			    	end = it.next();	
-			    	int end0 = end;  //store original boundary for next loop
-			    	 
-			    	if(starts.contains(end))		    		 
-			    		end -= 1; 
-			    	
-			    	if(start <= end)
-			    		blockIndex.put(start,  new Block(start, end));
-			    	
-			    	//next block must be one base forward
-			    	start = end0; 
-		    }
-		    
-		    //S3: filling repeat 
-		    for(Repeat rep : repeats){	
-				start = rep.start;	
-				//repeat must be greater than one base; 
-				//if end overlaop with next repeat start, chop the end
-				while(start < rep.end){
-					//all repeat start is never been chopped
-					Block block = blockIndex.get(start);
-					block.addRepeat(rep);
-					//next block must be one base forward
-					start = block.end+1;						
-				}
+		//S1: get unique block edge 
+		Set<Integer> starts = new HashSet<>(); //list will be very slow
+		Set<Integer> ends = new HashSet<>(); //list will be very slow
+		for(Repeat rep : repeats){				 
+			starts.add(rep.start);				
+			ends.add(rep.end);
+		}			
+		
+		//sort and unique the elements
+	   TreeSet<Integer> sortedStartEnd = new TreeSet<>();
+	    sortedStartEnd.addAll(starts);
+	    sortedStartEnd.addAll(ends);
+	    
+	    //S2:create block for each start end but the edge may require one base shift
+		Map<Integer, Block> blockIndex = new HashMap<>(); 
+		Iterator<Integer> it = sortedStartEnd.iterator(); 
+		int start = it.next();
+		int end = start; 
+		
+	    while(it.hasNext()){
+	    	
+	    	//do nothing if exists from starts disregards whether it is in ends or not
+	    	if(!starts.contains(start))
+	    		start += 1; 
+	    	
+	    	//trim if end is some repeat start
+	    	end = it.next();	
+	    	int end0 = end;  //store original boundary for next loop
+	    	 
+	    	if(starts.contains(end))		    		 
+	    		end -= 1; 
+	    	
+	    	if(start <= end)
+	    		blockIndex.put(start,  new Block(start, end));
+	    	
+	    	//next block must be one base forward
+	    	start = end0; 
+	    }
+	    
+	    //S3: filling repeat 
+	    for(Repeat rep : repeats){	
+			start = rep.start;	
+			//repeat must be greater than one base; 
+			//if end overlaop with next repeat start, chop the end
+			while(start < rep.end){
+				//all repeat start is never been chopped
+				Block block = blockIndex.get(start);
+				block.addRepeat(rep);
+				//next block must be one base forward
+				start = block.end+1;						
 			}
-		    
-		    
-		    //S4: each gap insert a index
-	 	    Map<Integer, Block> inserts = new HashMap<>();
-		    for(Block block:  blockIndex.values() ){		    	
-			    	start = block.start;
-			    	//throw null exception since some block is null
-			    	while (block.end > BLOCK_INDEX_GAP + start){	    		
-			    		start += BLOCK_INDEX_GAP;
-			    		inserts.put(start , block);	
-			    	}	    	
-		    }
-		    blockIndex.putAll(inserts);
-		    
-		    
-		    return new BlockIndex(sortedStartEnd.first(), sortedStartEnd.last(), blockIndex);
+		}
+	    
+	    
+	    //S4: each gap insert a index
+ 	    Map<Integer, Block> inserts = new HashMap<>();
+	    for(Block block:  blockIndex.values() ){		    	
+	    	start = block.start;
+	    	//throw null exception since some block is null
+	    	while (block.end > BLOCK_INDEX_GAP + start){		
+	    		start += BLOCK_INDEX_GAP;
+	    		inserts.put(start , block);
+	    	}	    	
+	    }
+	    blockIndex.putAll(inserts);
+	    
+	    return new BlockIndex(sortedStartEnd.first(), sortedStartEnd.last(), blockIndex);
 	}
 
 }

--- a/qannotate/src/au/edu/qimr/qannotate/modes/Vcf2mafTmp.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/Vcf2mafTmp.java
@@ -5,6 +5,13 @@
 */
 package au.edu.qimr.qannotate.modes;
 
+import static org.qcmg.common.util.Constants.BAR_STRING;
+import static org.qcmg.common.util.Constants.CHR;
+import static org.qcmg.common.util.Constants.COMMA_STRING;
+import static org.qcmg.common.util.Constants.MISSING_DATA_STRING;
+import static org.qcmg.common.util.Constants.SLASH_STRING;
+import static org.qcmg.common.util.Constants.VCF_MERGE_DELIM;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,21 +29,24 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.MafConfidence;
 import org.qcmg.common.string.StringUtils;
-
-import static org.qcmg.common.util.Constants.*;
-
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.util.IndelUtils.SVTYPE;
 import org.qcmg.common.util.SnpUtils;
-import org.qcmg.common.vcf.*;
+import org.qcmg.common.vcf.VcfFormatFieldRecord;
+import org.qcmg.common.vcf.VcfInfoFieldRecord;
+import org.qcmg.common.vcf.VcfRecord;
+import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 
 import au.edu.qimr.qannotate.Options;
-import au.edu.qimr.qannotate.utils.*;
+import au.edu.qimr.qannotate.utils.MafElement;
+import au.edu.qimr.qannotate.utils.SampleColumn;
+import au.edu.qimr.qannotate.utils.SnpEffConsequence;
+import au.edu.qimr.qannotate.utils.SnpEffMafRecord;
  
 
 public class Vcf2mafTmp extends AbstractMode{

--- a/qannotate/src/au/edu/qimr/qannotate/utils/ContigPileup.java
+++ b/qannotate/src/au/edu/qimr/qannotate/utils/ContigPileup.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
-import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qbamfilter.query.QueryExecutor;

--- a/qannotate/src/au/edu/qimr/qannotate/utils/SnpEffConsequence.java
+++ b/qannotate/src/au/edu/qimr/qannotate/utils/SnpEffConsequence.java
@@ -9,9 +9,10 @@
  */
 package au.edu.qimr.qannotate.utils;
 
+import org.qcmg.common.log.QLogger;
+import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
-import org.qcmg.common.log.*;
 
 /*
  * Consequence are happened at protein_coding with impact HIGH, MODERATE or LOW

--- a/qannotate/src/au/edu/qimr/qannotate/utils/SnpPileup.java
+++ b/qannotate/src/au/edu/qimr/qannotate/utils/SnpPileup.java
@@ -5,8 +5,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import htsjdk.samtools.SAMRecord;
 import org.qcmg.common.model.ChrPosition;
+
+import htsjdk.samtools.SAMRecord;
 
 /**
  * pileup on snp position, retrive the number of discard read, duplicate read, overlapped pairs, forward/backward reads, novel start reads for each Alleles

--- a/qannotate/src/au/edu/qimr/qannotate/utils/VariantPileup.java
+++ b/qannotate/src/au/edu/qimr/qannotate/utils/VariantPileup.java
@@ -1,6 +1,7 @@
 package au.edu.qimr.qannotate.utils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -10,8 +11,8 @@ import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.util.IndelUtils.SVTYPE;
 import org.qcmg.common.util.Pair;
 import org.qcmg.common.vcf.VcfRecord;
+
 import htsjdk.samtools.SAMRecord;
-import java.util.Arrays;
 
 public class VariantPileup {
 	
@@ -47,26 +48,36 @@ public class VariantPileup {
 		
 		for(SAMRecord re : pool){
 			String key = re.getReadName();
-			if(pairPool.containsKey(key)){ pairPool.remove(key); }		
+			if(pairPool.containsKey(key)){ 
+				pairPool.remove(key); 
+			}		
 			if(singlePool.containsKey(key)){
 				pairPool.put(key, new Pair<SAMRecord,SAMRecord>(singlePool.get(key), re));
 				singlePool.remove(key);
-			}else
+			} else {
 				singlePool.put(key, re);
+			}
 		}		
 		//check pairs, if same base push first pair to singlePool		
-		for(Pair<SAMRecord,SAMRecord> pair: pairPool.values()) 			 
+		for(Pair<SAMRecord,SAMRecord> pair: pairPool.values()) {
 			if(checkPair(pair)){
 				pairSame.incrementAndGet();
 				singlePool.put(pair.getLeft().getReadName(), pair.getLeft());
-			}else
+			} else {
 				pairDiff.incrementAndGet();
+			}
+		}
 			 		
 		//check singlePool
-		for(SAMRecord re : singlePool.values()) 
-			if(variantType.getOrder() < 5) checkMnp(re);
-			else if(variantType.equals(SVTYPE.DEL)) checkDel(re);	
-			else checkIns(re);	
+		for(SAMRecord re : singlePool.values()) {
+			if(variantType.getOrder() < 5) {
+				checkMnp(re);
+			} else if(variantType.equals(SVTYPE.DEL)) {
+				checkDel(re);	
+			} else {
+				checkIns(re);	
+			}
+		}
 	}
 
 	/**
@@ -77,25 +88,33 @@ public class VariantPileup {
 	List<SAMRecord> applyFilter( List<SAMRecord>  poolIn){
 		List<SAMRecord>  pool = new ArrayList<>( );
 		//start will be first base of MNP; one base before leading base which is two base before actually indel
-		int start = variantType.order <= 4? vcf.getPosition() : vcf.getPosition() - 1;
+		int start = variantType.order <= 4 ? vcf.getPosition() : vcf.getPosition() - 1;
 		//end will be last base of MNP; two base after indel
-		int end =  variantType.order <= 4? vcf.getPosition() + vcf.getRef().length()-1 : vcf.getPosition() + vcf.getRef().length()+1;
+		int end =  variantType.order <= 4 ? vcf.getPosition() + vcf.getRef().length() - 1 : vcf.getPosition() + vcf.getRef().length() + 1;
 				
 		for(SAMRecord re: poolIn){
 			if( re.getAlignmentStart() > start || re.getAlignmentEnd() < end ) continue;
 			int baseStart = re.getReadPositionAtReferencePosition( start ); //return 1 if first base; 0 if deletion in read
 			int baseEnd = re.getReadPositionAtReferencePosition( end );
 			boolean add2Pool = true;
-			if(baseStart == 0 || baseEnd == 0 ) ;
-			else if( variantType.order < 5 ){  //check snp mnp etc
+			if (baseStart == 0 || baseEnd == 0 ) {
+			} else if( variantType.order < 5 ){  //check snp mnp etc
 				byte[]  baseQ = re.getBaseQualities();
-				for(int i = baseStart-1; i < baseEnd; i ++)
-					if(baseQ[i] < 10 ){ add2Pool = false; break;}						
+				for(int i = baseStart - 1; i < baseEnd; i ++) {
+					if(baseQ[i] < 10 ){
+						add2Pool = false;
+						break;
+					}
+				}
 			}else if( variantType.equals(SVTYPE.INS) ){
 				//deletion occurs, belong to nearby indel, add to pool; otherwise check N			 				
 				byte[] maskedReadBases = re.getReadBases();
-				for ( int i = baseStart; i < baseEnd; i++ )
-					if( (char)maskedReadBases[i] == 'N'){ add2Pool = false; break;}									 
+				for ( int i = baseStart; i < baseEnd; i++ ) {
+					if( (char)maskedReadBases[i] == 'N'){
+						add2Pool = false;
+						break;
+					}
+				}
 			}//end INS
 			if( add2Pool )  pool.add( re );			 			
 		}			
@@ -113,13 +132,20 @@ public class VariantPileup {
 		int end = re.getReadPositionAtReferencePosition(vcf.getChrPosition().getEndPosition());	
 		
 		//deletion in MNP region
-		if(start == 0 || end  == 0){  otherCount.incrementAndGet(); return;  }
+		if(start == 0 || end  == 0){  
+			otherCount.incrementAndGet(); 
+			return;  
+		}
 		
-		byte[] bases = Arrays.copyOfRange(re.getReadBases(),  start-1, end ); 	
+		byte[] bases = Arrays.copyOfRange(re.getReadBases(),  start - 1, end ); 	
 		
-		if( Arrays.equals(bases, vcf.getRef().getBytes()) ) refCount.incrementAndGet();
-		else if( Arrays.equals(bases, vcf.getAlt().getBytes()) ) altCount.incrementAndGet();
-		else otherCount.incrementAndGet();			
+		if( Arrays.equals(bases, vcf.getRef().getBytes()) ) {
+			refCount.incrementAndGet();
+		} else if( Arrays.equals(bases, vcf.getAlt().getBytes()) ) {
+			altCount.incrementAndGet();
+		} else {
+			otherCount.incrementAndGet();			
+		}
 	}
 	
 	/**
@@ -133,14 +159,19 @@ public class VariantPileup {
 		int end = re.getReadPositionAtReferencePosition(vcf.getPosition() + vcf.getRef().length() ); 
 		
 		//if deletion happen in tail of del (adjacant), it is partical deletion, belong to others
-		if( start == 0 || end  == 0  ){	otherCount.incrementAndGet(); return;  }
+		if( start == 0 || end  == 0  ){	
+			otherCount.incrementAndGet(); 
+			return;  
+		}
 		
 		//match del: supporting read
-		if(end - start == 1) altCount.incrementAndGet();
-		//not deletion, maybe MNP/insertion, go to maf ref_count
-		else if(end -start >= vcf.getRef().length()) refCount.incrementAndGet();
-		//smaller deltion than vcf, partial supporting reads
-		else otherCount.incrementAndGet();
+		if(end - start == 1) {
+			altCount.incrementAndGet();
+		} else if(end -start >= vcf.getRef().length()) {	//not deletion, maybe MNP/insertion, go to maf ref_count
+			refCount.incrementAndGet();
+		} else {	//smaller deltion than vcf, partial supporting reads
+			otherCount.incrementAndGet();
+		}
 	}
 	
 	/**
@@ -154,15 +185,21 @@ public class VariantPileup {
 		int end = re.getReadPositionAtReferencePosition(vcf.getPosition() + vcf.getRef().length() ); 
 		
 		//deletion happen at the edge of ins, it is nearby indel, belong to maf ref_count
-		if( start == 0 || end  == 0  )   refCount.incrementAndGet();  	
+		if( start == 0 || end  == 0  ) {
+			refCount.incrementAndGet();  	
+		}
 		//no insertion
-		else if(end - start == 1)  refCount.incrementAndGet();  
-		else{ 
+		else if(end - start == 1) {
+			refCount.incrementAndGet();  
+		} else { 
 			//check insertions, one leading base + inserted base == vcf.alt
 			byte[] bases = Arrays.copyOfRange( re.getReadBases(),  start-1, end-1 ); 			
 			//do not compare reference: eg. bases.equals(vcf.getAlt().getBytes())
-			if(Arrays.equals(bases, vcf.getAlt().getBytes()))altCount.incrementAndGet();
-			else otherCount.incrementAndGet(); 			
+			if (Arrays.equals(bases, vcf.getAlt().getBytes())){
+				altCount.incrementAndGet();
+			} else {
+				otherCount.incrementAndGet(); 			
+			}
 		}		
 	}
 
@@ -173,7 +210,9 @@ public class VariantPileup {
 	 */
 	boolean checkPair( Pair<SAMRecord,SAMRecord> pair ){
 		
-		if(pair.getLeft() == null || pair.getRight() == null){ System.err.println("dealing with pair of null"); return false;  }
+		if (pair.getLeft() == null || pair.getRight() == null){ 
+			System.err.println("dealing with pair of null"); return false;  
+		}
 		
 		//check start base
 		int start1 = pair.getLeft().getReadPositionAtReferencePosition(vcf.getPosition(), true );
@@ -186,21 +225,25 @@ public class VariantPileup {
 		int end1 = pair.getLeft().getReadPositionAtReferencePosition(vcf.getChrPosition().getEndPosition() + 1 );
 		int end2 = pair.getRight().getReadPositionAtReferencePosition(vcf.getChrPosition().getEndPosition() + 1 );
 		// in case of deletion
-		if(end1 == 0)  end1 = start1 + 1;
-		if(end2 == 0)  end2 = start2 + 1;
+		if(end1 == 0) {
+			end1 = start1 + 1;
+		}
+		if(end2 == 0) {
+			end2 = start2 + 1;
+		}
 		if( pair.getLeft().getReferencePositionAtReadPosition(end1) != pair.getRight().getReferencePositionAtReadPosition(end2) )
 			return false;
  		
 		 //check pair base
 		try{
-			byte[] bases1 = Arrays.copyOfRange(pair.getLeft().getReadBases(),  start1-1, end1 ); 
-			byte[] bases2 = Arrays.copyOfRange(pair.getRight().getReadBases(),  start2-1, end2 );			
+			byte[] bases1 = Arrays.copyOfRange(pair.getLeft().getReadBases(),  start1 - 1, end1 ); 
+			byte[] bases2 = Arrays.copyOfRange(pair.getRight().getReadBases(),  start2 - 1, end2 );			
 			//compare array not reference
 			return  Arrays.equals(bases1, bases2);  			 
 		}catch( ArrayIndexOutOfBoundsException e){
 			System.err.println(vcf.toSimpleString() + " (pileup on): " + pair.getLeft().getReadName());
-			System.out.println(pair.getLeft().getReadBases() + " : substring of "+ (start1-1) + " ~ " + end1 );
-			System.out.println(pair.getRight().getReadBases() + " : substring of "+ (start2-1) + " ~ " + end2 );
+			System.out.println(Arrays.toString(pair.getLeft().getReadBases()) + " : substring of "+ (start1 - 1) + " ~ " + end1 );
+			System.out.println(Arrays.toString(pair.getRight().getReadBases()) + " : substring of "+ (start2 - 1) + " ~ " + end2 );
 		}
 		
 		return false; 
@@ -210,7 +253,11 @@ public class VariantPileup {
 		return String.format("%d[%d,%d,%d,%d,%d]", depth, pairSame.get(), pairDiff.get(), refCount.get(), altCount.get(),otherCount.get() );
 	}
 	
-	public VcfRecord getVcf(){return vcf; }
+	public VcfRecord getVcf(){
+		return vcf; 
+	}
 	
-	public int getSampleColumnNo(){ return sampleColumnNo; }
+	public int getSampleColumnNo(){ 
+		return sampleColumnNo; 
+	}
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/CCMModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/CCMModeTest.java
@@ -1,6 +1,7 @@
 package au.edu.qimr.qannotate.modes;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 

--- a/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/DbsnpModeTest.java
@@ -2,7 +2,6 @@ package au.edu.qimr.qannotate.modes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedWriter;
@@ -18,7 +17,6 @@ import org.junit.Test;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeader;
-import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.vcf.VCFFileReader;
 

--- a/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/HomoplymersModeTest.java
@@ -1,7 +1,8 @@
 package au.edu.qimr.qannotate.modes;
 
-import static org.junit.Assert.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.qcmg.common.string.StringUtils;

--- a/qannotate/test/au/edu/qimr/qannotate/modes/IndelConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/IndelConfidenceModeTest.java
@@ -1,6 +1,8 @@
 package au.edu.qimr.qannotate.modes;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/qannotate/test/au/edu/qimr/qannotate/modes/MakeValidModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/MakeValidModeTest.java
@@ -1,6 +1,8 @@
 package au.edu.qimr.qannotate.modes;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/TandemRepeatModeTest.java
@@ -1,6 +1,8 @@
 package au.edu.qimr.qannotate.modes;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -23,7 +25,9 @@ import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 
-import au.edu.qimr.qannotate.modes.TandemRepeatMode.*;
+import au.edu.qimr.qannotate.modes.TandemRepeatMode.Block;
+import au.edu.qimr.qannotate.modes.TandemRepeatMode.BlockIndex;
+import au.edu.qimr.qannotate.modes.TandemRepeatMode.Repeat;
 
 public class TandemRepeatModeTest {
 	String repeatFileName = "input.repeat";

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
@@ -14,9 +14,6 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import junit.framework.Assert;
-
-import org.junit.After;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.commandline.Executor;
@@ -29,6 +26,7 @@ import org.qcmg.vcf.VCFFileReader;
 
 import au.edu.qimr.qannotate.utils.MafElement;
 import au.edu.qimr.qannotate.utils.SnpEffMafRecord;
+import junit.framework.Assert;
 
 
 public class Vcf2mafIndelTest {

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
@@ -1,6 +1,10 @@
 package au.edu.qimr.qannotate.modes;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -19,7 +23,9 @@ import org.qcmg.common.commandline.Executor;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.IndelUtils;
+import org.qcmg.common.util.IndelUtils.SVTYPE;
 import org.qcmg.common.vcf.ContentType;
+import org.qcmg.common.vcf.VcfFormatFieldRecord;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;
@@ -66,6 +72,29 @@ public class Vcf2mafTest {
          assertEquals(false, Vcf2maf.isHighConfidence(maf));
          maf.setColumnValue(MafElement.Confidence, "PASS");
          assertEquals(true, Vcf2maf.isHighConfidence(maf));
+     }
+     
+     @Test
+     public void getAltCounts() {
+    	 /*
+    	  * Output array is in the following format:
+    	  * array[nns, depth, ref_count, alt_count, allele1, allele2, coverageString(AC,ACCS,ACINDEL)]; 
+    	  */
+    	 VcfFormatFieldRecord vffr = new VcfFormatFieldRecord();
+    	 String [] array = Vcf2maf.getAltCounts(vffr, "A", "C", SVTYPE.SNP, false);
+    	 assertArrayEquals(null, array);
+    	 
+    	 vffr = new VcfFormatFieldRecord("GT", "0/1");
+    	 array = Vcf2maf.getAltCounts(vffr, "A", "C", SVTYPE.SNP, false);
+    	 assertArrayEquals( new String[] {"0", "0", "0", "0", "A", "C", null}, array);
+    	 
+    	 vffr = new VcfFormatFieldRecord("GT:OABS", "0/1:A9[40]11[40];C4[40]6[30]");
+    	 array = Vcf2maf.getAltCounts(vffr, "A", "C", SVTYPE.SNP, false);
+    	 assertArrayEquals(new String[] {"0", "0", "0", "0", "A", "C", null}, array);
+    	 
+    	 vffr = new VcfFormatFieldRecord( "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS", "0/1:24,10:Germline:23:34:PASS:.:.:9:C13[39.69]11[39.73];T9[37]1[42]");
+    	 array = Vcf2maf.getAltCounts(vffr, "C", "T", SVTYPE.SNP, false);
+    	 assertArrayEquals(new String[] {"9", "0", "0", "0", "C", "T", null}, array);
      }
      
      @Test
@@ -364,6 +393,77 @@ public class Vcf2mafTest {
     	 assertEquals(".,PASS", Vcf2maf.getFilterDetails(new String[]{".","PASS"}));
     	 assertEquals(".,PASS,.", Vcf2maf.getFilterDetails(new String[]{".","PASS","."}));
     	 assertEquals("h,e,l,l,o", Vcf2maf.getFilterDetails(new String[]{"h","e","l","l","o"}));
+     }
+     
+     @Test 
+     public void tumourAlleleTest() {
+		final Vcf2maf v2m = new Vcf2maf(2,1, null, null, ContentType.MULTIPLE_CALLERS_MULTIPLE_SAMPLES);    //test column2; normal column 1            
+		String[] parms = {"chr1","19595137","rs2235795","C","T",".",".","FLANK=ATACGTGGCCT;DP=9;FS=0.000;MQ=60.00;MQ0=0;QD=28.75;SOR=1.402;IN=1,2;DB;VLD;VAF=0.6584;EFF=missense_variant(MODERATE|MISSENSE|Gcg/Acg|p.Ala77Thr/c.229G>A|153|AKR7L|protein_coding|CODING|ENST00000420396|4|1),downstream_gene_variant(MODIFIER||1890|||AKR7L|retained_intron|CODING|ENST00000493176||1),non_coding_exon_variant(MODIFIER|||n.431G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000457194|4|1),non_coding_exon_variant(MODIFIER|||n.763G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000429712|6|1)"
+		    ,"GT:DP:FT:MR:NNS:OABS:INF:AD:GQ"
+		    ,"1/1:9:COVN12:9:9:T6[36.67]3[37.67]:.:.:."
+		    ,"1/1:10:PASS:10:10:T8[36.12]2[30]:.:.:."
+		    ,"1/1:9:COVN12:9:9:T6[36.67]3[37.67]:.:0,9:27"
+		    ,"1/1:10:PASS:10:10:T8[36.12]2[30]:.:0,10:30"};
+		
+		 VcfRecord vcf = new VcfRecord(parms);
+		 SnpEffMafRecord maf = v2m.converter(vcf);
+		 assertEquals("T", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+		 assertEquals("T", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
+		 
+		 parms = new String[] {"chr1","19595137","rs2235795","C","T",".",".","FLANK=ATACGTGGCCT;DP=9;FS=0.000;MQ=60.00;MQ0=0;QD=28.75;SOR=1.402;IN=1,2;DB;VLD;VAF=0.6584;EFF=missense_variant(MODERATE|MISSENSE|Gcg/Acg|p.Ala77Thr/c.229G>A|153|AKR7L|protein_coding|CODING|ENST00000420396|4|1),downstream_gene_variant(MODIFIER||1890|||AKR7L|retained_intron|CODING|ENST00000493176||1),non_coding_exon_variant(MODIFIER|||n.431G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000457194|4|1),non_coding_exon_variant(MODIFIER|||n.763G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000429712|6|1)"
+				    ,"GT:DP:FT:MR:NNS:OABS:INF:AD:GQ"
+				    ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:.:."
+				    ,"0/1:10:PASS:10:10:T8[36.12]2[30]:.:.:."
+				    ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:0,9:27"
+				    ,"0/1:10:PASS:10:10:T8[36.12]2[30]:.:0,10:30"};
+		 vcf = new VcfRecord(parms);
+		 maf = v2m.converter(vcf);
+		 assertEquals("C", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+		 assertEquals("T", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
+		 
+		 parms = new String[] {"chr1","19595137","rs2235795","C","T,G,A",".",".","FLANK=ATACGTGGCCT;DP=9;FS=0.000;MQ=60.00;MQ0=0;QD=28.75;SOR=1.402;IN=1,2;DB;VLD;VAF=0.6584;EFF=missense_variant(MODERATE|MISSENSE|Gcg/Acg|p.Ala77Thr/c.229G>A|153|AKR7L|protein_coding|CODING|ENST00000420396|4|1),downstream_gene_variant(MODIFIER||1890|||AKR7L|retained_intron|CODING|ENST00000493176||1),non_coding_exon_variant(MODIFIER|||n.431G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000457194|4|1),non_coding_exon_variant(MODIFIER|||n.763G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000429712|6|1)"
+				 ,"GT:DP:FT:MR:NNS:OABS:INF:AD:GQ"
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:.:."
+				 ,"0/1:10:PASS:10:10:T8[36.12]2[30]:.:.:."
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:0,9:27"
+				 ,"0/1:10:PASS:10:10:T8[36.12]2[30]:.:0,10:30"};
+		 vcf = new VcfRecord(parms);
+		 maf = v2m.converter(vcf);
+		 assertEquals("C", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+		 assertEquals("T", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
+		 
+		 parms = new String[] {"chr1","19595137","rs2235795","C","T,G,A",".",".","FLANK=ATACGTGGCCT;DP=9;FS=0.000;MQ=60.00;MQ0=0;QD=28.75;SOR=1.402;IN=1,2;DB;VLD;VAF=0.6584;EFF=missense_variant(MODERATE|MISSENSE|Gcg/Acg|p.Ala77Thr/c.229G>A|153|AKR7L|protein_coding|CODING|ENST00000420396|4|1),downstream_gene_variant(MODIFIER||1890|||AKR7L|retained_intron|CODING|ENST00000493176||1),non_coding_exon_variant(MODIFIER|||n.431G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000457194|4|1),non_coding_exon_variant(MODIFIER|||n.763G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000429712|6|1)"
+				 ,"GT:DP:FT:MR:NNS:OABS:INF:AD:GQ"
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:.:."
+				 ,"1/2:10:PASS:10:10:T8[36.12]2[30]:.:.:."
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:0,9:27"
+				 ,"0/1:10:PASS:10:10:T8[36.12]2[30]:.:0,10:30"};
+		 vcf = new VcfRecord(parms);
+		 maf = v2m.converter(vcf);
+		 assertEquals("T", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+		 assertEquals("G", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
+		 
+		 parms = new String[] {"chr1","19595137","rs2235795","C","T,G,A",".",".","FLANK=ATACGTGGCCT;DP=9;FS=0.000;MQ=60.00;MQ0=0;QD=28.75;SOR=1.402;IN=1,2;DB;VLD;VAF=0.6584;EFF=missense_variant(MODERATE|MISSENSE|Gcg/Acg|p.Ala77Thr/c.229G>A|153|AKR7L|protein_coding|CODING|ENST00000420396|4|1),downstream_gene_variant(MODIFIER||1890|||AKR7L|retained_intron|CODING|ENST00000493176||1),non_coding_exon_variant(MODIFIER|||n.431G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000457194|4|1),non_coding_exon_variant(MODIFIER|||n.763G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000429712|6|1)"
+				 ,"GT:DP:FT:MR:NNS:OABS:INF:AD:GQ"
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:.:."
+				 ,"3/3:10:PASS:10:10:T8[36.12]2[30]:.:.:."
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:0,9:27"
+				 ,"1/1:10:PASS:10:10:T8[36.12]2[30]:.:0,10:30"};
+		 vcf = new VcfRecord(parms);
+		 maf = v2m.converter(vcf);
+		 assertEquals("A", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+		 assertEquals("A", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
+		 
+		 parms = new String[] {"chr1","19595137","rs2235795","C","T,G,A",".",".","FLANK=ATACGTGGCCT;DP=9;FS=0.000;MQ=60.00;MQ0=0;QD=28.75;SOR=1.402;IN=1,2;DB;VLD;VAF=0.6584;EFF=missense_variant(MODERATE|MISSENSE|Gcg/Acg|p.Ala77Thr/c.229G>A|153|AKR7L|protein_coding|CODING|ENST00000420396|4|1),downstream_gene_variant(MODIFIER||1890|||AKR7L|retained_intron|CODING|ENST00000493176||1),non_coding_exon_variant(MODIFIER|||n.431G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000457194|4|1),non_coding_exon_variant(MODIFIER|||n.763G>A||AKR7L|polymorphic_pseudogene|CODING|ENST00000429712|6|1)"
+				 ,"GT:DP:FT:MR:NNS:OABS:INF:AD:GQ"
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:.:."
+				 ,"2/3:10:PASS:10:10:T8[36.12]2[30]:.:.:."
+				 ,"0/0:9:COVN12:9:9:T6[36.67]3[37.67]:.:0,9:27"
+				 ,"0/1:10:PASS:10:10:T8[36.12]2[30]:.:0,10:30"};
+		 vcf = new VcfRecord(parms);
+		 maf = v2m.converter(vcf);
+		 assertEquals("G", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+		 assertEquals("A", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
      }
      
      @Test 

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -22,7 +22,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPointPosition;
@@ -200,7 +199,7 @@ public class VcfUtils {
 				} else {
 					sb = ffl.get(i);
 				}
-				StringUtils.updateStringBuilder(sb, sa[i-1], Constants.COLON);
+				StringUtils.updateStringBuilder(sb, sa[i - 1], Constants.COLON);
 			}
 		}
 		return ffl.stream().map(StringBuilder::toString).collect(Collectors.toList());
@@ -479,28 +478,19 @@ public class VcfUtils {
 	 * @param alts
 	 * @return
 	 */
-	public static List<String> getAlleles(String genotype, String ref, String alts) {
+	public static String[] getAlleles(String genotype, String ref, String alts) {
 		if (StringUtils.isNullOrEmptyOrMissingData(genotype) || Constants.MISSING_GT.equals(genotype)
 				|| StringUtils.isNullOrEmptyOrMissingData(ref)) {
-			return Collections.emptyList();
+			return new String[]{};
 		}
 		int gt1 = Integer.valueOf(genotype.charAt(0) + "");
 		int gt2 = Integer.valueOf(genotype.charAt(2) + "");
 		
-		List<String> l = new ArrayList<>(2);
+		String[] array = new String[2];
 		String [] altsArr = alts.split(Constants.COMMA_STRING);
-		if (gt1 == 0) {
-			l.add(ref);
-		} else {
-			l.add(altsArr[gt1 - 1]);
-		}
-		
-		if (gt2 == 0) {
-			l.add(ref);
-		} else {
-			l.add(altsArr[gt2 - 1]);
-		}
-		return l;
+		array[0] = gt1 == 0 ? ref : altsArr[gt1 - 1];
+		array[1] = gt2 == 0 ? ref : altsArr[gt2 - 1];
+		return array;
 	}
 	
 
@@ -525,7 +515,7 @@ public class VcfUtils {
 				String [] sa = TabTokenizer.tokenize(ff.get(i), Constants.COLON);
 				
 				for (int j = 0, len = sa.length ; j < len ; j++) {
-					ffm.get(headerFields[j])[i-1] = sa[j];
+					ffm.get(headerFields[j])[i - 1] = sa[j];
 				}
 			}
 			return ffm;
@@ -591,7 +581,7 @@ public class VcfUtils {
 	 */
 	public static VcfRecord createVcfRecord(ChrPosition cp, String id, String ref, String alt) {
  			
-		if(ref != null   && (cp.getEndPosition() - cp.getStartPosition() +1 )!= ref.length()) {
+		if(ref != null   && (cp.getEndPosition() - cp.getStartPosition() + 1 )!= ref.length()) {
 			return(new VcfRecord.Builder(cp.getChromosome(),cp.getStartPosition(), ref)).id(id).allele(alt).build();
 		}
 		if (cp instanceof ChrPointPosition) {
@@ -804,8 +794,6 @@ public class VcfUtils {
 	public static void addAdditionalSampleToFormatField(VcfRecord vcf, List<String> additionalSampleFormatFields) {
 		if ( null != additionalSampleFormatFields && additionalSampleFormatFields.size() > 1) {
 			
-//			logger.info("attempting to add sample ff to vcf rec: " + vcf.toString());
-//			additionalSampleFormatFields.stream().forEach(s -> logger.info("new ff: " + s));
 			List<String[]> additionalSampleFormatFieldsParams = additionalSampleFormatFields.stream().map(s -> s.split(Constants.COLON_STRING)).collect(Collectors.toList());
 			
 			List<String> existingFF = vcf.getFormatFields();
@@ -923,9 +911,8 @@ public class VcfUtils {
 									} else {
 										existingArray[index] = existingValue + separator + additionalValue;
 									}
-//									}
 									// re-insert into vcf
-										existingFF.set(j, Arrays.stream(existingArray).collect(Collectors.joining(Constants.COLON_STRING)));
+									existingFF.set(j, Arrays.stream(existingArray).collect(Collectors.joining(Constants.COLON_STRING)));
 								}
 							}
 						} else {
@@ -956,10 +943,10 @@ public class VcfUtils {
 			return oldAD;
 		}
 		String [] adArray = TabTokenizer.tokenize(oldAD, Constants.COMMA);
-		int newgt1 = Integer.valueOf(""+newGt.charAt(0));
-		int newgt2 = Integer.valueOf(""+newGt.charAt(2));
-		int oldgt1 = Integer.valueOf(""+oldGt.charAt(0));
-		int oldgt2 = Integer.valueOf(""+oldGt.charAt(2));
+		int newgt1 = Integer.valueOf("" + newGt.charAt(0));
+		int newgt2 = Integer.valueOf("" + newGt.charAt(2));
+		int oldgt1 = Integer.valueOf("" + oldGt.charAt(0));
+		int oldgt2 = Integer.valueOf("" + oldGt.charAt(2));
 		
 		if (Math.max(oldgt1, oldgt2) >= Math.max(newgt1, newgt2)) {
 			return oldAD;
@@ -1036,7 +1023,6 @@ public class VcfUtils {
 		if (control.getAlt().equals(test.getAlt())) {
 			List<String> ff = test.getFormatFields();
 			addAdditionalSampleToFormatField(control, ff);
-//			prepareGATKVcfForMerge(control);
 			return Optional.ofNullable(control);
 		} else {
 			
@@ -1054,8 +1040,6 @@ public class VcfUtils {
 			 */
 			List<String> cFF = control.getFormatFields();
 			m.setFormatFields(cFF);
-//			prepareGATKVcfForMerge(m);
-//			prepareGATKVcfForMerge(test);
 			
 			List<String> tFFs = test.getFormatFields(); 
 			String tFF = tFFs.get(1);
@@ -1308,40 +1292,6 @@ public class VcfUtils {
 	 */
 	public static boolean isRecordSomatic(VcfRecord rec) {
 		return isRecordSomatic(rec.getInfo(), rec.getFormatFieldsAsMap());
-		
-//		String info = rec.getInfo();
-//		if ( ! StringUtils.isNullOrEmpty(info) && info.contains(VcfHeaderUtils.INFO_SOMATIC)) {
-//			return true;
-//		}
-//		
-////		if (isMergedRecord(rec)) {
-//			/*
-//			 * check out the format fields - need all records to be somatic
-//			 */
-//			String ff = rec.getFormatFieldStrings();
-//			Map<String, String[]> m =getFormatFieldsAsMap(ff);
-//			
-//			if (m.isEmpty()) {
-//				return false;
-//			}
-//			String [] infos = m.get(VcfHeaderUtils.FORMAT_INFO);
-//			if (null == infos || infos.length == 0) {
-//				return false;
-//			}
-//			long somCount =  Arrays.asList(infos).stream().filter(f ->null != f && f.contains(VcfHeaderUtils.INFO_SOMATIC)).count();
-//			return somCount * 2 >= infos.length;
-			
-//			if (noOfSomatics == 0) {
-//				return false;
-//			}
-//			return noOfSomatics * 2 >= filter.length;
-//		}
-			/*
-			 *SOMATIC_1 and SOMATIC_2 to return true
-			 */
-//			return info.contains(VcfHeaderUtils.INFO_SOMATIC + "_1") && info.contains(VcfHeaderUtils.INFO_SOMATIC + "_2");  
-//		} else {
-//		}
 	}
 	
 	public static boolean isRecordSomatic(String info, Map<String, String[]> formatFields) {
@@ -1459,8 +1409,8 @@ public class VcfUtils {
 		String [] oldAltArray = oldAlt.split(Constants.COMMA_STRING);
 		String [] altsArray = alts.split(Constants.COMMA_STRING);
 		
-		int newFirst = first > 0 ?  ListUtils.positionOfStringInArray(altsArray, oldAltArray[first -1]) + 1 : first;
-		int newSecond = second > 0 ?  ListUtils.positionOfStringInArray(altsArray, oldAltArray[second -1]) + 1: second;
+		int newFirst = first > 0 ?  ListUtils.positionOfStringInArray(altsArray, oldAltArray[first - 1]) + 1 : first;
+		int newSecond = second > 0 ?  ListUtils.positionOfStringInArray(altsArray, oldAltArray[second - 1]) + 1: second;
 		
 		return newFirst + "/" + newSecond;
 	}

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -67,34 +67,34 @@ public class VcfUtilsTest {
 		 String gt = "0/0";
 		 String ref = "R";
 		 String alt = "A";
-		 List<String> alleles = VcfUtils.getAlleles(gt, ref, alt);
-		 assertEquals(2, alleles.size());
-		 assertEquals("R", alleles.get(0));
-		 assertEquals("R", alleles.get(1));
+		 String[] alleles = VcfUtils.getAlleles(gt, ref, alt);
+		 assertEquals(2, alleles.length);
+		 assertEquals("R", alleles[0]);
+		 assertEquals("R", alleles[1]);
 		 
 		 gt = "0/1";
 		 alleles = VcfUtils.getAlleles(gt, ref, alt);
-		 assertEquals(2, alleles.size());
-		 assertEquals("R", alleles.get(0));
-		 assertEquals("A", alleles.get(1));
+		 assertEquals(2, alleles.length);
+		 assertEquals("R", alleles[0]);
+		 assertEquals("A", alleles[1]);
 		 
 		 gt = "1/1";
 		 alleles = VcfUtils.getAlleles(gt, ref, alt);
-		 assertEquals(2, alleles.size());
-		 assertEquals("A", alleles.get(0));
-		 assertEquals("A", alleles.get(1));
+		 assertEquals(2, alleles.length);
+		 assertEquals("A", alleles[0]);
+		 assertEquals("A", alleles[1]);
 		 
 		 alt = "A,B";
 		 alleles = VcfUtils.getAlleles(gt, ref, alt);
-		 assertEquals(2, alleles.size());
-		 assertEquals("A", alleles.get(0));
-		 assertEquals("A", alleles.get(1));
+		 assertEquals(2, alleles.length);
+		 assertEquals("A", alleles[0]);
+		 assertEquals("A", alleles[1]);
 		 
 		 gt = "1/2";
 		 alleles = VcfUtils.getAlleles(gt, ref, alt);
-		 assertEquals(2, alleles.size());
-		 assertEquals("A", alleles.get(0));
-		 assertEquals("B", alleles.get(1));
+		 assertEquals(2, alleles.length);
+		 assertEquals("A", alleles[0]);
+		 assertEquals("B", alleles[1]);
 	}
 	
 	@Test


### PR DESCRIPTION
# Description

A user asked what would be reported in the tumour seq allele 1&2 fields in the maf file when there were multiple alt alleles present.
I didn't know, and so wrote some tests.

I also organised the imports and made some formatting changes to try and reduce the number of issues reported by the teamcity build.

And finally, in `VcfUtils.getAlleles()`, a String array (of length 2) is now returned rather than a `List<String>`.


**Reviewer be warned:** There are a large number of files that have minor cosmetic changes to them.

# How Has This Been Tested?

Additional unit tests have been put in place.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
