### PR TITLE
name attribute in Kmers section should have different value for unPaired BAM and fastq Seq

### DIFF
--- a/qcommon/build.gradle
+++ b/qcommon/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile 'com.typesafe:config:1.3.1'
     
     //jaxb is removed from JDK9+
-    //we need below jar in case to run on JDK8+
+    //we need below jar in case to run on JDK9 and above
     compile 'javax.xml.bind:jaxb-api:2.2.12' 
 }
 

--- a/qcommon/build.gradle
+++ b/qcommon/build.gradle
@@ -14,7 +14,9 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'org.slf4j:slf4j-simple:1.7.25'
     compile 'com.typesafe:config:1.3.1'
-
+    
+    //jaxb is removed from JDK9+
+    //we need below jar in case to run on JDK8+
     compile 'javax.xml.bind:jaxb-api:2.2.12' 
 }
 

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -196,8 +196,10 @@ public class BamSummaryReport2 extends SummaryReport {
 		}
 				
 		//1mers is same to baseByCycle
-		for( int i : new int[] { 2, 3, KmersSummary.maxKmers } )
+		for( int i : new int[] { 2, 3, KmersSummary.maxKmers } ) {
 			kmersSummary.toXml( parent,i, false);
+		}
+			
 	}
 	
 	//<QUAL>

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
@@ -221,7 +221,6 @@ public class KmersSummary {
 			String name = BamSummaryReport2.sourceName[pair];
 			
 			//read may have no pair information such as fastq
-			//if(pair == 0 && parsedCount[1].get() == 0 && parsedCount[2].get() == 0)
 			if( isFastq )
 				name = klength+"mers";
 			Set<String> kmerStrs = getPopularKmerString(maxNo,  klength, false, pair);

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/KmersSummary.java
@@ -125,7 +125,9 @@ public class KmersSummary {
 		 //readString may have differnt length to other reads
 		 for(int i = 0; i <= readString.length - merLength; i ++ ){
 			 byte[] mers = new byte[ merLength ];
-			 for(int j = 0; j <  merLength; j ++ )  mers[j] = dataString[ i + j ];	
+			 for(int j = 0; j <  merLength; j ++ ) {
+				 mers[j] = dataString[ i + j ];	
+			 }
 			 int pos = getPosition( i, mers );			 
 			 tally[flagFirstOfPair].increment( pos );
 		 }	
@@ -221,8 +223,9 @@ public class KmersSummary {
 			String name = BamSummaryReport2.sourceName[pair];
 			
 			//read may have no pair information such as fastq
-			if( isFastq )
+			if( isFastq ) {
 				name = klength+"mers";
+			}
 			Set<String> kmerStrs = getPopularKmerString(maxNo,  klength, false, pair);
 			
 			// "counts per mer string start on specified base cycle"	


### PR DESCRIPTION
# Description

The value of name attribute is the length + "kmers" if there are unpaired reads. The reason was Fastq reads are all unPaired, but it won't make sense to call them  "unPaired reads".  However, we clarify reads to "firstReadInPair", "secondReadInPair" and "unPaired" in BAM files. It makes the output inconsistent, the kmers section output "kmers" but missing "unPaired" reads. 
Here we put an additional argument to KmersSummary.toXml(Element parent,  int klength , boolean isFastq). it will set "kmers" to attribute "name"  if the "isFastq" is true;  otherwise it will set "unPaired" for unPaired reads. 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
 
# How Has This Been Tested?
The unit test is updated, and extra code are also added. It also tested on BAM and Fastq file. 

# Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
