### PR TITLE
At moment we put kmers as variable group name if reads are unpaired, due

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -172,7 +172,7 @@ public class BamSummaryReport2 extends SummaryReport {
 		//sequenceBase	
 		Element ele = XmlUtils.createMetricsNode( parent,  XmlUtils.SEQ_BASE,  rcPair );	
 		for(int order = 0; order < 3; order++) { 	
-			seqByCycle[order].toXml( ele,  sourceName[order], seqByCycle[order].getInputCounts() );
+			seqByCycle[order].toXml( ele,  sourceName[order], seqByCycle[order].getInputCounts());
 		}
 				
 		//seqLength
@@ -197,7 +197,7 @@ public class BamSummaryReport2 extends SummaryReport {
 				
 		//1mers is same to baseByCycle
 		for( int i : new int[] { 2, 3, KmersSummary.maxKmers } )
-			kmersSummary.toXml( parent,i );
+			kmersSummary.toXml( parent,i, false);
 	}
 	
 	//<QUAL>

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -58,8 +58,7 @@ public class FastqSummaryReport extends SummaryReport {
 		//header line:"analysis read name pattern for read group
 		Element element =   XmlElementUtils.createSubElement(parent, XmlUtils.QNAME ) ;							
 		readHeaderSummary.toXml(element );		
-				
-
+		
 		//seq								 			
 		element =   XmlElementUtils.createSubElement(parent,XmlUtils.SEQ  ) ;
 		long counts = 0;
@@ -68,12 +67,11 @@ public class FastqSummaryReport extends SummaryReport {
 		}
 		Pair<String, Number> rcPair = new Pair<>(ReadGroupSummary.READ_COUNT, counts);
 		Element ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_BASE , rcPair); 
-		seqByCycle.toXml( ele, XmlUtils.SEQ_BASE,seqByCycle.getInputCounts());	
+		seqByCycle.toXml( ele, XmlUtils.SEQ_BASE,seqByCycle.getInputCounts());
 		
 		ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_LENGTH , rcPair); 
-		XmlUtils.outputTallyGroup( ele, XmlUtils.SEQ_LENGTH, seqByCycle.getLengthMapFromCycle(), true, true );	
-		
-		
+		XmlUtils.outputTallyGroup( ele, XmlUtils.SEQ_LENGTH, seqByCycle.getLengthMapFromCycle(), true, true );
+				
 		counts = 0;
 		for(int order = 0; order < 3; order++) {
 			counts += seqBadReadLineLengths.getSum();	
@@ -85,7 +83,7 @@ public class FastqSummaryReport extends SummaryReport {
 		
 		//1mers is same to baseByCycle
 		for( int i : new int[] { 2, 3, KmersSummary.maxKmers } ) {
-			kmersSummary.toXml( element,i );	
+			kmersSummary.toXml( element,i, true );	
 		}
 		
 		//QUAL
@@ -99,7 +97,7 @@ public class FastqSummaryReport extends SummaryReport {
 		ele = XmlUtils.createMetricsNode( element,  XmlUtils.BAD_READ, null) ;
 		XmlUtils.outputTallyGroup( ele,  XmlUtils.BAD_READ ,  qualBadReadLineLengths.toMap(), false, true ) ;
 		XmlUtils.addCommentChild(ele, FastqSummaryReport.badQualComment );
-			
+		
  	}
 	
 	/**

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
@@ -126,8 +126,8 @@ public class KmersSummary {
 		 for(int i = 0; i <= readString.length - merLength; i ++ ){
 			 byte[] mers = new byte[ merLength ];
 			 for(int j = 0; j <  merLength; j ++ )  mers[j] = dataString[ i + j ];	
-			 int pos = getPosition(i, mers );			 
-			 tally[flagFirstOfPair].increment(pos);
+			 int pos = getPosition( i, mers );			 
+			 tally[flagFirstOfPair].increment( pos );
 		 }	
 		 
 		 parsedCount[flagFirstOfPair].incrementAndGet();
@@ -199,8 +199,14 @@ public class KmersSummary {
 		return count; 		
 	}
 	
-	
-	public void toXml( Element parent, int klength ) { 
+	 
+	/**
+	 * 
+	 * @param parent  is the parent element
+	 * @param klength is the length of kemers
+	 * @param isFastq is true, the variable group name will be length+"kmers"; otherwise it will be pair type. 
+	 */
+	public void toXml( Element parent,  int klength , boolean isFastq) { 
 		long sum = 0;
 		for(int pair = 0; pair < 3; pair ++){
 			sum += parsedCount[pair].get();	
@@ -215,7 +221,8 @@ public class KmersSummary {
 			String name = BamSummaryReport2.sourceName[pair];
 			
 			//read may have no pair information such as fastq
-			if(pair == 0 && parsedCount[1].get() == 0 &&parsedCount[2].get() == 0)
+			//if(pair == 0 && parsedCount[1].get() == 0 && parsedCount[2].get() == 0)
+			if( isFastq )
 				name = klength+"mers";
 			Set<String> kmerStrs = getPopularKmerString(maxNo,  klength, false, pair);
 			

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -134,7 +134,7 @@ public class KmersSummaryTest {
 		summary.parseKmers( base2.getBytes() , false, 0);
 		
 		Element root = XmlElementUtils.createRootElement("root", null);
-		summary.toXml(root, 2);
+		summary.toXml(root, 2, true);
 				
 		//only one <sequenceMetrics>
 		List<Element> eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS);
@@ -166,7 +166,7 @@ public class KmersSummaryTest {
 		}
  		
 		Element root = XmlElementUtils.createRootElement("root", null);
-		summary.toXml(root, 3);
+		summary.toXml(root, 3, false);
 		
 		//the popular kmers are based on counts on middle, middle of first half, middle of second half
 		//in this testing case it look at firt cyle, middle cycle and last cycle


### PR DESCRIPTION
updating toXml for KmersSummary, it will output "kmers" in case of fastq but "unParied" in case of  BAM