### PR TITLE
use MIN values to decide on MIUN annotation

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
@@ -55,6 +55,7 @@ public class ConfidenceMode extends AbstractMode{
 	public static final int sBiasAltPercentage = 5;
 	public static final int sBiasCovPercentage = 5;
 	
+	@Deprecated	// using values (both hard cutoff and percentage) from MIN for MIUN annotation
 	public static final int MIUN_CUTOFF = 2;	// based on existing values
 	
 	//filters 
@@ -82,14 +83,11 @@ public class ConfidenceMode extends AbstractMode{
 	private List<String> filtersToIgnore = new ArrayList<>();
 	private double mrPercentage = 0.0f;
 	
-	private int miunCutoff = MIUN_CUTOFF;
 	private int minCutoff = MUTATION_IN_NORMAL_MIN_COVERAGE;
 	private double minPercentage = MUTATION_IN_NORMAL_MIN_PERCENTAGE;
 	
 	//for unit testing
 	ConfidenceMode(){
-//		this.testCols = new TShortArrayList(testCol);
-//		this.controlCols = new TShortArrayList(controlCol);
 	}
 	ConfidenceMode(VcfFileMeta m){
 		this.meta = m;
@@ -102,9 +100,9 @@ public class ConfidenceMode extends AbstractMode{
 		logger.tool("input: " + options.getInputFileName());
         logger.tool("output annotated records: " + options.getOutputFileName());
         logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
+        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() : options.getLogLevel()));
  		
-		loadVcfRecordsFromFile(new File( options.getInputFileName())   );	
+		loadVcfRecordsFromFile(new File(options.getInputFileName()));	
 		
 		options.getNNSCount().ifPresent(i -> nnsCount = i.intValue());
 		options.getMRCount().ifPresent(i -> mrCount = i.intValue());
@@ -112,7 +110,6 @@ public class ConfidenceMode extends AbstractMode{
 		options.getControlCutoffForSomatic().ifPresent(i -> controlCovCutoffForSomaticCalls = i.intValue());
 		options.getTestCutoff().ifPresent(i -> testCovCutoff = i.intValue());
 		options.getMRPercentage().ifPresent(i -> mrPercentage = i.floatValue());
-		options.getMIUNCutoff().ifPresent(i -> miunCutoff = i.intValue());
 		options.getMINCutoff().ifPresent(i -> minCutoff = i.intValue());
 		options.getMINPercentage().ifPresent(i -> minPercentage = i.floatValue());
 		filtersToIgnore = options.getFiltersToIgnore();
@@ -122,7 +119,7 @@ public class ConfidenceMode extends AbstractMode{
 		logger.tool("Control coverage minimum value: " + controlCovCutoff);
 		logger.tool("Control coverage minimum value (for SOMATIC calls): " + controlCovCutoffForSomaticCalls);
 		logger.tool("Test coverage minimum value: " + testCovCutoff);
-		logger.tool("Mutation In Unfiltered Normal (MIUN) will be applied if the Failed Filter (FF) format field contains more than " + miunCutoff + " occurrences of the alt in the normal (control)");
+		logger.tool("Mutation In Unfiltered Normal (MIUN) will be applied if the Failed Filter (FF) format field contains more than max(" + minCutoff + ", " + minPercentage + "%) occurrences of the alt in the normal (control)");
 		logger.tool("Mutation In Normal (MIN) will be applied if number of alt reads in the normnal (control) are greater than or equal to " + minCutoff + " OR greather than or equal to " + minPercentage +"% of total reads");
 		logger.tool("Filters to ignore: " + filtersToIgnore.stream().collect(Collectors.joining(", ")));
 		
@@ -145,7 +142,7 @@ public class ConfidenceMode extends AbstractMode{
 				+ ", test coverage minimum value: " + testCovCutoff + ", control coverage minimum value (somatic/germline): "
 				+ controlCovCutoffForSomaticCalls + "/" + controlCovCutoff);
 		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL,"Mutation also found in pileup of normal (>= " + minPercentage + "% of reads)");
-		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL,"Mutation also found in pileup of unfiltered normal (>= " + miunCutoff + " reads)");  
+		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL,"Mutation also found in pileup of unfiltered normal (>=  max(" + minCutoff + ", " + minPercentage + "%) of reads)");  
 		header.addFilter(VcfHeaderUtils.FILTER_NOVEL_STARTS,"Less than " + nnsCount + " novel starts not considering read pair");
 		header.addFilter(VcfHeaderUtils.FILTER_MUTANT_READS,"Less than " + (mrPercentage > 0.0f ? mrPercentage +"%" : mrCount) + " mutant reads");
 		header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_ALT,"Alternate allele on only one strand (or percentage alternate allele on other strand is less than " + sBiasAltPercentage + "%)"); 
@@ -193,7 +190,6 @@ public class ConfidenceMode extends AbstractMode{
 				
 				String [] gtArray = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE);
 				String [] nnsArr = ffMap.get(VcfHeaderUtils.FILTER_NOVEL_STARTS);
-//				String [] mrArr = ffMap.get(VcfHeaderUtils.FORMAT_MUTANT_READS);
 				String [] filterArr = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
 				String [] covArr = ffMap.get(VcfHeaderUtils.FORMAT_READ_DEPTH);
 				String [] ccmArr = ffMap.get(VcfHeaderUtils.FORMAT_CCM);
@@ -223,7 +219,7 @@ public class ConfidenceMode extends AbstractMode{
 						continue;
 					}
 					
-					boolean isControl =  controlCols != null && controlCols.contains((short) (i+1));
+					boolean isControl =  controlCols != null && controlCols.contains((short) (i + 1));
 					/*
 					 * add all failed filters to FT field
 					 */
@@ -256,7 +252,8 @@ public class ConfidenceMode extends AbstractMode{
 						if ( ! fSb.toString().contains(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL)) {
 							if (null != ffArr && ffArr.length > i) {
 								String failedFilter = ffArr[i];
-								checkMIUN(alts, failedFilter, fSb, miunCutoff);
+								// using the same values as for the MIN annotation
+								checkMIUN(alts, cov, failedFilter, fSb, minCutoff, (float) minPercentage);
 							}
 						}
 						if ( ! fSb.toString().contains(VcfHeaderUtils.FILTER_COVERAGE) && cov < controlCovCutoffForSomaticCalls) {
@@ -386,8 +383,25 @@ public class ConfidenceMode extends AbstractMode{
 		}
 	}
 	
-	public static void checkMIUN(String [] alts, String failedFilter, StringBuilder sb, int miunCutoff) {
+	/**
+	 * This checkMIUN method will use the max(percentage of alts, hard cutoff) means of determining if the MIUN annotation should be added, similar to the checkMIN method
+	 * 
+	 * THe coverage used in the percentage calculation will need to take into account failed filter reads along with regular reads.
+	 * 
+	 * @param alts
+	 * @param coverage
+	 * @param failedFilter
+	 * @param sb
+	 * @param miunCutoff
+	 * @param miunPercentage
+	 */
+	public static void checkMIUN(String [] alts, int coverage, String failedFilter, StringBuilder sb, int miunCutoff, float miunPercentage) {
 		if (null != alts && ! StringUtils.isNullOrEmptyOrMissingData(failedFilter)) {
+			
+			int totalCoverage = coverage + getCoverageFromFailedFilterString(failedFilter);
+			float cutoffToUse = Math.max(miunCutoff, (float)((miunPercentage / 100) * totalCoverage));
+			
+			
 			for (String alt : alts) {
 				int altIndex = failedFilter.indexOf(alt);
 				if (altIndex > -1) {
@@ -396,7 +410,7 @@ public class ConfidenceMode extends AbstractMode{
 					 */
 					int semiColonIndex = failedFilter.indexOf(Constants.SEMI_COLON, altIndex);
 					int failedFilterCount = Integer.parseInt(failedFilter.substring(altIndex + alt.length(), semiColonIndex > -1 ? semiColonIndex : failedFilter.length()));
-					if (failedFilterCount >= miunCutoff) {
+					if (failedFilterCount >= cutoffToUse) {
 						StringUtils.updateStringBuilder(sb, VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL, Constants.SEMI_COLON);
 						break;
 					}
@@ -419,7 +433,7 @@ public class ConfidenceMode extends AbstractMode{
 		int maxBP = 0;
 		Map<String, int[]> eorMap = VcfUtils.getAllelicCoverageWithStrand(eor);
 		for (String alt : alts) {
-			if (gt.contains(""+i)) {
+			if (gt.contains("" + i)) {
 				int [] altCov = oabsMap.getOrDefault(alt, new int [] {0,0});
 				int [] altCovEOR = eorMap.getOrDefault(alt, new int [] {0,0});
 				int middleOfReadForwardStrand = altCov[0] - altCovEOR[0];
@@ -481,18 +495,61 @@ public class ConfidenceMode extends AbstractMode{
 		}
 	}
 
-	 public static int [] getFieldOfInts(VcfFormatFieldRecord formatField ,String key) {
+	 public static int [] getFieldOfInts(VcfFormatFieldRecord formatField, String key) {
 		 String value = formatField.getField(key);
 		 return getFieldOfInts(value);
 	 }
 	 
+	 /**
+	  * Takes a string containing 1 or 2 ints separated by a comma, and returns an int array representing the ints in the string.
+	  * If the string is null or empty, an int array containing a single element equal to 0 is returned.
+	  * 
+	  * This will throw an (unchecked) exception should the string contain characters that can't be coerced into a int using Interger.parseInt()
+	  * 
+	  * @param value
+	  * @return
+	  */
 	 public static int [] getFieldOfInts(String value) {
 		 if (StringUtils.isNullOrEmptyOrMissingData(value)) {
 			 return new int[]{0};
 		 }
 		 int cI = value.indexOf(Constants.COMMA);
 		 if (cI == -1) return new int[] {Integer.parseInt(value)};
-		 return new int[]{Integer.parseInt(value.substring(0,cI)), Integer.parseInt(value.substring(cI + 1))}; 
+		 return new int[]{Integer.parseInt(value.substring(0, cI)), Integer.parseInt(value.substring(cI + 1))}; 
+	 }
+	 
+	 /**
+	  * Returns the number of reads present in the failed filter string.
+	  * This string must be in the following format: "<base><count>[;<base><count>]"
+	  * eg. "A3;C8"
+	  * The coverage value returned in this instance would be 11.
+	  * 
+	  * @param ff
+	  * @return
+	  */
+	 public static int getCoverageFromFailedFilterString(String ff) {
+		int cov = 0;
+		if ( ! StringUtils.isNullOrEmptyOrMissingData(ff)) {
+			 
+			 int semiColonIndex = ff.indexOf(Constants.SEMI_COLON);
+				 
+			 // could probably start this at 1....
+			 for (int i = 0 ; i < ff.length() ; ) {
+				 if (Character.isDigit(ff.charAt(i))) {
+					 cov += Integer.parseInt(ff.substring(i, semiColonIndex > -1 ? semiColonIndex : ff.length()));
+					 if (semiColonIndex == -1) {
+						 break;
+					 } else {
+						 // increment i by semi colon index
+						 i = semiColonIndex + 1;
+						 semiColonIndex = ff.indexOf(Constants.SEMI_COLON, i);
+					 }
+				 } else {
+					 i++;
+				 }
+			 }
+		}
+		return cov;
 	 }
 	 
 	 public static int [] getAltCoveragesFromADField(String ad) {
@@ -503,9 +560,9 @@ public class ConfidenceMode extends AbstractMode{
 		 if (adArray.length < 2) {
 			 return new int[]{0};
 		 }
-		 int [] adIntArray = new int[adArray.length -1];
+		 int [] adIntArray = new int[adArray.length - 1];
 		 for (int i = 1 ; i < adArray.length ; i++) {
-			 adIntArray[i-1] = Integer.parseInt(adArray[i]);
+			 adIntArray[i - 1] = Integer.parseInt(adArray[i]);
 		 }
 		 return adIntArray;
 	 }

--- a/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
@@ -142,7 +142,7 @@ public class ConfidenceMode extends AbstractMode{
 				+ ", test coverage minimum value: " + testCovCutoff + ", control coverage minimum value (somatic/germline): "
 				+ controlCovCutoffForSomaticCalls + "/" + controlCovCutoff);
 		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL,"Mutation also found in pileup of normal (>= " + minPercentage + "% of reads)");
-		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL,"Mutation also found in pileup of unfiltered normal (>=  max(" + minCutoff + ", " + minPercentage + "%) of reads)");  
+		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL,"Mutation also found in pileup of unfiltered normal (>= " + minCutoff + " reads, and also >= " + minPercentage + "%) of reads)");  
 		header.addFilter(VcfHeaderUtils.FILTER_NOVEL_STARTS,"Less than " + nnsCount + " novel starts not considering read pair");
 		header.addFilter(VcfHeaderUtils.FILTER_MUTANT_READS,"Less than " + (mrPercentage > 0.0f ? mrPercentage +"%" : mrCount) + " mutant reads");
 		header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_ALT,"Alternate allele on only one strand (or percentage alternate allele on other strand is less than " + sBiasAltPercentage + "%)"); 

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -155,37 +155,46 @@ public class ConfidenceModeTest {
 	 @Test
 	 public void checkMIUN() {
 		 StringBuilder sb = null;
-		 ConfidenceMode.checkMIUN(null,   null,  sb, -1);
+		 ConfidenceMode.checkMIUN(null, 0, null,  sb, -1, 3);
 		 assertEquals(null, sb);
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, "", sb, -1);
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "", sb, -1, 3);
 		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, "C1", sb, 1);
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "C1", sb, 1, 3);
 		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, "C1;G2;T3", sb, 1);
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "C1;G2;T3", sb, 1, 3);
 		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C"}, "C1;G2;T3", sb, 2);
+		 ConfidenceMode.checkMIUN(new String [] {"A","C"}, 0, "C1;G2;T3", sb, 2, 3);
 		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, "C1;G2;T3", sb, 2);
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, 93, "C1;G2;T3", sb, 2, 3);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","G","T"}, 93, "C1;G2;T3", sb, 2, 3);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, "C1;G2;T3", sb, 3);
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, 94, "C1;G2;T3", sb, 2, 3);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, 0, "C1;G2;T3", sb, 3, 3);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"C"}, "C1;G2;T3", sb, 1);
+		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, 100, "C1;G2;T3", sb, 3, 3);
+		 assertEquals("", sb.toString());
+		 ConfidenceMode.checkMIUN(new String [] {"C"}, 0, "C1;G2;T3", sb, 1, 3);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"G"}, "C1;G2;T3", sb, 2);
+		 ConfidenceMode.checkMIUN(new String [] {"G"}, 0, "C1;G2;T3", sb, 2, 3);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1;G2;T3", sb, 3);
+		 ConfidenceMode.checkMIUN(new String [] {"T"}, 0, "C1;G2;T3", sb, 3, 3);
 		 assertEquals("MIUN", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"T"}, "C1;G2;T3", sb, 4);
+		 ConfidenceMode.checkMIUN(new String [] {"T"}, 0, "C1;G2;T3", sb, 4, 3);
 		 assertEquals("", sb.toString());
 		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, "A3;C8", sb, 2);
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "A3;C8", sb, 2, 3);
 		 assertEquals("MIUN", sb.toString());
+		 sb = new StringBuilder();
+		 ConfidenceMode.checkMIUN(new String [] {"A"}, 90, "A3;C8", sb, 2, 3);
+		 assertEquals("", sb.toString());
 	 }
 	 
 	 @Test
@@ -241,7 +250,12 @@ public class ConfidenceModeTest {
 		 /*
 		  * chr1	792590	.	C	A	.	.	FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT;EFF=downstream_gene_variant(MODIFIER||4458|||LINC01128|retained_intron|NON_CODING|ENST00000425657||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000416570||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000448975||1),downstream_gene_variant(MODIFIER||3584|||LINC01128|lincRNA|NON_CODING|ENST00000449005||1),non_coding_exon_variant(MODIFIER|||n.4370C>A||LINC01128|lincRNA|NON_CODING|ENST00000445118|5|1)	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:46,1:47:.:A3;C8:PASS:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.	0/1:61,7:68:C1[]2[]:A9;C3:PASS:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:62,11:73:.:.:PASS:99:SOMATIC:.:.:89.77
 		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","792590",".","C","A",".",".","FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT","GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL","0/0:46,1:47:.:A3;C8:.:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.","0/1:61,7:68:C1[]2[]:A9;C3:.:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.","./.:.:.:.:.:.:.:NCIG:.:.:.","0/1:62,11:73:.:.:.:99:SOMATIC:.:.:89.77"});
+		 VcfRecord r = new VcfRecord(new String[]{"chr1","792590",".","C","A",".",".","FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT",
+				 "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+				 "0/0:46,1:47:.:A3;C8:.:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.",
+				 "0/1:61,7:68:C1[]2[]:A9;C3:.:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.",
+				 "./.:.:.:.:.:.:.:NCIG:.:.:.",
+				 "0/1:62,11:73:.:.:.:99:SOMATIC:.:.:89.77"});
 		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
 		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
 		 cm.addAnnotation();
@@ -996,6 +1010,25 @@ public class ConfidenceModeTest {
 		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{1,2}, "10,5,4", 5));
 		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{2,2}, "10,5,6", 5));
 		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{2,2}, "10,4,5", 5));
+	 }
+	 
+	 @Test
+	 public void covFromFF() {
+		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString(null));
+		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString(""));
+		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString("."));
+		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString("A0"));
+		 assertEquals(1, ConfidenceMode.getCoverageFromFailedFilterString("A1"));
+		 assertEquals(10, ConfidenceMode.getCoverageFromFailedFilterString("A10"));
+		 assertEquals(100, ConfidenceMode.getCoverageFromFailedFilterString("A100"));
+		 assertEquals(101, ConfidenceMode.getCoverageFromFailedFilterString("A100;B1"));
+		 assertEquals(110, ConfidenceMode.getCoverageFromFailedFilterString("A100;B10"));
+		 assertEquals(113, ConfidenceMode.getCoverageFromFailedFilterString("A100;B10;X3"));
+		 // alts of more than 1 base too
+		 assertEquals(1, ConfidenceMode.getCoverageFromFailedFilterString("AA1"));
+		 assertEquals(2, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1"));
+		 assertEquals(107, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1;CAB105"));
+		 assertEquals(127, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1;CAB105;H20"));
 	 }
 	 
 	 @Test


### PR DESCRIPTION
# Description

The `MIUN` (**M**utation **I**n **U**nfiltered **N**ormal) annotation is added when there is evidence of the alt in reads that failed the filters. This annotation is applied if the `MIN` annotation is not present.
Currently, there is a single hard cutoff for this annotation (defaults to 2). 
It turns out that this is stricter that the cutoff used by the `MIN `annotation (`max(2, 3% of reads)`), which uses better quality reads (ie. reads that have passed the filter).

This change addresses this discrepancy, and applies the same cutoffs that are used in the `MIN` annotation for the `MIUN` annotation.

The defaults are now:
```
hard cutoff = 2
percentage = 3%
```

This means that the failed filter reads will need to contain `max(hard filter, percentage) `copies of the alt before the `MIUN` annotation is added.

eg.
If the passed filter coverage is 90, and the failed filter field is "A2;C8" giving us a combined coverage of 100, and if the default values are used (max(2, 3%)) then if the alt field contained "C", we would get the `MIUN` annotation.
If the alt field did not contain "C" but rather contained "A", then we would not see the `MIUN` annotation (2 is less than max(2,3%)). 

The hard cutoff and percentage values are configurable by the user.


Fixes #145 

# How Has This Been Tested?

Additional unit tests have been provided to cover the updated and new code


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
