### PR TITLE
Develop.master

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -474,16 +474,9 @@ public class BamSummaryReport2 extends SummaryReport {
 		this.bamHeader = header;	
 		this.isFullBamHeader = isFullBamHeader;
 	}
-//	public String getBamHeader() {	
-//		return bamHeader.getSAMString();	
-//	}
 	public void setSamSequenceDictionary(SAMSequenceDictionary samSeqDictionary) {	
 		this.samSeqDictionary = samSeqDictionary;	
 	}
-//	public SAMSequenceDictionary getSamSequenceDictionary() { 
-//		return samSeqDictionary;	
-//	}	
-
 	
 	
 	// ///////////////////////////////////////////////////////////////////////

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport2.java
@@ -199,7 +199,6 @@ public class BamSummaryReport2 extends SummaryReport {
 		for( int i : new int[] { 2, 3, KmersSummary.maxKmers } ) {
 			kmersSummary.toXml( parent,i, false);
 		}
-			
 	}
 	
 	//<QUAL>

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -61,10 +61,6 @@ public class FastqSummaryReport extends SummaryReport {
 		
 		//seq								 			
 		element =   XmlElementUtils.createSubElement(parent,XmlUtils.SEQ  ) ;
-//???		long counts = 0;
-//		for(int order = 0; order < 3; order++) {
-//			counts += seqByCycle.getInputCounts();
-//		}
 		Pair<String, Number> rcPair = new Pair<>(ReadGroupSummary.READ_COUNT, seqByCycle.getInputCounts());
 		Element ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_BASE , rcPair); 
 		seqByCycle.toXml( ele, XmlUtils.SEQ_BASE,seqByCycle.getInputCounts());
@@ -72,10 +68,6 @@ public class FastqSummaryReport extends SummaryReport {
 		ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_LENGTH , rcPair); 
 		XmlUtils.outputTallyGroup( ele, XmlUtils.SEQ_LENGTH, seqByCycle.getLengthMapFromCycle(), true, true );
 				
-//???		counts = 0;
-//		for(int order = 0; order < 3; order++) {
-//			counts += seqBadReadLineLengths.getSum();	
-//		}
 		rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, seqBadReadLineLengths.getSum());		
 		ele = XmlUtils.createMetricsNode( element, XmlUtils.BAD_READ, rcPair);
 		XmlUtils.outputTallyGroup( ele, XmlUtils.BAD_READ,   seqBadReadLineLengths.toMap(), true, true );	

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -46,10 +46,10 @@ public class FastqSummaryReport extends SummaryReport {
 	private final QCMGAtomicLongArray qualBadReadLineLengths = new QCMGAtomicLongArray(128);
 		
 	AtomicLong qualHeaderNotEqualToPlus = new AtomicLong();		
-	private ReadIDSummary readHeaderSummary = new ReadIDSummary(); 
+	private ReadIDSummary readNameSummary = new ReadIDSummary(); 
 	
 	public FastqSummaryReport() { super(); }
-	public ReadIDSummary getReadIDSummary(){	return readHeaderSummary;	}
+	public ReadIDSummary getReadIDSummary(){	return readNameSummary;	}
 	@Override
 	public void toXml(Element parent1) {		
 		Element parent = init( parent1, ProfileType.FASTQ, null, null );
@@ -57,7 +57,7 @@ public class FastqSummaryReport extends SummaryReport {
 		
 		//header line:"analysis read name pattern for read group
 		Element element =   XmlElementUtils.createSubElement(parent, XmlUtils.QNAME ) ;							
-		readHeaderSummary.toXml(element );		
+		readNameSummary.toXml(element );		
 		
 		//seq								 			
 		element =   XmlElementUtils.createSubElement(parent,XmlUtils.SEQ  ) ;
@@ -132,7 +132,7 @@ public class FastqSummaryReport extends SummaryReport {
 			qualHeaderNotEqualToPlus.incrementAndGet();	
 		
 		String id = record.getReadName();//record.getReadHeader();		
-		try { readHeaderSummary.parseReadId( id );
+		try { readNameSummary.parseReadId( id );
 		} catch (Exception e) {
 			if ( errNumber.incrementAndGet() < ReportErrNumber )
 				logger.error( "Invalid read id: " + id );

--- a/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/fastq/FastqSummaryReport.java
@@ -61,22 +61,22 @@ public class FastqSummaryReport extends SummaryReport {
 		
 		//seq								 			
 		element =   XmlElementUtils.createSubElement(parent,XmlUtils.SEQ  ) ;
-		long counts = 0;
-		for(int order = 0; order < 3; order++) {
-			counts += seqByCycle.getInputCounts();
-		}
-		Pair<String, Number> rcPair = new Pair<>(ReadGroupSummary.READ_COUNT, counts);
+//???		long counts = 0;
+//		for(int order = 0; order < 3; order++) {
+//			counts += seqByCycle.getInputCounts();
+//		}
+		Pair<String, Number> rcPair = new Pair<>(ReadGroupSummary.READ_COUNT, seqByCycle.getInputCounts());
 		Element ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_BASE , rcPair); 
 		seqByCycle.toXml( ele, XmlUtils.SEQ_BASE,seqByCycle.getInputCounts());
 		
 		ele = XmlUtils.createMetricsNode( element, XmlUtils.SEQ_LENGTH , rcPair); 
 		XmlUtils.outputTallyGroup( ele, XmlUtils.SEQ_LENGTH, seqByCycle.getLengthMapFromCycle(), true, true );
 				
-		counts = 0;
-		for(int order = 0; order < 3; order++) {
-			counts += seqBadReadLineLengths.getSum();	
-		}
-		rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, counts);		
+//???		counts = 0;
+//		for(int order = 0; order < 3; order++) {
+//			counts += seqBadReadLineLengths.getSum();	
+//		}
+		rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, seqBadReadLineLengths.getSum());		
 		ele = XmlUtils.createMetricsNode( element, XmlUtils.BAD_READ, rcPair);
 		XmlUtils.outputTallyGroup( ele, XmlUtils.BAD_READ,   seqBadReadLineLengths.toMap(), true, true );	
 		XmlUtils.addCommentChild(ele, FastqSummaryReport.badBaseComment );
@@ -88,15 +88,17 @@ public class FastqSummaryReport extends SummaryReport {
 		
 		//QUAL
 		element = XmlElementUtils.createSubElement(parent, XmlUtils.QUAL) ;
-		ele = XmlUtils.createMetricsNode( element, XmlUtils.QUAL_BASE , null); 
-		qualByCycleInteger.toXml(element,XmlUtils.QUAL_BASE, qualByCycleInteger.getInputCounts()) ;
+		rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, qualByCycleInteger.getInputCounts());	
+		ele = XmlUtils.createMetricsNode( element, XmlUtils.QUAL_BASE , rcPair); 
+		qualByCycleInteger.toXml( ele, XmlUtils.QUAL_BASE, qualByCycleInteger.getInputCounts()) ;
 		
-		ele = XmlUtils.createMetricsNode( element, XmlUtils.QUAL_LENGTH, null) ;
+		ele = XmlUtils.createMetricsNode( element, XmlUtils.QUAL_LENGTH, rcPair) ;
 		XmlUtils.outputTallyGroup( ele,  XmlUtils.QUAL_LENGTH,  qualByCycleInteger.getLengthMapFromCycle(), true, true ) ;	
-		
-		ele = XmlUtils.createMetricsNode( element,  XmlUtils.BAD_READ, null) ;
+
+		rcPair = new Pair<String, Number>(ReadGroupSummary.READ_COUNT, qualBadReadLineLengths.getSum());	
+		ele = XmlUtils.createMetricsNode( element,  XmlUtils.BAD_READ, rcPair) ;
 		XmlUtils.outputTallyGroup( ele,  XmlUtils.BAD_READ ,  qualBadReadLineLengths.toMap(), false, true ) ;
-		XmlUtils.addCommentChild(ele, FastqSummaryReport.badQualComment );
+		XmlUtils.addCommentChild( ele, FastqSummaryReport.badQualComment );
 		
  	}
 	

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
@@ -191,8 +191,21 @@ static final int MAX_POOL_SIZE = 500;
 		return elements.toArray(new String[elements.size()]); 			
 	}
 	
-	public void parseReadId(String readId) {
+	public void parseReadId(String id) {
 		inputNo.incrementAndGet();
+		String readId = id.trim(); 
+		
+		//read id line may contain extra informtion, such as below from fastq file
+		//NB551151:83:HWC2VBGX9:4:13602:8142:7462 1:N:0:GGGGGG
+		//we have to remove all string after space	
+		try {
+			StringTokenizer st = new StringTokenizer(readId," \n\r\t");	
+			//only get first token as readId
+			readId = st.nextToken();
+		}catch( NoSuchElementException e) {
+			//do nothing, just pass to next step. 
+		}
+		
 		
 		String[] elements = splitElements( readId);  
 		RNPattern pattern =  getPattern(elements);	

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
@@ -227,9 +227,12 @@ static final int MAX_POOL_SIZE = 500;
 				XmlUtils.updateMapWithLimit( columns[1], elements[1],TALLY_SIZE);					
 			case ThreeColon:		
 		    case TwoColon: //record element 0	
-		    case OneColon: //record element 0	 	    	
+		    case OneColon: //record element 0	
+		    	//debug add here
+		    	XmlUtils.updateMapWithLimit( columns[0], elements[0],TALLY_SIZE);
 			case NoColon_NCBI: //eg.  SRR3083868.47411824
-				XmlUtils.updateMapWithLimit( columns[0], elements[0],TALLY_SIZE);	
+				//XmlUtils.updateMapWithLimit( columns[0], elements[0],TALLY_SIZE);	
+				XmlUtils.updateMapWithLimit( runIds, elements[0],TALLY_SIZE);	
 				break;
 							
 			case NoColon_BGI:

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/ReadIDSummary.java
@@ -27,12 +27,12 @@ static final int MAX_POOL_SIZE = 500;
 		TwoColon_Torrent("<Run Id>:<X Pos>:<Y Pos>"),  // pattern 4 :  eg. WR6H1:09838:13771 0ZT4V:02282:09455
 		ThreeColon("<Element1>:<Element2>:<Element3>:<Element4>"), //not sure
 		FourColon("<Element1>:<Element2>:<Element3>:<Element4>:<Element5>"),
-		FourColon_OlderIllumina("<Instruments>:<Flow Cell Lane>:<Tile Number>:<X Pos>:<Y Pos><#Index></Pair>"),//  eg. hiseq2000: HWI-ST797_0059:3:2205:20826:152489#CTTGTA		
+		FourColon_OlderIllumina("<Instrument>:<Flow Cell Lane>:<Tile Number>:<X Pos>:<Y Pos><#Index></Pair>"),//  eg. hiseq2000: HWI-ST797_0059:3:2205:20826:152489#CTTGTA		
 		FourColon_OlderIlluminaWithoutIndex("<Instrument>:<Flow Cell Lane>:<Tile Number>:<X Pos>:<Y Pos>"),//   eg. hiseq2000: HWI-ST797_0059:3:2205:20826:152489
 		FiveColon("<Element1>:<Element2>:<Element3>:<Element4>:<Element5>:<Element6>"), //not sure
 		SixColon("<Element1>:<Element2>:<Element3>:<Element4>:<Element5>:<Element6>:<Element7>"), //not sure
 		SixColon_Illumina("<Instrument>:<Run Id>:<Flow Cell Id>:<Flow Cell Lane>:<Tile Number>:<X Pos>:<Y Pos>"), //pattern 6 :  eg. MG00HS15:400:C4KC7ACXX:4:2104:11896:63394
-		SevenColon_andMore("<Element1>:<Element2>:...:<Elementn>");  //not sure
+		SevenColon_andMore("<Element1>:<Element2>:...:<Elementn>");  // not sure
 				
 		final String pattern ; 
 		RNPattern(String str ){ this.pattern = str; }				
@@ -134,6 +134,9 @@ static final int MAX_POOL_SIZE = 500;
 			if(pos > 0) {
 				elements.add( parts[0].substring(0, pos ) );
 				elements.add( parts[0].substring( pos ) );		 
+			}else if(StringUtils.isNumeric( parts[0])) {
+				//NoColon_NUN("<Pos>") 
+				elements.add( parts[0] );
 			}else if(!StringUtils.isNumeric( parts[0].substring(0,1))) {
 				//if first char is not number then check BGI
 				//BGI L?C must appear after 5th
@@ -157,7 +160,8 @@ static final int MAX_POOL_SIZE = 500;
 					}
 					
 				}				
-			}		
+			}
+			
 		}else if(parts.length == 5) {
 			//check index and pair for five element name pattern
 			String pair=null, index=null, yPos= parts[4]; 
@@ -216,20 +220,22 @@ static final int MAX_POOL_SIZE = 500;
 			case NoColon ://do nothing			
 			case NoColon_NUN://do nothing
 				break;
-				
+			
+				//don't output last two column(mostly position), it may cause too many value 
 			case SevenColon_andMore:	
 			case SixColon: //record element 0~4	 
-				XmlUtils.updateMapWithLimit( columns[4], elements[4],TALLY_SIZE);	
-				XmlUtils.updateMapWithLimit( columns[3], elements[3],TALLY_SIZE);					
-			case FiveColon:		
+				XmlUtils.updateMapWithLimit( columns[4], elements[4],TALLY_SIZE);							
+			case FiveColon:	
+				XmlUtils.updateMapWithLimit( columns[3], elements[3],TALLY_SIZE);	
 			case FourColon: //record element 0~2
 				XmlUtils.updateMapWithLimit( columns[2], elements[2],TALLY_SIZE);	
-				XmlUtils.updateMapWithLimit( columns[1], elements[1],TALLY_SIZE);					
-			case ThreeColon:		
-		    case TwoColon: //record element 0	
+			case ThreeColon:
+				XmlUtils.updateMapWithLimit( columns[1], elements[1],TALLY_SIZE);									
+		    case TwoColon: //record element 0			    	
 		    case OneColon: //record element 0	
 		    	//debug add here
 		    	XmlUtils.updateMapWithLimit( columns[0], elements[0],TALLY_SIZE);
+		    	break;
 			case NoColon_NCBI: //eg.  SRR3083868.47411824
 				//XmlUtils.updateMapWithLimit( columns[0], elements[0],TALLY_SIZE);	
 				XmlUtils.updateMapWithLimit( runIds, elements[0],TALLY_SIZE);	
@@ -257,7 +263,11 @@ static final int MAX_POOL_SIZE = 500;
 		   case FourColon_OlderIlluminaWithoutIndex:
 				//FourColon_OlderIlluminaWithoutIndex("<InstrumentS>:<lane>:<tile>:<X Pos>:<Y Pos>"),
 				XmlUtils.updateMapWithLimit( tileNumbers,  elements[2],TALLY_SIZE);		 //too many tile number, so skip it for checking whether uniq	
-				isUpdated = XmlUtils.updateMapWithLimit(instruments, elements[0],TALLY_SIZE) || XmlUtils.updateMapWithLimit(flowCellLanes,  elements[1] ,TALLY_SIZE);		
+				
+				//both instruments and lanes have to be update first, and then judge either of them updated
+				boolean k1 = XmlUtils.updateMapWithLimit(instruments, elements[0],TALLY_SIZE);
+				boolean k2 = XmlUtils.updateMapWithLimit(flowCellLanes,  elements[1] ,TALLY_SIZE);				
+				isUpdated = k1 || k2;		
 				break;
 		    
 		   case SixColon_Illumina:    // code block				
@@ -314,8 +324,10 @@ static final int MAX_POOL_SIZE = 500;
 		Element element = XmlUtils.createMetricsNode(ele, "qnameInfo", new Pair(ReadGroupSummary.READ_COUNT, getInputReadNumber()));
 		XmlUtils.outputTallyGroup( element,  "QNAME Format", patterns , false , true);
 		for(int i = 0; i < columns.length; i ++) {
-			if(columns[i].size() > 0)
-				XmlUtils.outputTallyGroup( element,  (i+1)+"thColumnSplitByColon", columns[i] , false, true );
+			if(columns[i].size() > 0) {
+				XmlUtils.outputTallyGroup( element,  "Element" + (i+1), columns[i] , false, true );
+			}
+			//XmlUtils.outputTallyGroup( element,  (i+1)+"thColumnSplitByColon", columns[i] , false, true );
 		}
 				
 		XmlUtils.outputTallyGroup( element,  "Instrument", instruments , false , true);

--- a/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/bam/BamSummaryReportTest.java
@@ -270,14 +270,11 @@ public class BamSummaryReportTest {
 		record.setReadName("TESTDATA");
 		
 		//first read
-		record.setReadBases("ACCCT AACCC CAACC CTAAC CNTAA CCCTA ACCCA AC".replace(" ","" ).getBytes());
-		
-		report.parseRecord(record);//unapired
-		
+		record.setReadBases("ACCCT AACCC CAACC CTAAC CNTAA CCCTA ACCCA AC".replace(" ","" ).getBytes());		
+		report.parseRecord(record);//unapired		
 		record.setFlags(67); //firstInPair
 		report.parseRecord(record);
-		
-		
+				
 		Element root =  XmlElementUtils.createRootElement("root", null);
 		report.toXml(root);
 

--- a/qprofiler2/test/org/qcmg/qprofiler2/fastq/FastqSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/fastq/FastqSummaryReportTest.java
@@ -1,0 +1,162 @@
+package org.qcmg.qprofiler2.fastq;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Test;
+import org.qcmg.common.util.XmlElementUtils;
+import org.qcmg.qprofiler2.summarise.ReadGroupSummary;
+import org.qcmg.qprofiler2.util.XmlUtils;
+import org.w3c.dom.Element;
+import htsjdk.samtools.fastq.FastqRecord;
+
+public class FastqSummaryReportTest {
+			
+	//create fastq reads
+	private List<FastqRecord> createFastqRecord() {
+		List<FastqRecord> myList = new ArrayList<>();
+		
+		//seq read 1
+		String name = "NB551151:83:HWC2VBGX9:4:11401:16365:1025 1:N:0:NGTTAA";
+		String base = "AAAGGGG.N";
+		String qual = "#AAA/////";	
+		FastqRecord record = new FastqRecord(name, base, null, qual);
+		myList.add(record);
+		
+		//seq read 2
+		name = "NB551151:83:HWC2VBGX9:4:11401:16365:1025";
+		record = new FastqRecord(name, base, null, null);
+		myList.add(record);
+				
+		//seq read 3
+		record = new FastqRecord(null, "", null, qual);
+		myList.add(record);
+		
+		
+		//7~14th good qual
+		for(int i = 0; i < 8; i++) {
+			record = new FastqRecord("NB551151.1", "", null, "FFFFFFFFFFFFF");
+			myList.add(record);
+		}
+		
+		return myList;		
+	}
+	
+	
+	@Test
+	public void seqTest() throws ParserConfigurationException {
+		FastqSummaryReport report  = new FastqSummaryReport();		
+		for(FastqRecord record : createFastqRecord()) {
+			report.parseRecord(record);
+		}
+		
+		Element root =  XmlElementUtils.createRootElement("root", null);
+		report.toXml(root);
+		
+		Element seqEle = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.SEQ).get(0);
+		assertEquals( XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS).size(), 6  );
+		for(Element ele : XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS)) {
+			assertEquals( ele.getAttribute( ReadGroupSummary.READ_COUNT ) ,  "11");
+			assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP).get(0).getAttribute(XmlUtils.NAME), ele.getAttribute(XmlUtils.NAME) );
+		}
+		
+		for(Element ele : XmlElementUtils.getOffspringElementByTagName(seqEle, XmlUtils.TALLY)) {
+			if(ele.getAttribute( XmlUtils.VALUE).equals("0") ) {
+				//unless bad reads, value==0 means good
+				assertEquals( ele.getAttribute( XmlUtils.COUNT ) ,  "9");
+			}else {
+				//only two reads have seq, others are empty
+				assertEquals( ele.getAttribute( XmlUtils.COUNT ) ,  "2");
+			}
+		}
+		
+		//check read length
+		XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS)
+		
+	}
+	
+	@Test
+	public void qualTest() throws ParserConfigurationException {
+		FastqSummaryReport report  = new FastqSummaryReport();		
+		for(FastqRecord record : createFastqRecord()) {
+			report.parseRecord(record);
+		}
+		
+		Element root =  XmlElementUtils.createRootElement("root", null);
+		report.toXml(root);
+		
+		Element seqEle = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.QUAL).get(0);
+		assertEquals( XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS).size(), 3  );
+		for(Element ele : XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS)) {
+			//one of qual is null won't count
+			assertEquals( ele.getAttribute( ReadGroupSummary.READ_COUNT ) ,  "10");
+			assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP).get(0).getAttribute(XmlUtils.NAME), ele.getAttribute(XmlUtils.NAME) );
+		}
+		
+		for(Element ele : XmlElementUtils.getOffspringElementByTagName(seqEle, XmlUtils.TALLY)) {
+			if(ele.getAttribute( XmlUtils.VALUE).equals("0") ) {
+				//unless bad reads, value==0 means good
+				assertEquals( ele.getAttribute( XmlUtils.COUNT ) ,  "9");
+			}else {
+				//only two reads have seq, others are empty
+				assertEquals( ele.getAttribute( XmlUtils.COUNT ) ,  "2");
+			}
+		}
+		
+	}	
+	
+	
+	
+	
+	@Test
+	public void xuTest() throws ParserConfigurationException {
+		
+		FastqSummaryReport report  = new FastqSummaryReport();		
+		for(FastqRecord record : createFastqRecord()) {
+			report.parseRecord(record);
+		}
+		
+		Element root =  XmlElementUtils.createRootElement("root", null);
+		report.toXml(root);
+		XmlElementUtils.asXmlText(root, "/Users/christix/Documents/Eclipse/data/qprofiler2/test.xml");
+		
+	}
+	
+	
+	@Test
+	public void ExceptionTest() {
+		
+		FastqSummaryReport report  = new FastqSummaryReport();		 
+		
+		//base seq is empty  is ok
+	 	report.parseRecord(new FastqRecord("ok", "", null, null));
+	 	 	 	
+		//name, qual are null is ok  
+	 	report.parseRecord(new FastqRecord(null, "", null, null));
+	 	 
+	 		 	
+		try {
+			//base seq is null is not allowed
+		 	report.parseRecord(new FastqRecord("test", null, null, ""));
+		 	fail("not expect to complete parseRecord!");
+		}catch(NullPointerException e) {
+			//expect to have expection			
+		}	
+	 	
+		
+	}
+	
+//	System.out.println("\n*******");
+//	System.out.println( "record.getReadName() : " + record.getReadName() );
+//	System.out.println(  "record.getReadString(): " + record.getReadString() );
+//	System.out.println(  "record.getBaseQualityHeader(): " + record.getBaseQualityHeader() );
+//	System.out.println(  "record.getBaseQualityString(): " + record.getBaseQualityString() );
+//	System.out.println(  "record.toFastQString() : " + record.toFastQString() );			
+	
+
+}

--- a/qprofiler2/test/org/qcmg/qprofiler2/fastq/FastqSummaryReportTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/fastq/FastqSummaryReportTest.java
@@ -75,8 +75,11 @@ public class FastqSummaryReportTest {
 			}
 		}
 		
-		//check read length
-		XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS)
+		//value for name attributte are same 
+		for( Element ele : XmlElementUtils.getOffspringElementByTagName( seqEle, XmlUtils.SEQUENCE_METRICS ) ) {
+			String vname = XmlElementUtils.getChildElement( ele, XmlUtils.VARIABLE_GROUP, 0 ).getAttribute(XmlUtils.NAME);
+			assertEquals( ele.getAttribute(XmlUtils.NAME), vname );
+		}
 		
 	}
 	
@@ -90,43 +93,21 @@ public class FastqSummaryReportTest {
 		Element root =  XmlElementUtils.createRootElement("root", null);
 		report.toXml(root);
 		
-		Element seqEle = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.QUAL).get(0);
-		assertEquals( XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS).size(), 3  );
-		for(Element ele : XmlElementUtils.getChildElementByTagName(seqEle, XmlUtils.SEQUENCE_METRICS)) {
+		Element qulEle = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.QUAL).get(0);
+		assertEquals( XmlElementUtils.getChildElementByTagName(qulEle, XmlUtils.SEQUENCE_METRICS).size(), 3  );
+		for(Element ele : XmlElementUtils.getChildElementByTagName(qulEle, XmlUtils.SEQUENCE_METRICS)) {
 			//one of qual is null won't count
 			assertEquals( ele.getAttribute( ReadGroupSummary.READ_COUNT ) ,  "10");
 			assertEquals( XmlElementUtils.getChildElementByTagName(ele, XmlUtils.VARIABLE_GROUP).get(0).getAttribute(XmlUtils.NAME), ele.getAttribute(XmlUtils.NAME) );
 		}
 		
-		for(Element ele : XmlElementUtils.getOffspringElementByTagName(seqEle, XmlUtils.TALLY)) {
-			if(ele.getAttribute( XmlUtils.VALUE).equals("0") ) {
-				//unless bad reads, value==0 means good
-				assertEquals( ele.getAttribute( XmlUtils.COUNT ) ,  "9");
-			}else {
-				//only two reads have seq, others are empty
-				assertEquals( ele.getAttribute( XmlUtils.COUNT ) ,  "2");
-			}
+		//value for name attributte are same 
+		for( Element ele : XmlElementUtils.getOffspringElementByTagName( qulEle, XmlUtils.SEQUENCE_METRICS ) ) {
+			String vname = XmlElementUtils.getChildElement( ele, XmlUtils.VARIABLE_GROUP, 0 ).getAttribute(XmlUtils.NAME);
+			assertEquals( ele.getAttribute(XmlUtils.NAME), vname );
 		}
 		
-	}	
-	
-	
-	
-	
-	@Test
-	public void xuTest() throws ParserConfigurationException {
-		
-		FastqSummaryReport report  = new FastqSummaryReport();		
-		for(FastqRecord record : createFastqRecord()) {
-			report.parseRecord(record);
-		}
-		
-		Element root =  XmlElementUtils.createRootElement("root", null);
-		report.toXml(root);
-		XmlElementUtils.asXmlText(root, "/Users/christix/Documents/Eclipse/data/qprofiler2/test.xml");
-		
-	}
-	
+	}		
 	
 	@Test
 	public void ExceptionTest() {
@@ -149,14 +130,6 @@ public class FastqSummaryReportTest {
 		}	
 	 	
 		
-	}
-	
-//	System.out.println("\n*******");
-//	System.out.println( "record.getReadName() : " + record.getReadName() );
-//	System.out.println(  "record.getReadString(): " + record.getReadString() );
-//	System.out.println(  "record.getBaseQualityHeader(): " + record.getBaseQualityHeader() );
-//	System.out.println(  "record.getBaseQualityString(): " + record.getBaseQualityString() );
-//	System.out.println(  "record.toFastQString() : " + record.toFastQString() );			
-	
+	}	
 
 }

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/PairSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/PairSummaryTest.java
@@ -74,7 +74,7 @@ public class PairSummaryTest {
 			switch (ele.getAttribute(XmlUtils.NAME)) {
 				case "overlappedPairs": assertTrue( ele.getTextContent().equals(counts[0] + "") ); break;
 				case  "tlenUnder1500Pairs" : assertTrue( ele.getTextContent().equals(counts[1] + "") ); break;
-				case  "tlenZeroPairs" : System.out.println( ele.getTextContent() + " != " + counts[9]   ); break;
+				case  "tlenZeroPairs" : assertFalse( ele.getTextContent().equals( counts[9] +"" )   ); break;
 				case  "tlenOver10000Pairs" : assertTrue( ele.getTextContent().equals(counts[2] + "") ); break;
 				case  "tlenBetween1500And10000Pairs" : assertTrue( ele.getTextContent().equals(counts[3] + "") ); break;
 				case  "pairCountUnderTlen5000" : assertTrue( ele.getTextContent().equals(counts[4] + "") ); break;

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
@@ -1,14 +1,43 @@
 package org.qcmg.qprofiler2.summarise;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
 import org.qcmg.common.util.Constants;
+import org.qcmg.common.util.XmlElementUtils;
 import org.qcmg.qprofiler2.summarise.ReadIDSummary.RNPattern;
 import org.qcmg.qprofiler2.util.XmlUtils;
+import org.w3c.dom.Element;
 
 
 public class ReadIDSummaryTest {
+	
+	@Test
+	public void fastqIdTest() throws ParserConfigurationException {
+		ReadIDSummary idSummary = new ReadIDSummary();			
+		//accept empty string as id
+		RNPattern pa =  idSummary.getPattern( "".split(Constants.COLON_STRING));
+		assertTrue(pa.equals(RNPattern.NoColon ));
+		
+		//id not null
+		try {
+			idSummary.parseReadId(null);
+			fail("can't accept null id");
+		}catch(Exception e) {
+			//expect to catch exception			
+		}
+		
+		//remove substring after space,tab newline etc from id
+		idSummary.parseReadId(" NB551151:83:HWC2VBGX9:4:13602:8142:7462	1:N:0:GGGGGG");				
+		Element root = XmlElementUtils.createRootElement( "root", null);				
+		idSummary.toXml(root);		
+		Element ele = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VALUE).get(0);
+		assertEquals( ele.getAttribute(XmlUtils.NAME),"NB551151:83:HWC2VBGX9:4:13602:8142:7462" );
+	}
 		
 	@Test
 	public void patternTest() {

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
@@ -82,8 +82,6 @@ public class ReadIDSummaryTest {
 		
 		Element root =  XmlElementUtils.createRootElement("root", null);
 		idSummary.toXml(root);
-		XmlElementUtils.asXmlText(root, "/Users/christix/Documents/Eclipse/data/qprofiler2/test.xml");
-		
 		
 		//total 15 patterns
 		assertEquals( idSummary.patterns.keySet().size(), 15 );
@@ -95,7 +93,6 @@ public class ReadIDSummaryTest {
 				assertEquals( e.getAttribute(XmlUtils.COUNT), "2");
 			}else {
 				//others <tally count="1" value="..."/>
-				//System.out.println("debug: " + pa.toString());
 				Element e = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY) .stream().filter(k -> k.getAttribute(XmlUtils.VALUE).equals(pa.toString())).findFirst().get();
 				assertEquals( e.getAttribute(XmlUtils.COUNT), "1");				
 			}			
@@ -105,8 +102,6 @@ public class ReadIDSummaryTest {
 		int order = 1;
 		for( int count : new int[] {8,6,5,4,3} ) {
 			String name = "Element" + order;
-//			for(Element e : XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP))
-//				System.out.println("debug, " + e.getNodeName() + " : " + e.getAttribute("name")  + " == " + name);
 			
 			ele = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP).stream().filter( k -> k.getAttribute(XmlUtils.NAME).equals(name)).findFirst().get();
 			assertEquals(ele.getAttribute(XmlUtils.COUNT), count + "");
@@ -277,13 +272,6 @@ public class ReadIDSummaryTest {
 		assertTrue( idSummary.patterns.get( RNPattern.NoColon_NCBI.toString() ).get() == 1000 );
 		assertTrue( idSummary.patterns.get( RNPattern.NoColon_BGI.toString() ).get() == 4999000 );
 			
-		//debug
-//		System.out.println("columns[0]:size " + idSummary.columns[0].size());
-//		for(String str :  idSummary.columns[0].keySet())
-//			System.out.println("columns[0]: " + str);
-//		assertTrue( idSummary.columns[0].keySet().size() == 2 );
-//		assertTrue( idSummary.columns[0].keySet().size() == 1 );
-//		assertTrue( idSummary.columns[0].get("SRR3083868").get() == 1000 );
 		
 		//stop record runid to column[0] for NoColon_NCBI("<Run Id>.<Pos>")
 		assertTrue( idSummary.runIds.get("SRR3083868").get() == 1000 );

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/ReadIDSummaryTest.java
@@ -4,10 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
 import org.qcmg.common.util.Constants;
+import org.qcmg.common.util.Pair;
 import org.qcmg.common.util.XmlElementUtils;
 import org.qcmg.qprofiler2.summarise.ReadIDSummary.RNPattern;
 import org.qcmg.qprofiler2.util.XmlUtils;
@@ -38,9 +43,142 @@ public class ReadIDSummaryTest {
 		Element ele = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VALUE).get(0);
 		assertEquals( ele.getAttribute(XmlUtils.NAME),"NB551151:83:HWC2VBGX9:4:13602:8142:7462" );
 	}
+	
+	@Test
+	public void toXmlTest() throws ParserConfigurationException {
+		ReadIDSummary idSummary = new ReadIDSummary();	
+		
+		//NoColon("<Element>")
+		idSummary.parseReadId("element");		
+		//NoColon_NCBI("<Run Id>.<Pos>") eg. SRR3083868.47411824
+		idSummary.parseReadId("SRR3083868.47411824");				
+		//NoColon_NUN("<Pos>"), eg. 322356 ???belong to NoColon("<Element>")
+		idSummary.parseReadId(" 322356");				
+		//NoColon_BGI("<Flow Cell Id><Flow Cell Lane><Tile Number><Pos>"), like bgiseq500
+		idSummary.parseReadId(" FCL300002639L1C017R084_416735");
+		//OneColon("<Element1>:<Element2>"), //not sure
+		idSummary.parseReadId("element1:element2 ");
+		//TwoColon("<Element1>:<Element2>:<Element3>"),  not sure
+		idSummary.parseReadId(" element1:element2:element3");
+		//TwoColon_Torrent("<Run Id>:<X Pos>:<Y Pos>")
+		idSummary.parseReadId(" WR6H1:09838:13771");
+		//ThreeColon("<Element1>:<Element2>:<Element3>:<Element4>"), not sure
+		idSummary.parseReadId("element1:element2:element3:element4");
+		//FourColon("<Element1>:<Element2>:<Element3>:<Element4>:<Element5>"),
+		idSummary.parseReadId(" element1:element2:element3:element4:element5");
+		//FourColon_OlderIllumina("<Instruments>:<Flow Cell Lane>:<Tile Number>:<X Pos>:<Y Pos><#Index></Pair>"), hiseq2000
+		idSummary.parseReadId("HWI-ST797_0059:3:2205:20826:152489#CTTGTA");
+		//FourColon_OlderIlluminaWithoutIndex("<Instrument>:<Flow Cell Lane>:<Tile Number>:<X Pos>:<Y Pos>"), hiseq2000: 
+		idSummary.parseReadId("HWI-ST797_0059:3:2205:20826:152489");
+		//FiveColon("<Element1>:<Element2>:<Element3>:<Element4>:<Element5>:<Element6>"), not sure
+		idSummary.parseReadId("element1:element2:element3:element4:element5:element6 ");
+		//SixColon("<Element1>:<Element2>:<Element3>:<Element4>:<Element5>:<Element6>:<Element7>"), not sure
+		idSummary.parseReadId("element1:element2:element3:element4:element5:element6:element7");
+		//SixColon_Illumina("<Instrument>:<Run Id>:<Flow Cell Id>:<Flow Cell Lane>:<Tile Number>:<X Pos>:<Y Pos>"),   
+		idSummary.parseReadId("MG00HS15:400:C4KC7ACXX:4:2104:11896:63394");
+		//SevenColon_andMore("<Element1>:<Element2>:...:<Elementn>");  //not sure
+		idSummary.parseReadId("element1:element2:element3:element4:element5:element6:element7:8");
+		idSummary.parseReadId("element1:element2:element3:element4:element5:element6:element7:8:9");		
+		
+		Element root =  XmlElementUtils.createRootElement("root", null);
+		idSummary.toXml(root);
+		XmlElementUtils.asXmlText(root, "/Users/christix/Documents/Eclipse/data/qprofiler2/test.xml");
+		
+		
+		//total 15 patterns
+		assertEquals( idSummary.patterns.keySet().size(), 15 );
+		Element ele = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP).stream().filter( k -> k.getAttribute(XmlUtils.NAME).equals("QNAME Format") ).findFirst().get() ;
+		for(String pa : idSummary.patterns.keySet()) {
+			if(pa.equals(ReadIDSummary.RNPattern.SevenColon_andMore.toString())) {
+				//only <tally count="2" value="<Element1>:<Element2>:...:<Elementn>"/>
+				Element e = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY) .stream().filter(k -> k.getAttribute(XmlUtils.VALUE).equals(pa.toString())).findFirst().get();
+				assertEquals( e.getAttribute(XmlUtils.COUNT), "2");
+			}else {
+				//others <tally count="1" value="..."/>
+				//System.out.println("debug: " + pa.toString());
+				Element e = XmlElementUtils.getChildElementByTagName(ele, XmlUtils.TALLY) .stream().filter(k -> k.getAttribute(XmlUtils.VALUE).equals(pa.toString())).findFirst().get();
+				assertEquals( e.getAttribute(XmlUtils.COUNT), "1");				
+			}			
+		}
+		
+		//check <Element1..5>, last 2 element won't output, incase they are position and too many values
+		int order = 1;
+		for( int count : new int[] {8,6,5,4,3} ) {
+			String name = "Element" + order;
+//			for(Element e : XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP))
+//				System.out.println("debug, " + e.getNodeName() + " : " + e.getAttribute("name")  + " == " + name);
+			
+			ele = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP).stream().filter( k -> k.getAttribute(XmlUtils.NAME).equals(name)).findFirst().get();
+			assertEquals(ele.getAttribute(XmlUtils.COUNT), count + "");
+			//child element
+			ele = XmlElementUtils.getChildElement(ele, XmlUtils.TALLY, 0);
+			assertEquals(ele.getAttribute(XmlUtils.COUNT), count + "");
+			assertEquals(ele.getAttribute(XmlUtils.VALUE), "element"+ order);			
+			order ++;
+		}
+		
+		//3 instrument 
+		List<Pair<String, Integer>> valuePair = new ArrayList<Pair<String, Integer>>() {{
+			add( new Pair<>("HWI-ST797_0059",2));
+			add( new Pair<>("MG00HS15",1) );
+		}};
+		checkVariableGroup( root, "Instrument", valuePair  ) ;
+		
+		
+		//Flow Cell Id
+		valuePair = new ArrayList<Pair<String, Integer>>() {{
+			add( new Pair<>("FCL300002639",1));
+			add( new Pair<>("C4KC7ACXX",1) );
+		}};
+		checkVariableGroup( root, "Flow Cell Id", valuePair  ) ;
+		
+		//Run Id
+		valuePair = new ArrayList<Pair<String, Integer>>() {{
+			add( new Pair<>("SRR3083868",1));
+			add( new Pair<>("WR6H1",1) );
+			add( new Pair<>("400",1) );
+		}};
+		checkVariableGroup( root, "Run Id", valuePair  ) ;
+		
+		// Flow Cell Lane
+		valuePair = new ArrayList<Pair<String, Integer>>() {{
+			add( new Pair<>("L1",1) );
+			add( new Pair<>("3",2) );
+			add( new Pair<>("4",1) );
+		}};
+		checkVariableGroup( root, "Flow Cell Lane", valuePair  ) ;
+		
+		// Tile Number
+		valuePair = new ArrayList<Pair<String, Integer>>() {{
+			add( new Pair<>("C017R084",1) );
+			add( new Pair<>("2205",2) );
+			add( new Pair<>("2104",1) );
+		}};
+		checkVariableGroup( root, "Tile Number", valuePair  ) ;
+		
+		// Index
+		valuePair = new ArrayList<Pair<String, Integer>>() {{
+			add( new Pair<>("#CTTGTA",1) );
+		}};
+		checkVariableGroup( root, "Index", valuePair  ) ;			
+		
+	}
+	
+	private void checkVariableGroup(Element root, String name, List<Pair<String, Integer>> valuePair) {
+		Element ele = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.VARIABLE_GROUP).stream().filter( k -> k.getAttribute(XmlUtils.NAME).equals(name)).findFirst().get();
+		int total = 0;
+		for(Pair p : valuePair) {
+			Element e = XmlElementUtils.getChildElementByTagName( ele, XmlUtils.TALLY ).stream().filter(  k -> k.getAttribute(XmlUtils.VALUE ).equals(p.getLeft())).findFirst().get();
+			assertEquals( e.getAttribute(XmlUtils.COUNT), p.getRight() + "");
+			total += (Integer)p.getRight();
+		}
+				
+		assertEquals(ele.getAttribute(XmlUtils.COUNT),  total+"");		
+	}
+	
 		
 	@Test
-	public void patternTest() {
+ 	public void patternTest() {
 		ReadIDSummary idSummary = new ReadIDSummary();			
 //		NoColon("<element>"),
 		RNPattern pa =  idSummary.getPattern( "V100007022_3_001R018843237".split(Constants.COLON_STRING));
@@ -139,8 +277,16 @@ public class ReadIDSummaryTest {
 		assertTrue( idSummary.patterns.get( RNPattern.NoColon_NCBI.toString() ).get() == 1000 );
 		assertTrue( idSummary.patterns.get( RNPattern.NoColon_BGI.toString() ).get() == 4999000 );
 			
-		assertTrue( idSummary.columns[0].keySet().size() == 1 );
-		assertTrue( idSummary.columns[0].get("SRR3083868").get() == 1000 );
+		//debug
+//		System.out.println("columns[0]:size " + idSummary.columns[0].size());
+//		for(String str :  idSummary.columns[0].keySet())
+//			System.out.println("columns[0]: " + str);
+//		assertTrue( idSummary.columns[0].keySet().size() == 2 );
+//		assertTrue( idSummary.columns[0].keySet().size() == 1 );
+//		assertTrue( idSummary.columns[0].get("SRR3083868").get() == 1000 );
+		
+		//stop record runid to column[0] for NoColon_NCBI("<Run Id>.<Pos>")
+		assertTrue( idSummary.runIds.get("SRR3083868").get() == 1000 );
 				
 		assertTrue( idSummary.flowCellIds.get("FCL300002639").get() == 1999000 );
 		assertTrue( idSummary.flowCellIds.get("CL300002639").get() == 3000000 );


### PR DESCRIPTION
# Description

There are some shared java codes for both FASTQ and BAM mode, they are <QNAME>, <SEQ> and <QUAL>.  We run lots of BAMs to qprofiler2 but hardly have any FASTQ files.  During some updating and unit testing, just realize some different data information between these two modes.  FASTQ file may contain extra QNAME information but not belong to the BAM QNAM format, we have to filter it out. We also make sure the "unpaired" string won't appear to FASTQ mode but keep it in BAM mode. So here, I did more unit tests for FASTQ mode. 

Fixes # (issue)
not issued.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
 
# How Has This Been Tested?

Lots of unit test code are added, I also applied to both BAM and FASTQ files.
 
# Checklist:

- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
