### PR TITLE
Qsnp vcf mode no longer makes compound snps

### DIFF
--- a/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 

--- a/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
@@ -6,6 +6,7 @@
 package au.edu.qimr.qannotate.modes;
 
 import gnu.trove.list.TShortList;
+import htsjdk.samtools.SAMValidationError.Type;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -190,11 +192,10 @@ public class ConfidenceMode extends AbstractMode{
 				VcfInfoFieldRecord info = vcf.getInfoRecord();
 				int lhomo = (info.getField(VcfHeaderUtils.INFO_HOM) == null)? 1 :
 					StringUtils.string2Number(info.getField(VcfHeaderUtils.INFO_HOM).split(Constants.COMMA_STRING)[0], Integer.class);
-				
+				String caller = info.getField(VcfHeaderUtils.INFO_MERGE_IN);
 				
 				String [] gtArray = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE);
 				String [] nnsArr = ffMap.get(VcfHeaderUtils.FILTER_NOVEL_STARTS);
-//				String [] mrArr = ffMap.get(VcfHeaderUtils.FORMAT_MUTANT_READS);
 				String [] filterArr = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
 				String [] covArr = ffMap.get(VcfHeaderUtils.FORMAT_READ_DEPTH);
 				String [] ccmArr = ffMap.get(VcfHeaderUtils.FORMAT_CCM);
@@ -225,6 +226,7 @@ public class ConfidenceMode extends AbstractMode{
 					}
 					
 					boolean isControl =  controlCols != null && controlCols.contains((short) (i+1));
+					
 					/*
 					 * add all failed filters to FT field
 					 */

--- a/qannotate/src/au/edu/qimr/qannotate/modes/Vcf2maf.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/Vcf2maf.java
@@ -181,12 +181,12 @@ public class Vcf2maf extends AbstractMode{
     			boolean isConsequence = isConsequence(maf.getColumnValue(MafElement.Transcript_BioType), rank); //55
     			boolean isSomatic = maf.getColumnValue(MafElement.Mutation_Status).equalsIgnoreCase(VcfHeaderUtils.INFO_SOMATIC); //26
     			if (isHighConfidence(maf)) {
-    				if (isSomatic){
+    				if (isSomatic) {
     					out_SP.println(sMaf);
     					outSPVcf.add(vcf);
     					no_SHC ++;
     					
-    					if(isConsequence){
+    					if (isConsequence){
     						out_SPC.println(sMaf);
     						outSPCVcf.add(vcf);
     						no_SHCC ++;
@@ -196,13 +196,13 @@ public class Vcf2maf extends AbstractMode{
     					outGPVcf.add(vcf);
     					no_GHC ++; 
     					 
-    					if(isConsequence){
+    					if (isConsequence){
     						out_GPC.println(sMaf);
     						outGPCVcf.add(vcf);
     						no_GHCC ++;
     					}
     				}   
-    			} 
+    			}
 			}
 		}
 		

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -214,7 +214,6 @@ public class ConfidenceModeTest {
 		 assertEquals("HOM", sb.toString());
 	 }
 	 
-	 
 	 @Test
 	 public void endOfReads() {
 		 /*
@@ -256,7 +255,18 @@ public class ConfidenceModeTest {
 	 
 	 @Test
 	 public void firstCallerOnly() {
-		 
+		 /*
+		  * chr1    5323163 rs7525806       C       T       .       .       BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)     GT:AD:CCC:CCM:DP:FT:GQ:INF:QL   0/1:1,2:Germline:21:3:COV;MR:37:.:35.77 ./.:.:HomozygousLoss:21:.:PASS:.:NCIG:.	./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
+		  */
+		 VcfRecord r = new VcfRecord(new String[]{"chr1","5323163","rs7525806","C","T",".",".","BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)","GT:AD:CCC:CCM:DP:FT:GQ:INF:QL","0/1:1,2:Germline:21:3:.:37:.:35.77","./.:.:HomozygousLoss:21:.:.:.:NCIG:.","./.:.:.:1:.:.:.:.:.","./.:.:.:1:.:.:.:.:."});
+		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
 	 }
 	 
 	 @Test
@@ -796,31 +806,6 @@ public class ConfidenceModeTest {
 		 assertEquals("COV;MR", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
 	 }
 	 
-	 
-//	 @Test
-//	 public void homoplymerTest() {
-//		 //chr1	152281007	.	AA	GG	.	PASS_1;PASS_2	IN=1,2;CONF=ZERO_1,ZERO_2;EFF=missense_variant(MODERATE||cattat/caCCat|p.HisTyr2118HisHis/c.6354TT>CC|4061|FLG|protein_coding|CODING|ENST00000368799||1),sequence_feature[compositionally_biased_region:Ser-rich](LOW|||c.6354AA>GG|4061|FLG|protein_coding|CODING|ENST00000368799|3|1),upstream_gene_variant(MODIFIER||4928|||FLG-AS1|antisense|NON_CODING|ENST00000392688||1),intron_variant(MODIFIER|||n.463-6375AA>GG||FLG-AS1|antisense|NON_CODING|ENST00000420707|4|1),intron_variant(MODIFIER|||n.377-6375AA>GG||FLG-AS1|antisense|NON_CODING|ENST00000593011|2|1)	ACCS	AA,12,16,GG,4,6,_A,0,1&AA,13,17,GG,7,8,_A,0,1	AA,33,37,GG,10,8,CA,0,1&AA,39,40,GC,1,0,GG,21,13,G_,1,0,TG,1,0,CA,0,1
-//		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr1", 152281007, 152281007), "rs10753395","AA", "GG");
-//		 vcf.setFilter("PASS_1;PASS_2");
-//		 vcf.setInfo("IN=1,2;HOM=5,ATGCAggAATGC");
-//		 List<String> ff =  java.util.Arrays.asList("ACCS", "AA,12,16,GG,4,6,_A,0,1&AA,13,17,GG,7,8,_A,0,1", "AA,33,37,GG,10,8,CA,0,1&AA,39,40,GC,1,0,GG,21,13,G_,1,0,TG,1,0,CA,0,1");
-//		 vcf.setFormatFields(ff);
-//		 
-//		 ConfidenceMode cm =new ConfidenceMode(2,1);
-//		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-////		 cm.setSampleColumn(2,1);
-//		 cm.addAnnotation();
-//		 		 
-// 		 String conf = vcf.getInfoRecord().getField(VcfHeaderUtils.INFO_CONFIDENT);
-//		 assertEquals("HIGH_1,HIGH_2", conf);
-//		 		 
-//		 vcf.setInfo("IN=1,2;HOM=6,ATGAAggAATGC");
-//		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-//		 cm.addAnnotation();		 		 
-//		 conf = vcf.getInfoRecord().getField(VcfHeaderUtils.INFO_CONFIDENT);
-//		 assertEquals("LOW_1,LOW_2", conf);
-//	 }
-	 
 	 @Test
 	 public void willMultipleACValuesWork() {
 		 VcfFormatFieldRecord format = new VcfFormatFieldRecord("GT:GD:AC:MR:NNS:AD:DP:GQ:PL", "0/1:A/C:A8[33.75],11[38.82],C3[42],5[40]"+VCF_MERGE_DELIM+"A9[33.56],11[38.82],C3[42],5[40],G0[0],1[22],T1[11],0[0]:8:8:18"+VCF_MERGE_DELIM+"8:26:99:274,0,686");
@@ -1016,7 +1001,6 @@ public class ConfidenceModeTest {
 				 ,"0/0:.:.:.:.:NCIG:.:."
 				 ,"0/1:5,5:10:.:99:SOMATIC;GERM=117,185:.:."});
 		 ConfidenceMode cm = new ConfidenceMode();
-//		 ConfidenceMode cm =new ConfidenceMode(new short[] {1,3}, new short[]{2,4});
 		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
 		 cm.addAnnotation();
 		 
@@ -1181,7 +1165,6 @@ public class ConfidenceModeTest {
 			}
 		 }		 	 	 
 	 }
-	 
 	 
 	 @Ignore
 	 public void sampleColumnNoIDTest() throws IOException, Exception{	

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -30,6 +30,7 @@ import org.qcmg.vcf.VCFFileReader;
 public class ConfidenceModeTest {
 	
 	 public static final VcfFileMeta TWO_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
+	 public static final VcfFileMeta TWO_SAMPLE_ONE_CALLER_META = new VcfFileMeta( CCMModeTest.createTwoSampleVcf());
 	 public static final VcfFileMeta SINGLE_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createSingleSampleTwoCallerVcf());
 	
 	 @AfterClass
@@ -251,6 +252,127 @@ public class ConfidenceModeTest {
 		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
 		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
 		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+	 }
+	 
+	 @Test
+	 public void firstCallerOnly() {
+		 
+	 }
+	 
+	 @Test
+	 public void secondCallerOnly() {
+		 /*
+		  * chr1    5323163 rs7525806       C       T       .       .       BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)     GT:AD:CCC:CCM:DP:FT:GQ:INF:QL   ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.   0/1:1,2:Germline:21:3:COV;MR:37:.:35.77 ./.:.:HomozygousLoss:21:.:PASS:.:NCIG:.
+		  */
+		 VcfRecord r = new VcfRecord(new String[]{"chr1","5323163","rs7525806","C","T",".",".","BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)","GT:AD:CCC:CCM:DP:FT:GQ:INF:QL","./.:.:.:1:.:.:.:.:.","./.:.:.:1:.:.:.:.:.","0/1:1,2:Germline:21:3:.:37:.:35.77","./.:.:HomozygousLoss:21:.:.:.:NCIG:."});
+		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+	 }
+	 
+	 @Test
+	 public void compoundSnp() {
+		 /*
+		  * chr1    14221527        .       TG      CA      .       .       IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)    GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS        1/1:0,22:Germline:34:39:PASS:.:21:CA12[]10[];CG8[]9[];C_2[]0[]  1/1:0,6:Germline:34:50:PASS:.:6:CA3[]3[];CG23[]21[];_G1[]1[]    ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
+		  */
+		 VcfRecord r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+				 "1/1:0,22:Germline:34:39:.:.:21:CA12[]10[];CG8[]9[];C_2[]0[]",
+				 "1/1:0,6:Germline:34:50:.:.:6:CA3[]3[];CG23[]21[];_G1[]1[]",
+				 "./.:.:.:1:.:.:.:.:.",
+				 "./.:.:.:1:.:.:.:.:."});
+		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+	 }
+	 
+	 @Test
+	 public void compoundSnp2() {
+		 /*
+		  * chr1    14221527        .       TG      CA      .       .       IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)    
+		  * GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS        
+		  * 1/1:0,22:Germline:34:39:PASS:.:21:CA12[]10[];CG8[]9[];C_2[]0[]  
+		  * 1/1:0,6:Germline:34:50:PASS:.:6:CA3[]3[];CG23[]21[];_G1[]1[]    
+		  * ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
+		  */
+		 VcfRecord r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+				 "./.:.:.:1:.:.:.:.:.",
+				 "1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]",
+				 "./.:.:.:1:.:.:.:.:.",
+		 		 "./.:.:.:1:.:.:.:.:."});
+		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 
+		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+				 "0/0:3:.:1:.:.:.:.:TG1[]2[]",
+				 "1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]",
+				 "./.:.:.:1:.:.:.:.:.",
+		 		 "./.:.:.:1:.:.:.:.:."});
+		 cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 
+		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+				 "1/1:0,16:Germline:34:50:.:.:16:CA13[]3[];CG23[]21[];_G1[]1[]",
+		 		"./.:.:.:1:.:.:.:.:."});
+		 cm = new ConfidenceMode(SINGLE_SAMPLE_TWO_CALLER_META);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 
+		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+				 "1/1:0,16:Germline:34:50:.:.:16:CA13[]3[];CG23[]21[];_G1[]1[]",
+		 		  "./.:.:.:1:.:.:.:.:."});
+		 cm = new ConfidenceMode(TWO_SAMPLE_ONE_CALLER_META);
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 
+		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+				 "./.:.:.:1:.:.:.:.:.",
+		 		"1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]"});
+		 cm = new ConfidenceMode();
+		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
+		 cm.addAnnotation();
+		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
+		 
+		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
 	 }
 	 @Test
 	 public void realLifeMIN() {
@@ -698,7 +820,7 @@ public class ConfidenceModeTest {
 //		 conf = vcf.getInfoRecord().getField(VcfHeaderUtils.INFO_CONFIDENT);
 //		 assertEquals("LOW_1,LOW_2", conf);
 //	 }
-//	 
+	 
 	 @Test
 	 public void willMultipleACValuesWork() {
 		 VcfFormatFieldRecord format = new VcfFormatFieldRecord("GT:GD:AC:MR:NNS:AD:DP:GQ:PL", "0/1:A/C:A8[33.75],11[38.82],C3[42],5[40]"+VCF_MERGE_DELIM+"A9[33.56],11[38.82],C3[42],5[40],G0[0],1[22],T1[11],0[0]:8:8:18"+VCF_MERGE_DELIM+"8:26:99:274,0,686");

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
@@ -26,6 +26,7 @@ import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.util.IndelUtils.SVTYPE;
 import org.qcmg.common.vcf.ContentType;
 import org.qcmg.common.vcf.VcfFileMeta;
+import org.qcmg.common.vcf.VcfFormatFieldRecord;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafTest.java
@@ -20,6 +20,7 @@ import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.IndelUtils;
 import org.qcmg.common.vcf.ContentType;
+import org.qcmg.common.vcf.VcfFileMeta;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;
@@ -35,6 +36,32 @@ public class Vcf2mafTest {
     
     @org.junit.Rule
     public  TemporaryFolder testFolder = new TemporaryFolder();
+    
+    private static final VcfFileMeta TWO_CALLER_TWO_SAMPLE;
+	private static final VcfFileMeta TWO_CALLER_ONE_SAMPLE;
+	private static final VcfFileMeta ONE_CALLER_TWO_SAMPLE;
+	
+	static {
+		VcfHeader header = new VcfHeader();
+		header.addOrReplace("##1:qControlBamUUID=control-bam-uuid");
+		header.addOrReplace("##1:qTestBamUUID=test-bam-uuid");
+		header.addOrReplace("##2:qControlBamUUID=control-bam-uuid");
+		header.addOrReplace("##2:qTestBamUUID=test-bam-uuid");
+		header.addOrReplace("#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	control-bam-uuid_1	test-bam-uuid_1	control-bam-uuid_2	test-bam-uuid_2");
+		TWO_CALLER_TWO_SAMPLE = new VcfFileMeta(header);
+		
+		header = new VcfHeader();
+		header.addOrReplace("##1:qTestBamUUID=test-bam-uuid");
+		header.addOrReplace("##2:qTestBamUUID=test-bam-uuid");
+		header.addOrReplace("#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test-bam-uuid_1	test-bam-uuid_2");
+		TWO_CALLER_ONE_SAMPLE = new VcfFileMeta(header);
+		
+		header = new VcfHeader();
+		header.addOrReplace("##1:qControlBamUUID=control-bam-uuid");
+		header.addOrReplace("##1:qTestBamUUID=test-bam-uuid");
+		header.addOrReplace("#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	control-bam-uuid	test-bam-uuid");
+		ONE_CALLER_TWO_SAMPLE = new VcfFileMeta(header);
+	}
     
      @Test
      public void isHC() {
@@ -90,45 +117,41 @@ public class Vcf2mafTest {
      private VcfHeader createMergedVcfHeader() {
          VcfHeader h = new VcfHeader();
          
-//have to remove empty line "##"         
+         //have to remove empty line "##"         
          Arrays.asList("##fileformat=VCFv4.2",
-"##fileDate=20160523",
-"##qUUID=209dec81-a127-4aa3-92b4-2c15c21b75c7",
-"##qSource=qannotate-2.0 (1170)",
-"##1:qUUID=7554fdcc-7230-400e-aefe-5c9a4c79907b",
-"##1:qSource=qSNP v2.0 (1170)",
-"##1:qDonorId=my_donor",
-"##1:qControlSample=my_control_sample",
-"##1:qTestSample=my_test_sample",
-"##1:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##1:qControlBamUUID=null",
-"##1:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##1:qTestBamUUID=null",
-"##1:qAnalysisId=e3afda85-469f-412b-8919-10cd31d2ca52",
-"##2:qUUID=aa7d805f-2ec8-4aea-b1e6-7bc410a41c4b",
-"##2:qSource=qSNP v2.0 (1170)",
-"##2:qDonorId=my_donor",
-"##2:qControlSample=my_control_sample",
-"##2:qTestSample=my_test_sample",
-"##2:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##2:qControlBamUUID=null",
-"##2:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
-"##2:qTestBamUUID=null",
-"##2:qAnalysisId=3334e934-cb45-4215-9eb5-84b63d96a502",
-"##2:qControlVcf=/mnt/lustre/home/oliverH/q3testing/analysis/9/7/97b3715c-0a80-4115-844e-cc877b2cf409/controlGatkHCCV.vcf",
-"##2:qControlVcfUUID=null",
-"##2:qControlVcfGATKVersion=3.4-46-gbc02625",
-"##2:qTestVcf=/mnt/lustre/home/oliverH/q3testing/analysis/c/f/cfccdb1c-6c26-48e9-bd73-ad4ebd806aa6/testGatkHCCV.vcf",
-"##2:qTestVcfUUID=null",
-"##2:qTestVcfGATKVersion=3.4-46-gbc02625",
-"##INPUT=1,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/e/3/e3afda85-469f-412b-8919-10cd31d2ca52/e3afda85-469f-412b-8919-10cd31d2ca52.vcf",
-//"##INPUT=2,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/3/3/3334e934-cb45-4215-9eb5-84b63d96a502/3334e934-cb45-4215-9eb5-84b63d96a502.vcf").stream().forEach(h::parseHeaderLine);
-"##INPUT=2,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/3/3/3334e934-cb45-4215-9eb5-84b63d96a502/3334e934-cb45-4215-9eb5-84b63d96a502.vcf").stream().forEach(h::addOrReplace);
-
+		"##fileDate=20160523",
+		"##qUUID=209dec81-a127-4aa3-92b4-2c15c21b75c7",
+		"##qSource=qannotate-2.0 (1170)",
+		"##1:qUUID=7554fdcc-7230-400e-aefe-5c9a4c79907b",
+		"##1:qSource=qSNP v2.0 (1170)",
+		"##1:qDonorId=my_donor",
+		"##1:qControlSample=my_control_sample",
+		"##1:qTestSample=my_test_sample",
+		"##1:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+		"##1:qControlBamUUID=null",
+		"##1:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+		"##1:qTestBamUUID=null",
+		"##1:qAnalysisId=e3afda85-469f-412b-8919-10cd31d2ca52",
+		"##2:qUUID=aa7d805f-2ec8-4aea-b1e6-7bc410a41c4b",
+		"##2:qSource=qSNP v2.0 (1170)",
+		"##2:qDonorId=my_donor",
+		"##2:qControlSample=my_control_sample",
+		"##2:qTestSample=my_test_sample",
+		"##2:qControlBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9031/aligned_read_group_sets/dna_primarytumour_externpsar20150414090_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+		"##2:qControlBamUUID=null",
+		"##2:qTestBam=/mnt/lustre/working/genomeinfo/study/uqccr_amplicon_ffpe/donors/psar_9014/aligned_read_group_sets/dna_primarytumour_externpsar20150414076_nolibkit_truseqampliconcancerpanel_bwakit0712_miseq.bam",
+		"##2:qTestBamUUID=null",
+		"##2:qAnalysisId=3334e934-cb45-4215-9eb5-84b63d96a502",
+		"##2:qControlVcf=/mnt/lustre/home/oliverH/q3testing/analysis/9/7/97b3715c-0a80-4115-844e-cc877b2cf409/controlGatkHCCV.vcf",
+		"##2:qControlVcfUUID=null",
+		"##2:qControlVcfGATKVersion=3.4-46-gbc02625",
+		"##2:qTestVcf=/mnt/lustre/home/oliverH/q3testing/analysis/c/f/cfccdb1c-6c26-48e9-bd73-ad4ebd806aa6/testGatkHCCV.vcf",
+		"##2:qTestVcfUUID=null",
+		"##2:qTestVcfGATKVersion=3.4-46-gbc02625",
+		"##INPUT=1,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/e/3/e3afda85-469f-412b-8919-10cd31d2ca52/e3afda85-469f-412b-8919-10cd31d2ca52.vcf",
+		"##INPUT=2,FILE=/mnt/lustre/home/oliverH/q3testing/analysis/3/3/3334e934-cb45-4215-9eb5-84b63d96a502/3334e934-cb45-4215-9eb5-84b63d96a502.vcf").stream().forEach(h::addOrReplace);
          return h;
      }
-     
-     
      
      @Test
      public void compoundSNPTest() {
@@ -172,6 +195,75 @@ public class Vcf2mafTest {
          assertEquals("null", maf.getColumnValue(MafElement.Amino_Acid_Change));
          assertEquals("ENST00000433342", maf.getColumnValue(MafElement.Transcript_ID));
          assertEquals("c.2237-80TG>CA", maf.getColumnValue(MafElement.CDS_Change));
+     }
+     
+     @Test
+     public void compoundSNPTest2() {
+    	 /*
+    	  * chr1    11836441        rs71492357      TG      CA      .       .       IN=1,2;DB;EFF=upstream_gene_variant(MODIFIER||2547||615|C1orf167|protein_coding|CODING|ENST00000444493||1|WARNING_TRANSCRIPT_NO_START_CODON),upstream_gene_variant(MODIFIER||3433||531|C1orf167|protein_coding|CODING|ENST00000449278||1|WARNING_TRANSCRIPT_NO_START_CODON),downstream_gene_variant(MODIFIER||693|||RP11-56N19.5|antisense|NON_CODING|ENST00000376620||1),intron_variant(MODIFIER|||c.314-80TG>CA|827|C1orf167|protein_coding|CODING|ENST00000312793|2|1|WARNING_TRANSCRIPT_NO_START_CODON),intron_variant(MODIFIER|||c.2237-80TG>CA|1473|C1orf167|protein_coding|CODING|ENST00000433342|9|1),intron_variant(MODIFIER|||n.1210-80TG>CA||C1orf167|processed_transcript|CODING|ENST00000484153|7|1)       GT:DP:FT:MR:NNS:OABS:INF        1/1:22:.:22:22:CA14[]8[];C_1[]0[];_A1[]0[]:.;CONF=HIGH  1/1:19:.:19:16:CA18[]1[]:.;.    1/1:22:.:22:22:CA14[]8[];C_1[]0[];_A1[]0[]:.;CONF=HIGH  1/1:19:.:19:16:CA18[]1[]:.;.
+    	  */
+    	 String[] array = {
+    			 "chr1","11836441","rs71492357","TG","CA",".",".","IN=1,2;DB;EFF=upstream_gene_variant(MODIFIER||2547||615|C1orf167|protein_coding|CODING|ENST00000444493||1|WARNING_TRANSCRIPT_NO_START_CODON),upstream_gene_variant(MODIFIER||3433||531|C1orf167|protein_coding|CODING|ENST00000449278||1|WARNING_TRANSCRIPT_NO_START_CODON),downstream_gene_variant(MODIFIER||693|||RP11-56N19.5|antisense|NON_CODING|ENST00000376620||1),intron_variant(MODIFIER|||c.314-80TG>CA|827|C1orf167|protein_coding|CODING|ENST00000312793|2|1|WARNING_TRANSCRIPT_NO_START_CODON),intron_variant(MODIFIER|||c.2237-80TG>CA|1473|C1orf167|protein_coding|CODING|ENST00000433342|9|1),intron_variant(MODIFIER|||n.1210-80TG>CA||C1orf167|processed_transcript|CODING|ENST00000484153|7|1)"
+    			 ,"GT:DP:FT:MR:NNS:OABS:INF"
+    			 ,"1/1:22:PASS:22:22:CA14[]8[];C_1[]0[];_A1[]0[]:."
+    			 ,"1/1:19:PASS:19:16:CA18[]1[]:."
+    			 ,"./.:.:COV:.:.:.:."
+    			 ,"./.:.:COV:.:.:.:."
+    	 };
+    	 
+    	 final VcfRecord vcf = new VcfRecord(array);
+    	 final Vcf2maf mode = new Vcf2maf(TWO_CALLER_TWO_SAMPLE);
+    	 SnpEffMafRecord maf = mode.converter(vcf);
+    	 
+    	 assertFalse(maf == null);        
+    	 assertEquals("TG", maf.getColumnValue(MafElement.Reference_Allele));    
+    	 assertEquals("CA", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+    	 assertEquals("CA", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
+    	 assertEquals("CA", maf.getColumnValue(MafElement.Match_Norm_Seq_Allele1));
+    	 assertEquals("CA", maf.getColumnValue(MafElement.Match_Norm_Seq_Allele2));
+    	 
+    	 /*
+    	  * This should be a GERMLINE PASS as only the fist caller can call CSs and the second caller has no presence here
+    	  */
+    	 assertEquals("GERM", maf.getColumnValue(MafElement.Mutation_Status));
+    	 assertEquals("PASS", maf.getColumnValue(MafElement.Confidence));
+     }
+     
+     @Test
+     public void compoundSNPTest3() {
+    	 /*
+    	  * chrX	129362963	.	GG	AA	.	.	IN=1;HOM=4,GAAAACTCATggGGAGTGTGTG;EFF=missense_variant(MODERATE||ccccat/ccTTat|p.ProHis378ProTyr/c.1134CC>TT|737|ZNF280C|protein_coding|CODING|ENST00000370978||1),missense_variant(MODERATE||ccccat/ccTTat|p.ProHis378ProTyr/c.1134CC>TT|609|ZNF280C|protein_coding|CODING|ENST00000447817||1|WARNING_TRANSCRIPT_INCOMPLETE)	
+    	  * GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS	
+    	  * 0/0:17,0:Reference:14:17:PASS:.:.:GG12[]5[]	
+    	  * 1/1:0,64:SomaticNoReference:14:65:PASS:SOMATIC:58:AA38[]26[];A_0[]1[];CA1[]0[]	
+    	  * ./.:.:.:1:.:COV:.:.:.	
+    	  * ./.:.:.:1:.:COV:.:.:.
+    	  */
+    	 String[] array = {
+    			 "chrX","129362963",".","GG","AA",".",".","IN=1;HOM=4,GAAAACTCATggGGAGTGTGTG"
+    			 ,"GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS"
+    			 ,"0/0:17,0:Reference:14:17:PASS:.:.:GG12[]5[]"
+    			 ,"1/1:0,64:SomaticNoReference:14:65:PASS:SOMATIC:58:AA38[]26[];A_0[]1[];CA1[]0[]"
+    			 ,"./.:.:.:1:.:COV:.:.:."
+    			 ,"./.:.:.:1:.:COV:.:.:."
+    	 };
+    	 
+    	 final VcfRecord vcf = new VcfRecord(array);
+    	 final Vcf2maf mode = new Vcf2maf(TWO_CALLER_TWO_SAMPLE);
+    	 SnpEffMafRecord maf = mode.converter(vcf);
+    	 
+    	 assertFalse(maf == null);        
+    	 assertEquals("GG", maf.getColumnValue(MafElement.Reference_Allele));    
+    	 assertEquals("AA", maf.getColumnValue(MafElement.Tumor_Seq_Allele1));
+    	 assertEquals("AA", maf.getColumnValue(MafElement.Tumor_Seq_Allele2));
+    	 assertEquals("AA", maf.getColumnValue(MafElement.Match_Norm_Seq_Allele1));
+    	 assertEquals("AA", maf.getColumnValue(MafElement.Match_Norm_Seq_Allele2));
+    	 
+    	 /*
+    	  * This should be a SOMATIC PASS as only the fist caller can call CSs and the second caller has no presence here
+    	  */
+    	 assertEquals("SOMATIC", maf.getColumnValue(MafElement.Mutation_Status));
+    	 assertEquals("PASS", maf.getColumnValue(MafElement.Confidence));
      }
     
      //do it tomorrow
@@ -228,6 +320,31 @@ public class Vcf2mafTest {
          
          maf = v2m.converter(rec);
          assertEquals("PASS", maf.getColumnValue(MafElement.Confidence));
+     }
+     
+     @Test
+     public void confidenceFirstCallerOnly() {
+    	 
+    	 Vcf2maf v2m = new Vcf2maf(2,1, null, null, ContentType.MULTIPLE_CALLERS_MULTIPLE_SAMPLES);    //test column2; normal column 1            
+    	 VcfRecord rec = new VcfRecord( new String[] {"chr1","13302","rs180734498","C","T",".",".","FLANK=GGACATGCTGT;IN=1,2;DB;VAF=0.1143",
+    			 "GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS",
+    			 "0/1:.:Germline:23:34:PASS:.:.:10:9:C13[39.69]11[39.73];T9[37]1[42]",
+    			 "0/1:.:Germline:23:80:PASS:.:.:9:8:C35[40.11]36[39.19];T8[38.88]1[42]",
+    			 "0/1:26,10:Germline:22:36:PASS:99:.:10:9:C13[39.69]11[39.73];T9[37]1[42]",
+    	 "0/0:.:LOH:22:80:PASS:.:.:.:.:C35[40.11]36[39.19];T8[38.88]1[42]"});
+    	 
+    	 SnpEffMafRecord maf = v2m.converter(rec);
+    	 assertEquals("PASS", maf.getColumnValue(MafElement.Confidence));
+    	 
+    	 rec = new VcfRecord( new String[] {"chr1","13418",".","G","A",".",".","FLANK=ACCCCAAGATC;IN=1,2;DB;VAF=0.1143",
+    			 "GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS",
+    			 "0/1:.:Germline:22:54:PASS:.:.:6:6:A5[42]1[37];G26[38.92]22[37.36]",
+    			 "0/0:.:LOH:22:159:PASS:.:.:.:.:A4[39.5]2[42];G81[38.6]72[37.33]",
+    			 "0/1:45,6:Germline:22:51:PASS:65:.:6:6:A5[42]1[37];G26[38.92]22[37.36]",
+    	 "0/0:.:LOH:22:159:PASS:.:.:.:.:A4[39.5]2[42];G81[38.6]72[37.33]"});
+    	 
+    	 maf = v2m.converter(rec);
+    	 assertEquals("PASS", maf.getColumnValue(MafElement.Confidence));
      }
      
      @Test
@@ -591,36 +708,35 @@ public class Vcf2mafTest {
          File log = testFolder.newFile();
          File input = testFolder.newFile();
          File out = testFolder.newFile();
-            String[] str = {                
-                    VcfHeaderUtils.STANDARD_FILE_FORMAT + "=VCFv4.0",    
-                    VcfHeaderUtils.STANDARD_CONTROL_SAMPLE + "=CONTROL_sample",
-                    VcfHeaderUtils.STANDARD_TEST_SAMPLE + "=TEST_sample",    
-                    VcfHeaderUtils.STANDARD_TEST_BAMID + "=TEST_bamID",                
-                    VcfHeaderUtils.STANDARD_CONTROL_BAMID + "=CONTROL_bamID",                
-                    VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_bamID\tTEST_bamID",
-                    "chr1\t7722099\trs6698334\tC\tT\t.\t.\tBaseQRankSum=-0.736;ClippingRankSum=0.736;DP=3;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.736;QD=14.92;ReadPosRankSum=0.736;SOR=0.223;IN=2;DB;VLD;VAF=0.06887;EFF=intron_variant(MODIFIER|||c.805+173C>T|1673|CAMTA1|protein_coding|CODING|ENST00000303635|8|1),intron_variant(MODIFIER|||c.805+173C>T|1659|CAMTA1|protein_coding|CODING|ENST00000439411|8|1)\tGT:AD:DP:GQ:FT:MR:NNS:OABS:INF\t.:.:.:.:.:.:.:.:CONF=ZERO\t.:.:.:.:.:.:.:.:.\t0/1:1,2:3:35:COVN8:2:2:C0[0]1[39];T1[35]1[37]:CONF=ZERO\t.:.:.:.:.:.:.:.:."};            
-                createVcf(input, str); 
-                try {
-                    Vcf2mafTest.createVcf(input, str);
-                    final String[] command = {"--mode", "vcf2maf",  "--log", log.getAbsolutePath(),  "-i", input.getAbsolutePath() , "-o" , out.getAbsolutePath()};
-                    au.edu.qimr.qannotate.Main.main(command);
-                } catch ( Exception e) {
-                    e.printStackTrace(); 
-                    fail(); 
-                }                
-                try(BufferedReader br = new BufferedReader(new FileReader(out));) {
-                    String line = null;
-                    while ((line = br.readLine()) != null) {
-                            if(line.startsWith("#") || line.startsWith(MafElement.Hugo_Symbol.name())) continue; //skip vcf header
-                            
-                        SnpEffMafRecord maf =  Vcf2mafIndelTest.toMafRecord(line);        
-                         assertTrue(maf.getColumnValue(16).equals("TEST_bamID"));
-                         assertEquals("CONTROL_bamID", maf.getColumnValue(MafElement.Matched_Norm_Sample_Barcode));     
-                         assertTrue(maf.getColumnValue(33).equals("TEST_sample"));
-                         assertEquals("TEST_bamID:CONTROL_bamID", maf.getColumnValue(MafElement.BAM_File));
-                    }    
-                }
-         
+        String[] str = {                
+                VcfHeaderUtils.STANDARD_FILE_FORMAT + "=VCFv4.0",    
+                VcfHeaderUtils.STANDARD_CONTROL_SAMPLE + "=CONTROL_sample",
+                VcfHeaderUtils.STANDARD_TEST_SAMPLE + "=TEST_sample",    
+                VcfHeaderUtils.STANDARD_TEST_BAMID + "=TEST_bamID",                
+                VcfHeaderUtils.STANDARD_CONTROL_BAMID + "=CONTROL_bamID",                
+                VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL_bamID\tTEST_bamID",
+                "chr1\t7722099\trs6698334\tC\tT\t.\t.\tBaseQRankSum=-0.736;ClippingRankSum=0.736;DP=3;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.736;QD=14.92;ReadPosRankSum=0.736;SOR=0.223;IN=2;DB;VLD;VAF=0.06887;EFF=intron_variant(MODIFIER|||c.805+173C>T|1673|CAMTA1|protein_coding|CODING|ENST00000303635|8|1),intron_variant(MODIFIER|||c.805+173C>T|1659|CAMTA1|protein_coding|CODING|ENST00000439411|8|1)\tGT:AD:DP:GQ:FT:MR:NNS:OABS:INF\t.:.:.:.:.:.:.:.:CONF=ZERO\t.:.:.:.:.:.:.:.:.\t0/1:1,2:3:35:COVN8:2:2:C0[0]1[39];T1[35]1[37]:CONF=ZERO\t.:.:.:.:.:.:.:.:."};            
+        createVcf(input, str); 
+        try {
+            Vcf2mafTest.createVcf(input, str);
+            final String[] command = {"--mode", "vcf2maf",  "--log", log.getAbsolutePath(),  "-i", input.getAbsolutePath() , "-o" , out.getAbsolutePath()};
+            au.edu.qimr.qannotate.Main.main(command);
+        } catch ( Exception e) {
+            e.printStackTrace(); 
+            fail(); 
+        }                
+        try(BufferedReader br = new BufferedReader(new FileReader(out));) {
+            String line = null;
+            while ((line = br.readLine()) != null) {
+                    if(line.startsWith("#") || line.startsWith(MafElement.Hugo_Symbol.name())) continue; //skip vcf header
+                    
+                SnpEffMafRecord maf =  Vcf2mafIndelTest.toMafRecord(line);        
+                 assertTrue(maf.getColumnValue(16).equals("TEST_bamID"));
+                 assertEquals("CONTROL_bamID", maf.getColumnValue(MafElement.Matched_Norm_Sample_Barcode));     
+                 assertTrue(maf.getColumnValue(33).equals("TEST_sample"));
+                 assertEquals("TEST_bamID:CONTROL_bamID", maf.getColumnValue(MafElement.BAM_File));
+            }    
+        }
      }
      
      @Ignore
@@ -796,8 +912,6 @@ public class Vcf2mafTest {
         } catch (Exception e){
              fail(e.getMessage());
         }
-        
     }
-
 }
 

--- a/qcommon/src/org/qcmg/common/vcf/VcfRecord.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfRecord.java
@@ -352,19 +352,29 @@ public class VcfRecord implements Comparable<VcfRecord> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (obj == null) return false;
-		if (getClass() != obj.getClass()) return false;
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
 		
 		VcfRecord other = (VcfRecord) obj;
 		
 		//compare position
-		boolean flag = (cpp == null)? other.cpp == null : cpp.equals(other.cpp);
-		if( !flag ) return flag; 
+		boolean flag = (cpp == null) ? other.cpp == null : cpp.equals(other.cpp);
+		if ( ! flag ) {
+			return flag; 
+		}
 		
 		//compare ref if same position		
 		flag = (ref == null) ?  (other.ref == null) : ref.equals(other.ref);
-		if( !flag ) return flag; 
+		if( !flag ) {
+			return flag; 
+		}
 		
 		//compare alleles if same ref
 		flag = (alt == null) ? (other.alt == null) : alt.equals(other.alt);		
@@ -374,10 +384,12 @@ public class VcfRecord implements Comparable<VcfRecord> {
 	
 	@Override
 	public int compareTo(VcfRecord arg0) {
-		int Diff =  CHR_POS_COMPARATOR.compare(cpp, arg0.cpp);		
-		if(Diff != 0) return Diff; 
+		int diff =  CHR_POS_COMPARATOR.compare(cpp, arg0.cpp);		
+		if (diff != 0) {
+			return diff; 
+		}
 		
-		int l1 = (ref != null)? ref.length(): 0;
+		int l1 = (ref != null) ? ref.length() : 0;
 		int l2 = (arg0.ref != null) ? arg0.ref.length() : 0;		
 		return l1 - l2;
 	}

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -23,7 +23,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPointPosition;
@@ -40,17 +39,13 @@ import org.qcmg.common.vcf.header.VcfHeaderUtils;
 public class VcfUtils {
 	
 	private static final QLogger logger = QLoggerFactory.getLogger(VcfUtils.class);
-	
 	public static final Pattern pattern_AC = Pattern.compile("[ACGT][0-9]+\\[[0-9]+.?[0-9]*\\],[0-9]+\\[[0-9]+.?[0-9]*\\]");
 	public static final Pattern pattern_ACCS = Pattern.compile("[ACGT_]+,[0-9]+,[0-9]+");
 	public static final int CONF_LENGTH = (VcfHeaderUtils.INFO_CONFIDENCE + Constants.EQ).length();
-
-	
 	
 	/**
 	 * Attempts to merge a number of vcf records that have the same start position
 	 * NOTE that only the first 8 columns are merged, info, format fields will be empty
-	 * 
 	 * 
 	 * 
 	 * @param records
@@ -132,9 +127,7 @@ public class VcfUtils {
   * @return the counts for specified base or return total allels counts if base is null;
   */
 	public static int getAltFrequency( VcfFormatFieldRecord re, String base){
-		
 		int count = 0;
-		
  		 
 		final Matcher m;
 		String countString = null;
@@ -209,39 +202,6 @@ public class VcfUtils {
 	
 	public static Map<String, int[]> getAllelicCoverageFromOABS(String oabs) {
 		return getAllelicCoverageWithStrand(oabs);
-		
-		/*
-		 * need to decompose the OABs string into a map of string keys and corresponding counts
-		 */
-//		if ( ! StringUtils.isNullOrEmptyOrMissingData(oabs)) {
-//			
-//			String [] a = oabs.split(Constants.SEMI_COLON_STRING);
-//			Map<String, int[]> m = new HashMap<>(a.length * 2);
-//			
-//			for (String pileup : a) {
-//				int openBracketIndex = pileup.indexOf(Constants.OPEN_SQUARE_BRACKET);
-//				int startOfNumberIndex = 1;
-//				for (int i = 1 ; i < openBracketIndex ; i++) {
-//					char c = pileup.charAt(i);
-//					if (Character.isDigit(c)) {
-//						/*
-//						 * end of the line
-//						 */
-//						startOfNumberIndex = i;
-//						break;
-//					}
-//				}
-//				
-//				/*
-//				 * get fs + rs count
-//				 */
-//				int fsCount = Integer.parseInt(pileup.substring(startOfNumberIndex, openBracketIndex));
-//				int rsCount = Integer.parseInt(pileup.substring(pileup.indexOf(Constants.CLOSE_SQUARE_BRACKET) + 1, pileup.indexOf(Constants.OPEN_SQUARE_BRACKET, openBracketIndex + 1)));
-//				m.put(pileup.substring(0, startOfNumberIndex), new int[]{fsCount, rsCount});
-//			}
-//			return m;
-//		}
-//		return Collections.emptyMap();
 	}
 	
 	/**
@@ -525,8 +485,6 @@ public class VcfUtils {
 		return l;
 	}
 	
-
-	
 	/**
 	 * Returns a map of string arrays that represent the format field records
 	 * @param ff
@@ -654,7 +612,6 @@ public class VcfUtils {
 		
 		return re1; 
 	}
-
 	
 	/**
 	 * A vcf record is considered to be a snp if the length of the ref and alt fields are the same (and not null/0), the fields don't contain commas, and are not equal 
@@ -707,12 +664,10 @@ public class VcfUtils {
 					 */
 					return Arrays.stream(alts).allMatch(s -> s.length() == refLength);
 				}
-				
 			}
 		}
 		return false;
 	}
-	
 	
 	public static Map<String, int[]> getAllelicCoverageWithStrand(String oabs) {
 		
@@ -741,7 +696,6 @@ public class VcfUtils {
 							break;
 						}
 					}
-					
 					/*
 					 * get fs + rs count
 					 */
@@ -752,7 +706,6 @@ public class VcfUtils {
 			}
 			return m;
 		}
-		
 		return Collections.emptyMap();
 	}
 	
@@ -809,7 +762,6 @@ public class VcfUtils {
 		/*
 		 * split list up and add 1 at a time...
 		 */
-		
 		if (additionalSampleFormatFields.size() == 2) {
 			addAdditionalSampleToFormatField(vcf, additionalSampleFormatFields);
 		} else {
@@ -826,10 +778,7 @@ public class VcfUtils {
 	public static void addAdditionalSampleToFormatField(VcfRecord vcf, List<String> additionalSampleFormatFields) {
 		if ( null != additionalSampleFormatFields && additionalSampleFormatFields.size() > 1) {
 			
-//			logger.info("attempting to add sample ff to vcf rec: " + vcf.toString());
-//			additionalSampleFormatFields.stream().forEach(s -> logger.info("new ff: " + s));
 			List<String[]> additionalSampleFormatFieldsParams = additionalSampleFormatFields.stream().map(s -> s.split(Constants.COLON_STRING)).collect(Collectors.toList());
-			
 			List<String> existingFF = vcf.getFormatFields();
 			
 			if( existingFF.isEmpty()) {
@@ -1437,40 +1386,6 @@ public class VcfUtils {
 	 */
 	public static boolean isRecordSomatic(VcfRecord rec) {
 		return isRecordSomatic(rec.getInfo(), rec.getFormatFieldsAsMap());
-		
-//		String info = rec.getInfo();
-//		if ( ! StringUtils.isNullOrEmpty(info) && info.contains(VcfHeaderUtils.INFO_SOMATIC)) {
-//			return true;
-//		}
-//		
-////		if (isMergedRecord(rec)) {
-//			/*
-//			 * check out the format fields - need all records to be somatic
-//			 */
-//			String ff = rec.getFormatFieldStrings();
-//			Map<String, String[]> m =getFormatFieldsAsMap(ff);
-//			
-//			if (m.isEmpty()) {
-//				return false;
-//			}
-//			String [] infos = m.get(VcfHeaderUtils.FORMAT_INFO);
-//			if (null == infos || infos.length == 0) {
-//				return false;
-//			}
-//			long somCount =  Arrays.asList(infos).stream().filter(f ->null != f && f.contains(VcfHeaderUtils.INFO_SOMATIC)).count();
-//			return somCount * 2 >= infos.length;
-			
-//			if (noOfSomatics == 0) {
-//				return false;
-//			}
-//			return noOfSomatics * 2 >= filter.length;
-//		}
-			/*
-			 *SOMATIC_1 and SOMATIC_2 to return true
-			 */
-//			return info.contains(VcfHeaderUtils.INFO_SOMATIC + "_1") && info.contains(VcfHeaderUtils.INFO_SOMATIC + "_2");  
-//		} else {
-//		}
 	}
 	
 	public static boolean isRecordSomatic(String info, Map<String, String[]> formatFields) {

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -207,39 +208,40 @@ public class VcfUtils {
 	}
 	
 	public static Map<String, int[]> getAllelicCoverageFromOABS(String oabs) {
+		return getAllelicCoverageWithStrand(oabs);
 		
 		/*
 		 * need to decompose the OABs string into a map of string keys and corresponding counts
 		 */
-		if ( ! StringUtils.isNullOrEmptyOrMissingData(oabs)) {
-			
-			String [] a = oabs.split(Constants.SEMI_COLON_STRING);
-			Map<String, int[]> m = new HashMap<>(a.length * 2);
-			
-			for (String pileup : a) {
-				int openBracketIndex = pileup.indexOf(Constants.OPEN_SQUARE_BRACKET);
-				int startOfNumberIndex = 1;
-				for (int i = 1 ; i < openBracketIndex ; i++) {
-					char c = pileup.charAt(i);
-					if (Character.isDigit(c)) {
-						/*
-						 * end of the line
-						 */
-						startOfNumberIndex = i;
-						break;
-					}
-				}
-				
-				/*
-				 * get fs + rs count
-				 */
-				int fsCount = Integer.parseInt(pileup.substring(startOfNumberIndex, openBracketIndex));
-				int rsCount = Integer.parseInt(pileup.substring(pileup.indexOf(Constants.CLOSE_SQUARE_BRACKET) + 1, pileup.indexOf(Constants.OPEN_SQUARE_BRACKET, openBracketIndex + 1)));
-				m.put(pileup.substring(0, startOfNumberIndex), new int[]{fsCount, rsCount});
-			}
-			return m;
-		}
-		return Collections.emptyMap();
+//		if ( ! StringUtils.isNullOrEmptyOrMissingData(oabs)) {
+//			
+//			String [] a = oabs.split(Constants.SEMI_COLON_STRING);
+//			Map<String, int[]> m = new HashMap<>(a.length * 2);
+//			
+//			for (String pileup : a) {
+//				int openBracketIndex = pileup.indexOf(Constants.OPEN_SQUARE_BRACKET);
+//				int startOfNumberIndex = 1;
+//				for (int i = 1 ; i < openBracketIndex ; i++) {
+//					char c = pileup.charAt(i);
+//					if (Character.isDigit(c)) {
+//						/*
+//						 * end of the line
+//						 */
+//						startOfNumberIndex = i;
+//						break;
+//					}
+//				}
+//				
+//				/*
+//				 * get fs + rs count
+//				 */
+//				int fsCount = Integer.parseInt(pileup.substring(startOfNumberIndex, openBracketIndex));
+//				int rsCount = Integer.parseInt(pileup.substring(pileup.indexOf(Constants.CLOSE_SQUARE_BRACKET) + 1, pileup.indexOf(Constants.OPEN_SQUARE_BRACKET, openBracketIndex + 1)));
+//				m.put(pileup.substring(0, startOfNumberIndex), new int[]{fsCount, rsCount});
+//			}
+//			return m;
+//		}
+//		return Collections.emptyMap();
 	}
 	
 	/**
@@ -410,8 +412,28 @@ public class VcfUtils {
 	}
 	
 	public static boolean isCompoundSnp(VcfRecord vcf) {
-		String ff = vcf.getFormatFieldStrings();
-		return ff.contains(VcfHeaderUtils.FORMAT_ALLELE_COUNT_COMPOUND_SNP);
+		int refLength = vcf.getRef().length();
+		if (refLength > 1) {
+			String alt = vcf.getAlt();
+			if (alt.indexOf(Constants.COMMA) > -1) {
+				/*
+				 * all alts need to be of the same length, and also equal to refLength
+				 */
+				String [] alts = alt.split(Constants.COMMA_STRING);
+				for (String a : alts) {
+					if (a.length() != refLength) {
+						return false;
+					}
+				}
+				return true;
+			} else {
+				/*
+				 * single alt, just check the length
+				 */
+				return alt.length() == refLength;
+			}
+		}
+		return false;
 	}
 	
 	public static String getGenotypeFromGATKVCFRecord(VcfRecord rec) {
@@ -1002,7 +1024,6 @@ public class VcfUtils {
 	 * 
 	 * If both control and test exist, will merge the records into a single record with (hopefully) all required data populated.
 	 * 
-	 * 
 	 * @param control
 	 * @param test
 	 * @return
@@ -1036,7 +1057,6 @@ public class VcfUtils {
 		if (control.getAlt().equals(test.getAlt())) {
 			List<String> ff = test.getFormatFields();
 			addAdditionalSampleToFormatField(control, ff);
-//			prepareGATKVcfForMerge(control);
 			return Optional.ofNullable(control);
 		} else {
 			
@@ -1054,8 +1074,6 @@ public class VcfUtils {
 			 */
 			List<String> cFF = control.getFormatFields();
 			m.setFormatFields(cFF);
-//			prepareGATKVcfForMerge(m);
-//			prepareGATKVcfForMerge(test);
 			
 			List<String> tFFs = test.getFormatFields(); 
 			String tFF = tFFs.get(1);
@@ -1171,21 +1189,9 @@ public class VcfUtils {
 		}
 	}
 	
-	public static void removeFilter(VcfRecord rec, String filter) {
-		// perform some null guarding
-		if (null == rec) throw new IllegalArgumentException("Null vcf record passed to removeAnnotation");
-		if (null == filter) {
-			return;
-		}
-		
-		rec.setFilter(StringUtils.removeFromString(rec.getFilter(), filter, Constants.SC));
-	}
-	
 	public static Map<String, String[]> getFormatFieldsAsMap(String ff) {
 		return getFormatFieldsAsMap(Arrays.asList(ff.split(Constants.TAB_STRING)));
 	}
-	
-	
 	
 	/**
 	 * For SOMATIC records, if all format columns have a PASS in them, then we are a PASS.
@@ -1199,18 +1205,10 @@ public class VcfUtils {
 	}
 	
 	public static boolean isRecordAPass(Map<String, String[]> ffMap) {
-		String [] filterArr = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
-		
-		long passCount =  null != filterArr ? Arrays.asList(filterArr).stream().filter(f -> f.contains(VcfHeaderUtils.FILTER_PASS)).count() : 0;
-		if (passCount == 0) {
-			return false;
-		}
-		
-		/*
-		 * if all columns have a pass, we are done
-		 */
-		if (passCount == filterArr.length) {
-			return true;
+		String [] filterArray = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
+		Optional<Boolean> shortCut = getShortCutPassFail(filterArray);
+		if (shortCut.isPresent()) {
+			return shortCut.get().booleanValue();
 		}
 		
 		String [] infoArr = ffMap.get(VcfHeaderUtils.FORMAT_INFO);
@@ -1221,7 +1219,7 @@ public class VcfUtils {
 		if (somCount == 0) {
 			int i = 0;
 			boolean allPasses = true;
-			for (String s : filterArr) {
+			for (String s : filterArray) {
 				if (i++ %2 == 0) {
 					if ( ! s.equals(VcfHeaderUtils.FILTER_PASS)) {
 						allPasses = false;
@@ -1232,6 +1230,137 @@ public class VcfUtils {
 			return allPasses;
 		}
 		return false;	
+	}
+	
+	/**
+	 * Return true if there is a PASS in the fields that are specified in the int array.
+	 * False otherwise
+	 * 
+	 * @param ffMap
+	 * @param columnsThatMustHavePass
+	 * @return
+	 */
+	public static boolean isRecordAPass(Map<String, String[]> ffMap, int[] columnsThatMustHavePass) {
+		String [] filterArr = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
+		int filterArrayLength = filterArr.length;
+		for (int i : columnsThatMustHavePass) {
+			if (i >= filterArrayLength || ! filterArr[i].equals(VcfHeaderUtils.FILTER_PASS)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	public static boolean isRecordAPass(VcfRecord v, VcfFileMeta meta) {
+		if (null == meta) {
+			return isRecordAPass(v);
+		}
+		return isRecordAPass(v.getFormatFieldsAsMap(), meta, v.getInfo(), isCompoundSnp(v));
+	}
+	
+	/**
+	 * If the filter fields String array contains "PASS" at the positions (1-based) in the positions short array, return true.
+	 * False otherwise
+	 * 
+	 * @param filterFields
+	 * @param positions
+	 * @return
+	 */
+	public static boolean areTheseFilterFieldsAPass(String [] filterFields, short[] positions) {
+		if (null != filterFields && filterFields.length > 0 
+				&& null != positions && positions.length > 0) {
+			
+			boolean allGood = true;
+			for (int i : positions) {
+				if (i > 0 && i <= filterFields.length) {
+					if ( ! VcfHeaderUtils.FILTER_PASS.equals(filterFields[i - 1])) {
+						allGood =  false;
+					}
+				} else {
+					allGood = false;
+				}
+			}
+			return allGood;
+		}
+		return false;
+	}
+	
+	public static boolean isRecordAPass(Map<String, String[]> ffMap, VcfFileMeta meta, String infoField, boolean compoundSnp) {
+		String [] filterArray = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
+		
+		Optional<Boolean> shortCut = getShortCutPassFail(filterArray);
+		if (shortCut.isPresent()) {
+			return shortCut.get().booleanValue();
+		}
+		
+		/*
+		 * if record is a regular snp, check to see if it is somatic
+		 * If somatic, need all samples to carry the PASS
+		 * If germline, need all control samples to carry the PASS
+		 * 
+		 * If its a compound snp and 
+		 */
+		String [] infoArr = ffMap.get(VcfHeaderUtils.FORMAT_INFO);
+		long somaticCount = null != infoArr ? Arrays.asList(infoArr).stream().filter(f -> f.contains(VcfHeaderUtils.INFO_SOMATIC)).count() : 0;
+		if (compoundSnp) {
+			
+			/*
+			 * If its a compound snp, there is an assumption that this will have only been called by 
+			 * 1 caller (qsnp) and also that qsnp was the first caller.
+			 */
+			
+			short [] positions = somaticCount > 0 ?  new short[]{(short) meta.getFirstControlSamplePos(), (short)meta.getFirstTestSamplePos()}
+													: new short[]{(short) meta.getFirstControlSamplePos()};
+			return areTheseFilterFieldsAPass(filterArray, positions);
+			
+		} else {
+			
+			/*
+			 * Single Nucleotide Polymorphism
+			 */
+			if (somaticCount == 0) {
+				return areTheseFilterFieldsAPass(filterArray, meta.getAllControlPositions().toArray());
+			} else {
+				/*
+				 * somatic, we need all fields to be PASS, but that is not the case (getShortCutPassFail didn't give us a pass)
+				 * and so will fall through to returning false
+				 */
+			}
+		}
+		
+		return false;
+	}
+	
+	public static Optional<Boolean> getShortCutPassFail(String [] filterArr) {
+		if (null == filterArr || filterArr.length == 0) {
+			return Optional.of(false);
+		}
+		
+		int passCount = 0;
+		for (String s : filterArr) {
+			if (VcfHeaderUtils.FILTER_PASS.equals(s)) {
+				passCount++;
+			}
+		}
+		
+		/*
+		 * If we have no PASS, return optional false
+		 */
+		if (passCount == 0) {
+			return Optional.of(false);
+		}
+		
+		/*
+		 * if all columns have a pass, return optional true
+		 */
+		if (passCount == filterArr.length) {
+			return Optional.of(true);
+		}
+		
+		/*
+		 * otherwise return empty optional
+		 */
+		return Optional.empty();
 	}
 	
 	/**
@@ -1356,38 +1485,53 @@ public class VcfUtils {
 		if (null == infos || infos.length == 0) {
 			return false;
 		}
-		long somCount =  Arrays.asList(infos).stream().filter(f ->null != f && f.contains(VcfHeaderUtils.INFO_SOMATIC)).count();
+		int somCount =  getSomaticCountFromFormatInfoFields(infos);
+		if (0 == somCount) {
+			return false;
+		}
+		
+		/*
+		 * need to see how many callers contributed to this call
+		 * If 1, then need a single SOMATIC
+		 * If 2, need 2 SOMATICs etc.
+		 */
+		OptionalInt callerCount = getCallerCount(info);
+		if (callerCount.isPresent()) {
+			return somCount >= callerCount.getAsInt();
+		}
+		
+		/*
+		 * default to pre-existing behaviour should caller count not be present
+		 */
 		return somCount * 2 >= infos.length;
 	}
 	
 	/**
-	 * return true if info field OR the specified format column contains SOMATIC
-	 * position is zero based
-	 * @param rec
-	 * @param formatColumn
+	 * Will return the number of callers used to make this call as depicted in the "IN=.." entry in the INFO field.
+	 * If the INFO field contains IN=1,2 then OptionalInt.of(2) will be returned
+	 * If the INFO field contains IN=1 or IN=2, then OptionalInt(1) will be returned
+	 * If the INFO field doesn't contain IN then OptionalInt.empty() will be returned
+	 * @param info
 	 * @return
 	 */
-	public static boolean isRecordSomatic(VcfRecord rec, int formatColumn) {
-		String info = rec.getInfo();
-		if ( ! StringUtils.isNullOrEmpty(info) && info.contains(VcfHeaderUtils.INFO_SOMATIC)) {
-			return true;
+	public static OptionalInt getCallerCount(String info) {
+		if ( ! StringUtils.isNullOrEmptyOrMissingData(info) && info.contains("IN=")) {
+			int commaCount = (int) new VcfInfoFieldRecord(info).getField(Constants.VCF_MERGE_INFO).chars().filter(c -> c == Constants.COMMA).count();
+			return OptionalInt.of(commaCount + 1);
 		}
-		
-		Map<String, String[]> m =rec.getFormatFieldsAsMap();
-		
-		if (m.isEmpty()) {
-			return false;
+		return OptionalInt.empty();
+	}
+
+	/**
+	 * Returns the number of times the string SOMATIC appears in the format info (INF) fields
+	 * @param infos
+	 * @return
+	 */
+	public static int getSomaticCountFromFormatInfoFields(String [] infos) {
+		if (null != infos && infos.length > 0) {
+			return (int) Arrays.asList(infos).stream().filter(f -> null != f && f.contains(VcfHeaderUtils.INFO_SOMATIC)).count();
 		}
-		String [] filter = m.get(VcfHeaderUtils.FORMAT_INFO);
-		if (null == filter) {
-			return false;
-		}
-		
-		if (filter.length > formatColumn) {
-			return filter[formatColumn].contains(VcfHeaderUtils.INFO_SOMATIC); 
-		}
-		
-		return false;
+		return 0;
 	}
 	
 	/**

--- a/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/VcfUtils.java
@@ -200,10 +200,6 @@ public class VcfUtils {
 		return ffl.stream().map(StringBuilder::toString).collect(Collectors.toList());
 	}
 	
-	public static Map<String, int[]> getAllelicCoverageFromOABS(String oabs) {
-		return getAllelicCoverageWithStrand(oabs);
-	}
-	
 	/**
 	 * calculates the AD for a sample based on the ref, alts, and OABS
 	 * Should be safe to use for snps and compound snps alike - yay
@@ -660,6 +656,17 @@ public class VcfUtils {
 		return false;
 	}
 	
+	/**
+	 * Takes a String representing the observed allele by strand (OABS) and returns a corresponding map where the keys are the bases seen, and the values are an int array containing counts on each strand
+	 * 
+	 * eg. A12[40]20[30];T5[34]9[18]
+	 * would be represented by the following map:
+	 * <A: int[]{12,20}>
+	 * <T: int[]{5,9}>
+	 * 
+	 * @param oabs
+	 * @return
+	 */
 	public static Map<String, int[]> getAllelicCoverageWithStrand(String oabs) {
 		
 		/*

--- a/qcommon/src/org/qcmg/common/vcf/header/VcfHeaderUtils.java
+++ b/qcommon/src/org/qcmg/common/vcf/header/VcfHeaderUtils.java
@@ -108,7 +108,15 @@ public class VcfHeaderUtils {
 	public static final String FORMAT_ALLELE_COUNT_DESC = "Allele Count: lists number of reads on forward strand [avg base quality], reverse strand [avg base quality]";
 	public static final String FORMAT_OBSERVED_ALLELES_BY_STRAND = "OABS";
 	public static final String FORMAT_OBSERVED_ALLELES_BY_STRAND_DESC = "Observed Alleles By Strand: semi-colon separated list of observed alleles with each one in this format: forward_strand_count[avg_base_quality]reverse_strand_count[avg_base_quality], e.g. A18[39]12[42]";
+	/**
+	 * No longer use ACCS for compound snps. Compound snps are now handled like regular snps and have an OABS (FORMAT_OBSERVED_ALLELES_BY_STRAND) field
+	 */
+	@Deprecated
 	public static final String FORMAT_ALLELE_COUNT_COMPOUND_SNP = "ACCS";
+	/**
+	 *  No longer use ACCS for compound snps. Compound snps are now handled like regular snps and have an OABS (FORMAT_OBSERVED_ALLELES_BY_STRAND) field
+	 */
+	@Deprecated
 	public static final String FORMAT_ALLELE_COUNT_COMPOUND_SNP_DESC = "Allele Count Compound Snp: lists read sequence and count (forward strand, reverse strand)";
 	public static final String FORMAT_MUTANT_READS = FILTER_MUTANT_READS;
 	public static final String FORMAT_MUTANT_READS_DESC = "Number of reads carrying the alt";

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -732,7 +732,6 @@ public class VcfUtilsTest {
 		rec.setFilter("PASS_1;PASS_2");
 		assertEquals("PASS_1", VcfUtils.getFiltersEndingInSuffix(rec, "_1"));
 		assertEquals("PASS_2", VcfUtils.getFiltersEndingInSuffix(rec, "_2"));
-		
 	}
 	
 	@Test
@@ -840,7 +839,6 @@ public class VcfUtilsTest {
 		assertEquals(GenotypeEnum.GG, VcfUtils.calculateGenotypeEnum("0/0", 'G', 'G'));
 		assertEquals(GenotypeEnum.GG, VcfUtils.calculateGenotypeEnum("0/1", 'G', 'G'));
 		assertEquals(GenotypeEnum.GG, VcfUtils.calculateGenotypeEnum("1/1", 'G', 'G'));
-		
 	}
 	
 	@Test
@@ -858,13 +856,6 @@ public class VcfUtilsTest {
 		assertEquals("NOVELCOV=A:1,C:1,G:0,T:0,N:0,TOTAL:2", VcfUtils.getPileupElementAsString(pileups, true));
 		assertEquals("FULLCOV=A:1,C:1,G:0,T:0,N:0,TOTAL:2", VcfUtils.getPileupElementAsString(pileups, false));
 	}
-	
-//	@Test
-//	public void testGetMutationAndGTsRealLife() {
-//		assertArrayEquals(new String[] {"C", "0/1","0/1"} , VcfUtils.getMutationAndGTs("G",  GenotypeEnum.CG, GenotypeEnum.CG));
-//		assertArrayEquals(new String[] {"C", "1/1","1/1"} , VcfUtils.getMutationAndGTs("G",  GenotypeEnum.CC, GenotypeEnum.CC));
-//	}
-	
 	
 	@Test
 	public void getGTStringWithCommas() {
@@ -925,8 +916,6 @@ public class VcfUtilsTest {
 		assertEquals("CTTGT", VcfUtils.getUpdateAltString("CATTTGT", "CAT", "C"));
 	}
 	
-	
-	
 	@Test
 	public void isRecordAMnp() {
 		
@@ -968,7 +957,6 @@ public class VcfUtilsTest {
 		
 		rec = VcfUtils.resetAllel(rec,"A,AACCACC");
 		assertEquals(false, VcfUtils.isRecordAMnp(rec));
-		
 	}
 	
 	@Test
@@ -1032,7 +1020,6 @@ public class VcfUtilsTest {
 		assertEquals("./.:anythinghere:.:0:.:blah:.", rec.getFormatFields().get(2));
 	}
 	
-	
 	@Test
 	public void additionalSamplesRealLife() {
 		VcfRecord rec = new VcfRecord( new String[] {"chr1","3418618",".","G","A",".",".","FLANK=CCGGCACCTCC;DB;DP=3;FS=0.000;MQ=60.00;MQ0=0;QD=32.74;SOR=2.833;SOMATIC;IN=1,2"
@@ -1040,7 +1027,6 @@ public class VcfUtilsTest {
 				,"0/1:20:.:14:14:A3[23]11[24.18];G2[35]4[32]:.:.:."
 				,"0/0:7:COVT:.:.:A0[0]2[23.5];G2[36]3[35]:.:.:."
 				,"0/0:6:MIN:A3[23]11[24.18];G2[35]4[32]:.:.:SOMATIC"});
-		//VcfUtils.createVcfRecord("1", 1, "");
 		VcfUtils.addAdditionalSamplesToFormatField(rec, Arrays.asList("GT:AD:DP:FT:GQ:INF:MR:NNS:OABS","1/1:0,3:3:SBIASALT;COVT:9:SOMATIC:2:2:A0[0]2[23.5];G2[36]3[35]"));
 		assertEquals(5, rec.getFormatFields().size());
 		
@@ -1048,7 +1034,6 @@ public class VcfUtilsTest {
 	@Test
 	public void additionalSamples() {
 		VcfRecord rec = new VcfRecord( new String[] {"1","1",".","ACCACCACC","."});
-		//VcfUtils.createVcfRecord("1", 1, "");
 		VcfUtils.addFormatFieldsToVcf(rec, Arrays.asList("GT:GD:AC:MR:NNS","0/1:A/C:A38[31.42],32[25],C11[27.64],5[36.6]:16:16","0/1:A/C:A75[31.96],57[29.32],C12[35.25],6[38]:18:16"));
 		VcfUtils.addAdditionalSamplesToFormatField(rec, Arrays.asList("GT:AD:DP:GQ:PL:GD:AC:MR:NNS","0/1:2,2:4:69:72,0,69:A/C:A101[29.56],51[27.63],C30[30.83],21[37.29],G1[12],0[0]:51:44",".:.:.:.:.:.:A191[31.2],147[27.37],C70[30.29],92[37.47],T0[0],1[37]:162:101"));
 		assertEquals(5, rec.getFormatFields().size());
@@ -1353,7 +1338,6 @@ public class VcfUtilsTest {
 		assertEquals(false, VcfUtils.samplesPass(null, null, null, null, null));
 		assertEquals(false, VcfUtils.samplesPass("", "", "", "", ""));
 		assertEquals(false, VcfUtils.samplesPass(".", ".", ".", ".", "."));
-//		assertEquals(false, VcfUtils.samplesPass("PASS", "5", "PASS", "SOMATIC", "5"));
 	}
 	
 	@Test
@@ -1392,7 +1376,6 @@ public class VcfUtilsTest {
 		assertEquals("12,20", VcfUtils.getAD("T", "A", "A10[10]10[20];T1[]11[];C22[1]33[5]"));
 		assertEquals("12,20,55", VcfUtils.getAD("T", "A,C", "A10[10]10[20];T1[]11[];C22[1]33[5]"));
 		assertEquals("0,20,55", VcfUtils.getAD("G", "A,C", "A10[10]10[20];T1[]11[];C22[1]33[5]"));
-		
 	}
 	
 	@Test
@@ -1523,13 +1506,11 @@ public class VcfUtilsTest {
 		assertEquals(false, VcfUtils.mutationInNormal(0, 0, 0, 0));
 		assertEquals(false, VcfUtils.mutationInNormal(0, 10, 1, 2));
 		assertEquals(false, VcfUtils.mutationInNormal(1, 10, 1, 2));
-//		assertEquals(true, VcfUtils.mutationInNormal(1, 10, 1, 2));
 		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 1, 2));
 		assertEquals(false, VcfUtils.mutationInNormal(2, 10, 1, 3));
 		assertEquals(false, VcfUtils.mutationInNormal(2, 10, 25, 2));
 		assertEquals(false, VcfUtils.mutationInNormal(2, 10, 25, 3));
 		assertEquals(true, VcfUtils.mutationInNormal(2, 10, 20, 2));
-		
 		
 		assertEquals(false, VcfUtils.mutationInNormal(1, 24, 5, 3));
 		assertEquals(false, VcfUtils.mutationInNormal(3, 63, 5, 3));		// 3.15 = 0.05 * 63

--- a/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/vcf/VcfUtilsTest.java
@@ -364,19 +364,19 @@ public class VcfUtilsTest {
 	
 	@Test
 	public void getOABSDetails() {
-		Map<String, int[]> map = VcfUtils.getAllelicCoverageFromOABS("A1[10]0[0]");
+		Map<String, int[]> map = VcfUtils.getAllelicCoverageWithStrand("A1[10]0[0]");
 		assertEquals(1, map.size());
 		assertEquals(1, map.get("A")[0]);
 		assertEquals(0, map.get("A")[1]);
 		
-		map = VcfUtils.getAllelicCoverageFromOABS("A1[10]0[0];B0[0]10[2]");
+		map = VcfUtils.getAllelicCoverageWithStrand("A1[10]0[0];B0[0]10[2]");
 		assertEquals(2, map.size());
 		assertEquals(1, map.get("A")[0]);
 		assertEquals(0, map.get("A")[1]);
 		assertEquals(0, map.get("B")[0]);
 		assertEquals(10, map.get("B")[1]);
 		
-		map = VcfUtils.getAllelicCoverageFromOABS("A1[10]0[0];B0[0]10[2];C12[44]21[33]");
+		map = VcfUtils.getAllelicCoverageWithStrand("A1[10]0[0];B0[0]10[2];C12[44]21[33]");
 		assertEquals(3, map.size());
 		assertEquals(1, map.get("A")[0]);
 		assertEquals(0, map.get("A")[1]);

--- a/qio/test/org/qcmg/pileup/QSnpRecordTest.java
+++ b/qio/test/org/qcmg/pileup/QSnpRecordTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.qcmg.common.util.SnpUtils;
-import org.qcmg.common.vcf.VcfUtils;
 
 public class QSnpRecordTest {
 	
@@ -22,38 +21,4 @@ public class QSnpRecordTest {
 		rec.getVcfRecord().addFilter(SnpUtils.LESS_THAN_8_READS_TUMOUR);
 		assertEquals(SnpUtils.MUTATION_IN_NORMAL + ";" + SnpUtils.LESS_THAN_8_READS_TUMOUR, rec.getAnnotation());
 	}
-	
-//	@Test
-//	public void getNucleotides() {
-//		QSnpRecord rec = new QSnpRecord("chr1", 12345, "ACGT", "TGCA");
-//		rec.setNormalOABS(null);
-//		assertEquals(null, rec.getNormalNucleotides());
-//		rec.setNormalOABS("A1[10]0[0]");
-//		assertEquals("A1[10],0[0]", rec.getNormalNucleotides());
-//		rec.setNormalOABS("A1[10]0[0];B0[0]35[99]");
-//		assertEquals("A1[10],0[0],B0[0],35[99]", rec.getNormalNucleotides());
-//		rec.setNormalOABS("A1[10]0[0];B0[0]35[99];C28[82]93[39]");
-//		assertEquals("A1[10],0[0],B0[0],35[99],C28[82],93[39]", rec.getNormalNucleotides());
-//	}
-	
-	@Test
-	public void testRemoveAnnotation() {
-		QSnpRecord rec = new QSnpRecord("chr1", 12345, "ACGT", "TGCA");
-		rec.getVcfRecord().addFilter(SnpUtils.MUTATION_IN_NORMAL);
-		assertEquals(SnpUtils.MUTATION_IN_NORMAL, rec.getAnnotation());
-		VcfUtils.removeFilter(rec.getVcfRecord(), SnpUtils.LESS_THAN_12_READS_NORMAL);
-		assertEquals(SnpUtils.MUTATION_IN_NORMAL, rec.getAnnotation());
-		VcfUtils.removeFilter(rec.getVcfRecord(), SnpUtils.MUTATION_IN_NORMAL);
-		assertEquals(null, rec.getAnnotation());
-		
-		rec.getVcfRecord().addFilter(SnpUtils.MUTATION_IN_NORMAL);
-		rec.getVcfRecord().addFilter(SnpUtils.LESS_THAN_12_READS_NORMAL);
-		VcfUtils.removeFilter(rec.getVcfRecord(), SnpUtils.LESS_THAN_12_READS_NORMAL);
-		assertEquals(SnpUtils.MUTATION_IN_NORMAL, rec.getAnnotation());
-		
-		rec.getVcfRecord().addFilter(SnpUtils.LESS_THAN_12_READS_NORMAL);
-		VcfUtils.removeFilter(rec.getVcfRecord(), SnpUtils.MUTATION_IN_NORMAL);
-		assertEquals(SnpUtils.LESS_THAN_12_READS_NORMAL, rec.getAnnotation());
-	}
-
 }

--- a/qsnp/src/org/qcmg/snp/StandardPipeline.java
+++ b/qsnp/src/org/qcmg/snp/StandardPipeline.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.ToIntFunction;
 
 import org.ini4j.Ini;
 import org.qcmg.common.meta.QExec;

--- a/qsnp/src/org/qcmg/snp/VcfPipeline.java
+++ b/qsnp/src/org/qcmg/snp/VcfPipeline.java
@@ -134,52 +134,52 @@ public final class VcfPipeline extends Pipeline {
 		logger.info("about to classify - DONE[" + snps.size() + "]");
 		
 		// compound snps!
-		logger.info("about to do compound snps");
-		compoundSnps();
-		logger.info("about to do compound snps - DONE");
+//		logger.info("about to do compound snps");
+//		compoundSnps();
+//		logger.info("about to do compound snps - DONE");
 		
 		// write output
 		writeVCF(vcfFile);
 	}
 	
-	@Override
-	void compoundSnps() {
-		List<List<VcfRecord>> loloSnps = PipelineUtil.listOfListOfAdjacentVcfs(snps);
-		logger.info("Getting loloSnps [ " + loloSnps.size() + "] - DONE");
-		
-		if (loloSnps.isEmpty()) {
-			return;
-		}
-		
-		Set<VcfRecord> toRemove = new HashSet<>(1024 * 8);
-		
-		for (List<VcfRecord> loSnps : loloSnps) {
-			
-			Optional<VcfRecord> optionalVcf = PipelineUtil.createCompoundSnpGATK(loSnps, singleSampleMode);
-			
-			/*
-			 * if present, add to compound snps collection and remove from snps collection, if not present, do nowt
-			 */
-			if (optionalVcf.isPresent()) {
-				compoundSnps.add(optionalVcf.get());
-				toRemove.addAll(loSnps);
-			}
-		}
-		
-		if (toRemove.size() > 0) {
-			logger.info("About to call remove with toRemove size: " + toRemove.size());
-			Iterator<VcfRecord> iter = snps.iterator();
-			while (iter.hasNext()) {
-				VcfRecord v = iter.next();
-				if (toRemove.contains(v)) {
-					iter.remove();
-				}
-			}
-			logger.info("About to call remove with toRemove size: " + toRemove.size() + " - DONE");
-		}
-		
-		logger.info("Created " + compoundSnps.size() + " compound snps so far");
-	}
+//	@Override
+//	void compoundSnps() {
+//		List<List<VcfRecord>> loloSnps = PipelineUtil.listOfListOfAdjacentVcfs(snps);
+//		logger.info("Getting loloSnps [ " + loloSnps.size() + "] - DONE");
+//		
+//		if (loloSnps.isEmpty()) {
+//			return;
+//		}
+//		
+//		Set<VcfRecord> toRemove = new HashSet<>(1024 * 8);
+//		
+//		for (List<VcfRecord> loSnps : loloSnps) {
+//			
+//			Optional<VcfRecord> optionalVcf = PipelineUtil.createCompoundSnpGATK(loSnps, singleSampleMode);
+//			
+//			/*
+//			 * if present, add to compound snps collection and remove from snps collection, if not present, do nowt
+//			 */
+//			if (optionalVcf.isPresent()) {
+//				compoundSnps.add(optionalVcf.get());
+//				toRemove.addAll(loSnps);
+//			}
+//		}
+//		
+//		if (toRemove.size() > 0) {
+//			logger.info("About to call remove with toRemove size: " + toRemove.size());
+//			Iterator<VcfRecord> iter = snps.iterator();
+//			while (iter.hasNext()) {
+//				VcfRecord v = iter.next();
+//				if (toRemove.contains(v)) {
+//					iter.remove();
+//				}
+//			}
+//			logger.info("About to call remove with toRemove size: " + toRemove.size() + " - DONE");
+//		}
+//		
+//		logger.info("Created " + compoundSnps.size() + " compound snps so far");
+//	}
 	
 	void classifyPileup() {
 		for (VcfRecord v : snps) {

--- a/qsnp/src/org/qcmg/snp/VcfPipeline.java
+++ b/qsnp/src/org/qcmg/snp/VcfPipeline.java
@@ -12,12 +12,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -40,7 +36,6 @@ import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.common.model.Classification;
 import org.qcmg.snp.util.GenotypeUtil;
 import org.qcmg.snp.util.IniFileUtil;
-import org.qcmg.snp.util.PipelineUtil;
 import org.qcmg.vcf.VCFFileReader;
 
 
@@ -133,53 +128,9 @@ public final class VcfPipeline extends Pipeline {
 		classifyPileup();
 		logger.info("about to classify - DONE[" + snps.size() + "]");
 		
-		// compound snps!
-//		logger.info("about to do compound snps");
-//		compoundSnps();
-//		logger.info("about to do compound snps - DONE");
-		
 		// write output
 		writeVCF(vcfFile);
 	}
-	
-//	@Override
-//	void compoundSnps() {
-//		List<List<VcfRecord>> loloSnps = PipelineUtil.listOfListOfAdjacentVcfs(snps);
-//		logger.info("Getting loloSnps [ " + loloSnps.size() + "] - DONE");
-//		
-//		if (loloSnps.isEmpty()) {
-//			return;
-//		}
-//		
-//		Set<VcfRecord> toRemove = new HashSet<>(1024 * 8);
-//		
-//		for (List<VcfRecord> loSnps : loloSnps) {
-//			
-//			Optional<VcfRecord> optionalVcf = PipelineUtil.createCompoundSnpGATK(loSnps, singleSampleMode);
-//			
-//			/*
-//			 * if present, add to compound snps collection and remove from snps collection, if not present, do nowt
-//			 */
-//			if (optionalVcf.isPresent()) {
-//				compoundSnps.add(optionalVcf.get());
-//				toRemove.addAll(loSnps);
-//			}
-//		}
-//		
-//		if (toRemove.size() > 0) {
-//			logger.info("About to call remove with toRemove size: " + toRemove.size());
-//			Iterator<VcfRecord> iter = snps.iterator();
-//			while (iter.hasNext()) {
-//				VcfRecord v = iter.next();
-//				if (toRemove.contains(v)) {
-//					iter.remove();
-//				}
-//			}
-//			logger.info("About to call remove with toRemove size: " + toRemove.size() + " - DONE");
-//		}
-//		
-//		logger.info("Created " + compoundSnps.size() + " compound snps so far");
-//	}
 	
 	void classifyPileup() {
 		for (VcfRecord v : snps) {
@@ -391,5 +342,4 @@ public final class VcfPipeline extends Pipeline {
 		logger.tool("**** OTHER CONFIG ****");
 		logger.tool("mutationIdPrefix: " + mutationIdPrefix);
 	}
-
 }

--- a/qsnp/test/org/qcmg/snp/TestVcfPipeline.java
+++ b/qsnp/test/org/qcmg/snp/TestVcfPipeline.java
@@ -1,15 +1,10 @@
 package org.qcmg.snp;
 
-import java.util.List;
-
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.util.Constants;
-import org.qcmg.common.vcf.VcfRecord;
-import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeader;
 import org.qcmg.common.vcf.header.VcfHeaderRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
-import org.qcmg.pileup.QSnpRecord;
 
 public class TestVcfPipeline extends Pipeline {
 	

--- a/qsnp/test/org/qcmg/snp/TestVcfPipeline.java
+++ b/qsnp/test/org/qcmg/snp/TestVcfPipeline.java
@@ -28,41 +28,6 @@ public class TestVcfPipeline extends Pipeline {
 		this.testVcfHeader = h;
 	}
 
-	QSnpRecord getQSnpRecord(QSnpRecord normal, QSnpRecord tumour) {
-		QSnpRecord qpr = null;
-		
-		//TODO need to merge the underlying VcfRecords should both exist
-		
-		if (null != normal && null != tumour) {
-			// create new VcfRecord
-			VcfRecord mergedVcf = normal.getVcfRecord();
-			// add filter and format fields
-			mergedVcf.addFilter(tumour.getVcfRecord().getFilter());
-			List<String> formatFields = mergedVcf.getFormatFields();
-			formatFields.add(tumour.getVcfRecord().getFormatFields().get(1));
-			mergedVcf.setFormatFields(formatFields);
-			
-			// create new QSnpRecord with the mergedVcf details
-			qpr = new QSnpRecord(mergedVcf);
-//			qpr.setNormalNucleotides(normal.getNormalNucleotides());
-//			qpr.setNormalGenotype(normal.getNormalGenotype());
-//			qpr.setTumourNucleotides(tumour.getTumourNucleotides());
-//			qpr.setTumourGenotype(tumour.getTumourGenotype());
-//			
-			
-		} else if (null != normal) {
-			qpr = normal;
-			// need to add a format field entry for the empty tumoursample
-			VcfUtils.addMissingDataToFormatFields(qpr.getVcfRecord(), 2);
-		} else {
-			// tumour only
-			qpr = tumour;
-			VcfUtils.addMissingDataToFormatFields(qpr.getVcfRecord(), 1);
-		}		
-//		qpr.setId(++mutationId);
-		return qpr;
-	}
-	
 	@Override
 	VcfHeader getExistingVCFHeaderDetails()  {
 		VcfHeader existingHeader = new VcfHeader();


### PR DESCRIPTION
# Description


This change removes the capability of `qsnp` vcf mode to create compound snps.

To call a compound snp with any confidence, you need to be sure that the alts are present on the same reads. This is not possible when running `qsnp` in vcf mode, as the vcf files produced by `GATK` don't carry read ids.

Previously, `qsnp` vcf mode would naively create a compound snp if there were adjacent snps present in the vcf file. This is no longer the case.

As a consequence of this, compound snps called by `qsnp` std mode (where we do have the ability to determine if the CS is on the same read) will not have any supporting information from `GATK` after the vcf merge process.
To deal with this, changes to `qannotate` were made so that compound snps could still end up in the `pass` file (formerly `High Confidence`).

Here is a before and after snapshot:

```
chr16	9770667	.	CC	AG	.	.	IN=1,2;HOM=0,ATACGAGTCAccGCACCAAATT
GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS:QL
0/1:21,6:Germline:23:27:PASS:.:.:6:AG3[]3[];CC10[]11[]:.
0/1:43,9:Germline:23:52:PASS:.:.:8:AG7[]2[];CC21[]22[];_C1[]1[]:.
0/1:30,23:Germline:23:53:PASS:99:.:.:.:880.77
0/1:48,30:Germline:23:78:PASS:99:.:.:.:1080.77
```

and after the change:

```
chr16	9770667	.	CC	AG	.	.	IN=1;HOM=0,ATACGAGTCAccGCACCAAATT
GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS
0/1:21,6:Germline:23:27:PASS:.:6:AG3[]3[];CC10[]11[]
0/1:43,9:Germline:23:52:PASS:.:8:AG7[]2[];CC21[]22[];_C1[]1[]
./.:.:.:1:.:COV:.:.:.
./.:.:.:1:.:COV:.:.:.
```

and the 2 entries from the vcf mode (GATK) are in the `all` file:

```
chr16	9770667	rs117394156	C	A	.	.	BaseQRankSum=1.112;ClippingRankSum=0.000;DP=54;ExcessHet=3.0103;FS=3.900;MQ=56.07;MQRankSum=-3.096;QD=16.31;ReadPosRankSum=1.067;SOR=1.329;IN=2;DB;VLD;VAF=0.2805;GERM=A:1:0:1:0;HOM=2,ATACGAGTCAcCGCACCAAAT;EFF=missense_variant(MODERATE|MISSENSE|gGt/gTt|p.Gly9Val/c.26G>T|99|RP11-297M9.1|protein_coding|CODING|ENST00000561538|1|1)
GT:AD:CCC:CCM:DP:FT:GQ:INF:QL
./.:.:.:1:.:COV:.:.:.
./.:.:.:1:.:COV:.:.:.
0/1:30,24:Germline:23:54:PASS:99:.:880.77
0/1:48,30:Germline:23:78:PASS:99:.:1080.77
```

and

```
chr16	9770668	rs117577549	C	G	.	.	BaseQRankSum=1.340;ClippingRankSum=0.000;DP=53;ExcessHet=3.0103;FS=3.822;MQ=56.46;MQRankSum=-2.900;QD=16.62;ReadPosRankSum=1.374;SOR=1.241;IN=2;DB;VLD;VAF=0.2801;GERM=G:1:0:1:0;HOM=2,TACGAGTCACcGCACCAAATT;EFF=missense_variant(MODERATE|MISSENSE|Ggt/Cgt|p.Gly9Arg/c.25G>C|99|RP11-297M9.1|protein_coding|CODING|ENST00000561538|1|1)
GT:AD:CCC:CCM:DP:FT:GQ:INF:QL
./.:.:.:1:.:COV:.:.:.
./.:.:.:1:.:COV:.:.:.
0/1:30,23:Germline:23:53:PASS:99:.:880.77
0/1:50,30:Germline:23:80:PASS:99:.:1080.77
```

Fixes #20 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`Qsnp's` vcf mode and `qannotate` modes were run against output generated by the nightly regression tests and the results were compared.
The `Somatic.Pass.Consequence` files contained the same variants (they differed due to the lack of `GATK` information in the call).
The new `Germline.Pass.Consequence` file had 1 additional entry which was explainable (due to vcf mode creating 2 seperate entries rather than a single compound snp).

The new `Somatic.Pass` file was also compared to the old one, and all differences were expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
