### PR TITLE
Removed versioning from project jar files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ subprojects {
       def classpath = project.configurations.runtime.collect { it.name }.join(' ')
       manifest {    
         attributes 'Implementation-Title': project.name,
-        	   'Implementation-Version': "$version ($revision)",
         	   'SVN-Version': revision,
                    'Built-By': System.properties['user.name'],
                    'Date': new java.util.Date().toString(),

--- a/qannotate/build.gradle
+++ b/qannotate/build.gradle
@@ -1,4 +1,3 @@
-version = '2.1.2'
 apply plugin: 'application'
 
 mainClassName = 'au.edu.qimr.qannotate.Main'

--- a/qbamannotate/build.gradle
+++ b/qbamannotate/build.gradle
@@ -1,4 +1,3 @@
-version = '0.3pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qbamannotate.Main'

--- a/qbamfilter/build.gradle
+++ b/qbamfilter/build.gradle
@@ -1,4 +1,3 @@
-version = '1.2'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qbamfilter.query.Query'

--- a/qbamfix/build.gradle
+++ b/qbamfix/build.gradle
@@ -1,4 +1,3 @@
-version = '0.2pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qbamfix.Main'

--- a/qbammerge/build.gradle
+++ b/qbammerge/build.gradle
@@ -1,4 +1,3 @@
-version = '0.7pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.bammerge.Main'

--- a/qbasepileup/build.gradle
+++ b/qbasepileup/build.gradle
@@ -1,4 +1,3 @@
-version = '0.1pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qbasepileup.QBasePileup'

--- a/qcnv/build.gradle
+++ b/qcnv/build.gradle
@@ -1,4 +1,3 @@
-version = '0.3pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.cnv.Main'

--- a/qcommon/build.gradle
+++ b/qcommon/build.gradle
@@ -1,5 +1,3 @@
-version = '0.4'
-
 def isExecutable = true
 
 dependencies {

--- a/qcoverage/build.gradle
+++ b/qcoverage/build.gradle
@@ -1,4 +1,3 @@
-version = '0.7pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.coverage.Coverage'

--- a/qio/build.gradle
+++ b/qio/build.gradle
@@ -1,5 +1,3 @@
-version = '0.1.1'
-
 def isExecutable = true
 
 dependencies {

--- a/qmaftools/build.gradle
+++ b/qmaftools/build.gradle
@@ -1,4 +1,3 @@
-version = '0.2'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.maf.QMafPipeline'

--- a/qmito/build.gradle
+++ b/qmito/build.gradle
@@ -1,4 +1,3 @@
-version = '0.1pre'
 apply plugin: 'application'
 
 mainClassName = 'au.edu.qimr.qmito.Mito'

--- a/qmotif/build.gradle
+++ b/qmotif/build.gradle
@@ -1,4 +1,3 @@
-version = '1.2'
 apply plugin: 'application'
 def xmlVersion = '0.3'
 

--- a/qmule/build.gradle
+++ b/qmule/build.gradle
@@ -1,4 +1,3 @@
-version = '0.1pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qmule.Main'

--- a/qpicard/build.gradle
+++ b/qpicard/build.gradle
@@ -1,5 +1,3 @@
-version = '1.1'
-
 def isExecutable = false
 
 dependencies {

--- a/qpileup/build.gradle
+++ b/qpileup/build.gradle
@@ -1,8 +1,6 @@
 import com.sun.org.apache.xalan.internal.xsltc.compiler.TestSeq;
 apply plugin: 'application'
 
-version = '0.1pre'
-
 mainClassName = 'org.qcmg.pileup.QPileup'
 def scriptname = 'qpileup'
 def isExecutable = true

--- a/qprofiler/build.gradle
+++ b/qprofiler/build.gradle
@@ -1,4 +1,3 @@
-version = '1.0'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qprofiler.QProfiler'

--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -1,4 +1,3 @@
-version = '2.0'
 apply plugin: 'application'
 mainClassName = 'org.qcmg.qprofiler2.QProfiler2'
 def scriptname = 'qprofiler2'
@@ -24,7 +23,6 @@ task fatJar(type: Jar ) {
 		
 		manifest {
 			attributes 'Implementation-Title': baseName,
-					   'Implementation-Version': "$version ($revision)",
 					   'Built-By': System.properties['user.name'],
 					   'Date': new java.util.Date().toString(),
 					   'Main-Class' : mainClassName,

--- a/qsignature/build.gradle
+++ b/qsignature/build.gradle
@@ -1,4 +1,3 @@
-version = '1.0'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.sig.QSignature'

--- a/qsnp/build.gradle
+++ b/qsnp/build.gradle
@@ -1,4 +1,3 @@
-version = '2.1.4'
 apply plugin: 'application'
 apply plugin: 'scala'
 

--- a/qsplit/build.gradle
+++ b/qsplit/build.gradle
@@ -1,4 +1,3 @@
-version = '0.1pre'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.split.Main'

--- a/qsv/build.gradle
+++ b/qsv/build.gradle
@@ -1,4 +1,3 @@
-version = '0.3'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qsv.QSV'

--- a/qtesting/build.gradle
+++ b/qtesting/build.gradle
@@ -1,5 +1,3 @@
-version = '0.1pre'
-
 def isExecutable = false
 
 dependencies {

--- a/qvisualise/build.gradle
+++ b/qvisualise/build.gradle
@@ -1,4 +1,3 @@
-version = '1.0'
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qvisualise.QVisualise'


### PR DESCRIPTION
# Description

Removed versions from project jar files. The parent adamajava version will dictate the version of the project jar.

The release of this will need to coincide with an update to the numerous wdl tasks that call adamajava jar files

Fixes #38 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change - will need to update any wdl tasks that use adamajava jar files

# How Has This Been Tested?

A build has been run and the project jar files are created without version numbers.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
