### PR TITLE
QSignature Compare tidy-up

### DIFF
--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -159,7 +159,7 @@ public class Compare {
 				/*
 				 * remove all from map
 				 */
-				result =new Pair<>(rgResults.getKey(), rgResults.getSecond().remove("all"));
+				result = new Pair<>(rgResults.getKey(), rgResults.getSecond().remove("all"));
 				
 				List<String> rgs = new ArrayList<>(rgResults.getSecond().keySet());
 				for (int i = 0 ; i < rgs.size() ; i++) {

--- a/qsignature/src/org/qcmg/sig/QSigCompare.java
+++ b/qsignature/src/org/qcmg/sig/QSigCompare.java
@@ -39,7 +39,6 @@ import org.qcmg.tab.TabbedHeader;
 import org.qcmg.tab.TabbedRecord;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
 /**
  * This was the original compare class.
  * It has now been superseded many times, with the latest "best practice" method being the Compare class.
@@ -50,6 +49,7 @@ import org.w3c.dom.Element;
  *
  *@deprecated
  */
+@Deprecated
 public class QSigCompare {
 	
 	// make static

--- a/qsignature/src/org/qcmg/sig/QSigCompare.java
+++ b/qsignature/src/org/qcmg/sig/QSigCompare.java
@@ -7,7 +7,6 @@
 package org.qcmg.sig;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,6 +40,16 @@ import org.qcmg.tab.TabbedRecord;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * This was the original compare class.
+ * It has now been superseded many times, with the latest "best practice" method being the Compare class.
+ * Deprecating, and will delete soon. 
+ * 
+ * 
+ * @author oliverh
+ *
+ *@deprecated
+ */
 public class QSigCompare {
 	
 	// make static
@@ -59,10 +68,10 @@ public class QSigCompare {
 	private int minCoverage = 10;
 	private float cutoff = 0.035f;
 	
-	private final  List<File> vcfFiles = new ArrayList<File>();
+	private final  List<File> vcfFiles = new ArrayList<>();
 	
-	private final Map<File, Map<ChrPosition, int[]>> fileRatios = new HashMap<File, Map<ChrPosition, int[]>>();
-	private final List<String[]> displayResults = new ArrayList<String[]>();
+	private final Map<File, Map<ChrPosition, int[]>> fileRatios = new HashMap<>();
+	private final List<String[]> displayResults = new ArrayList<>();
 	
 	private int engage() throws Exception {
 		
@@ -151,12 +160,12 @@ public class QSigCompare {
 		
 		// if no output specified, output to standard out
 		StreamResult result = null;
-		if (cmdLineOutputFiles == null || cmdLineOutputFiles.length < 1)
+		if (cmdLineOutputFiles == null || cmdLineOutputFiles.length < 1) {
 			result = new StreamResult(System.out );
-		else 
+		} else { 
 			result = new StreamResult(new File(cmdLineOutputFiles[0]));
-		 
-		 try {
+		}
+		try {
 			transformer.transform(source, result);
 		} catch (TransformerException e) {
 			logger.error("Can't transform file", e);
@@ -244,9 +253,15 @@ public class QSigCompare {
 		if (null == rating) throw new IllegalArgumentException("null rating passed to getFlag");
 		
 		// some hard-coded rules in here to start with
-		if (snpCount == 0) return "???";
-		if (rating.startsWith("B") && score < cutoffValue) return "???";
-		if (rating.startsWith("A") && score > cutoffValue) return "???";
+		if (snpCount == 0) {
+			return "???";
+		}
+		if (rating.startsWith("B") && score < cutoffValue) {
+			return "???";
+		}
+		if (rating.startsWith("A") && score > cutoffValue) {
+			return "???";
+		}
 		
 		return "OK";
 	}
@@ -267,20 +282,23 @@ public class QSigCompare {
 		if (null == s1 || null == s2 || s1.length < 3 || s2.length < 3) 
 			throw new IllegalArgumentException("invalid argument passed to getRating");
 		
-		if (Arrays.deepEquals(s1, s2)) return "AAA";
+		if (Arrays.deepEquals(s1, s2)) {
+			return "AAA";
+		}
 		
-		if (s1[0].equals(s2[0]) && s1[1].equals(s2[1]))
+		if (s1[0].equals(s2[0]) && s1[1].equals(s2[1])) {
 			return "AAB";
-		else if (s1[1].equals(s2[1]) && s1[2].equals(s2[2]))
+		} else if (s1[1].equals(s2[1]) && s1[2].equals(s2[2])) {
 			return "BAA";
-		else if (s1[0].equals(s2[0]) && s1[2].equals(s2[2]))
+		} else if (s1[0].equals(s2[0]) && s1[2].equals(s2[2])) {
 			return "ABA";
-		else if (s1[0].equals(s2[0]) )
+		} else if (s1[0].equals(s2[0])) {
 			return "ABB";
-		else if (s1[1].equals(s2[1]) )
+		} else if (s1[1].equals(s2[1])) {
 			return "BAB";
-		else if (s1[2].equals(s2[2]) )
+		} else if (s1[2].equals(s2[2])) {
 			return "BBA";
+		}
 		
 		return "BBB";
 	}
@@ -293,21 +311,27 @@ public class QSigCompare {
 			final int[] file1Ratio = file1RatiosEntry.getValue();
 			final int f1TotalCount = file1Ratio[1];
 			// both total counts must be above the minCoverage value
-			if (f1TotalCount < minCoverage) continue;
+			if (f1TotalCount < minCoverage) {
+				continue;
+			}
 			
 			final int[] file2Ratio = file2Ratios.get(file1RatiosEntry.getKey());
-			if (file2Ratio == null) continue;
+			if (file2Ratio == null) {
+				continue;
+			}
 			
 			// first entry in array is the non-ref count, the second is the total count
 			final int f2TotalCount = file2Ratio[1];
-			if (f2TotalCount < minCoverage) continue;
+			if (f2TotalCount < minCoverage) {
+				continue;
+			}
 			
 			final int f2NonRefCount = file2Ratio[0];
 			final int f1NonRefCount = file1Ratio[0];
 			
 			noOfPositionsUsed.incrementAndGet();
 			
-			totalDifference += Math.abs(((float)f1NonRefCount / f1TotalCount)- ((float)f2NonRefCount / f2TotalCount));
+			totalDifference += Math.abs(((float)f1NonRefCount / f1TotalCount) - ((float)f2NonRefCount / f2TotalCount));
 		}
 		
 		return totalDifference;
@@ -320,11 +344,9 @@ public class QSigCompare {
 		
 		for (TabbedRecord vcfRecord : reader) {
 			String[] params = TabTokenizer.tokenize(vcfRecord.getData());
-//			String[] params = tabbedPattern.split(vcfRecord.getData(), -1);
 			ChrPosition chrPos = ChrPointPosition.valueOf(params[0], Integer.parseInt(params[1]));
 			char ref = params[3].charAt(0);
 			if ('-' == ref || '.' == ref) {
-//				logger.warn("skipping position with ref = -");
 				continue;
 			}
 			String coverage = params[7];
@@ -359,7 +381,9 @@ public class QSigCompare {
 		
 		int[] baseCoverages = SignatureUtil.decipherCoverageString(coverage);
 		int total = baseCoverages[4];
-		if (total < 10) return null;
+		if (total < 10) {
+			return null;
+		}
 		
 		final double aFrac = (double) baseCoverages[0] / total;
 		final double cFrac = (double) baseCoverages[1] / total;
@@ -375,9 +399,15 @@ public class QSigCompare {
 	}
 	
 	public static double getDiscretisedValue(double initialValue) {
-		if (initialValue >= hom_up) return 1.0;
-		if (initialValue <= hom_low) return 0.0;
-		if (initialValue > het_low && initialValue < het_up) return 0.5;
+		if (initialValue >= hom_up) {
+			return 1.0;
+		}
+		if (initialValue <= hom_low) {
+			return 0.0;
+		}
+		if (initialValue > het_low && initialValue < het_up) {
+			return 0.5;
+		}
 		return DOUBLE_NAN;
 	}
 	
@@ -388,10 +418,18 @@ public class QSigCompare {
 		String snpFile = null;
 		for (Iterator<String> iter = header.iterator() ; iter.hasNext() ; ) {
 			String headerLine = iter.next();
-			if (headerLine.contains("patient_id")) patient = headerLine.substring(headerLine.indexOf("=") + 1);  
-			if (headerLine.contains("library")) library = headerLine.substring(headerLine.indexOf("=") + 1);  
-			if (headerLine.contains("input_type")) inputType = headerLine.substring(headerLine.indexOf("=") + 1);
-			if (headerLine.contains("snp_file")) snpFile = headerLine.substring(headerLine.indexOf("=") + 1);
+			if (headerLine.contains("patient_id")) {
+				patient = headerLine.substring(headerLine.indexOf("=") + 1);  
+			}
+			if (headerLine.contains("library")) {
+				library = headerLine.substring(headerLine.indexOf("=") + 1);  
+			}
+			if (headerLine.contains("input_type")) {
+				inputType = headerLine.substring(headerLine.indexOf("=") + 1);
+			}
+			if (headerLine.contains("snp_file")) {
+				snpFile = headerLine.substring(headerLine.indexOf("=") + 1);
+			}
 		}
 		return new String[] {patient, library, inputType, snpFile};
 	}
@@ -403,13 +441,16 @@ public class QSigCompare {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 1;
-			if (null != logger)
+			if (null != logger) {
 				logger.error("Exception caught whilst running QSigCompare:", e);
-			else System.err.println("Exception caught whilst running QSigCompare");
+			} else {
+				System.err.println("Exception caught whilst running QSigCompare");
+			}
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
+		}
 		
 		System.exit(exitStatus);
 	}
@@ -463,8 +504,9 @@ public class QSigCompare {
 			
 			options.getMinCoverage().ifPresent(i -> {minCoverage = i.intValue();});
 			
-			if (options.getCutoff() > 0.0f)
+			if (options.getCutoff() > 0.0f) {
 				cutoff =  options.getCutoff();
+			}
 			
 			logger.tool("Will use minCoverage of: " + minCoverage + ", and a cutoff of: " + cutoff);
 			

--- a/qsignature/src/org/qcmg/sig/QSigCompareDistance.java
+++ b/qsignature/src/org/qcmg/sig/QSigCompareDistance.java
@@ -51,6 +51,7 @@ import org.w3c.dom.Element;
  * 
  * @deprecated
  */
+@Deprecated
 public class QSigCompareDistance {
 	
 	private static QLogger logger;

--- a/qsignature/src/org/qcmg/sig/QSigCompareDistance.java
+++ b/qsignature/src/org/qcmg/sig/QSigCompareDistance.java
@@ -45,6 +45,11 @@ import org.w3c.dom.Element;
 
 /**
  * The Class QSigCompareDistance.
+ * 
+ * This uses the Euclidean distance method to compare positions.
+ * This class has been superseded by the Compare class and so is deprecated. 
+ * 
+ * @deprecated
  */
 public class QSigCompareDistance {
 	
@@ -59,19 +64,21 @@ public class QSigCompareDistance {
 	private int minCoverage = 20;
 	private float cutoff = 0.035f;
 	
-	private final  List<File> vcfFiles = new ArrayList<File>();
-	private final Map<File, String[]> fileStats = new HashMap<File, String[]>();
+	private final  List<File> vcfFiles = new ArrayList<>();
+	private final Map<File, String[]> fileStats = new HashMap<>();
 	
-	private static final List<ChrPosition> snps = new ArrayList<ChrPosition>();
+	private static final List<ChrPosition> snps = new ArrayList<>();
 	
-	private Map<ChrPosition, double[]> currentFileRatios = new HashMap<ChrPosition, double[]>();
-	private final Map<File, Map<ChrPosition, double[]>> fileRatiosCache = new HashMap<File, Map<ChrPosition, double[]>>();
-	private final List<String[]> displayResults = new ArrayList<String[]>();
+	private Map<ChrPosition, double[]> currentFileRatios = new HashMap<>();
+	private final Map<File, Map<ChrPosition, double[]>> fileRatiosCache = new HashMap<>();
+	private final List<String[]> displayResults = new ArrayList<>();
 	
 	private int engage() throws Exception {
 		
 		// populate the random SNP Positions map
-		for (String s : cmdLineInputFiles) loadVcfFiles(s);
+		for (String s : cmdLineInputFiles) {
+			loadVcfFiles(s);
+		}
 		
 		if ( ! vcfFiles.isEmpty() || vcfFiles.size() == 1) {
 			// lets go
@@ -245,42 +252,19 @@ public class QSigCompareDistance {
 			file2Ratios = loadRatiosFromFile(f2);
 			
 			// cache f2 if instructed to do so
-			if (cacheF2) fileRatiosCache.put(f2, file2Ratios);
+			if (cacheF2) {
+				fileRatiosCache.put(f2, file2Ratios);
+			}
 		}
-		
-		// update fileStats
-//		String[] file1Data = fileStats.get(f1);
-//		if (null != file1Data && file1Data.length > 4 && StringUtils.isNullOrEmpty(file1Data[4]))
-//			file1Data[4] = getCoverageAcrossSnps(file1Ratios);
-		
-//		String[] file2Data  = fileStats.get(f2);
-//		if (null != file2Data && file2Data.length > 4 && StringUtils.isNullOrEmpty(file2Data[4]))
-//			file2Data[4] = getCoverageAcrossSnps(file2Ratios);
-		
-		
-//		AtomicIntegerArray noOfPositionsUsed = new AtomicIntegerArray(minCoverage);
 		
 		logger.info("about to compareRatios with sizes: " + file1Ratios.size() + " + " + file2Ratios.size());
 		double[] results = compareRatios(file1Ratios, file2Ratios);
 		final double avg = results[0] / results[1];
-		if (null != logger)
+		if (null != logger) {
 			logger.info("avg: " + avg + ", sum: " + results[0] + ", count: " + (int)results[1]);
-		else {
+		} else {
 			System.out.println("avg: " + avg + ", sum: " + results[0] + ", count: " + (int)results[1]);
 		}
-//		compareRatios(file1Ratios, file2Ratios, minCoverage, noOfPositionsUsed);
-		
-//		float [] totalDiffs = compareRatios(file1Ratios, file2Ratios, minCoverage, noOfPositionsUsed);
-//		
-//		String rating = getRating(f1, f2);
-//		for (int i = 0 , len = totalDiffs.length ; i < len ; i++) {
-//			
-//			float score = noOfPositionsUsed.get(i) == 0 ? Float.NaN : (totalDiffs[i] / noOfPositionsUsed.get(i));
-//			String flag = QSigCompare.getFlag(rating, score, noOfPositionsUsed.get(i), cutoff);
-//			
-//			displayResults.add(new String[] {"" + (vcfFiles.indexOf(f1) + 1) , "" +  (vcfFiles.indexOf(f2) + 1), 
-//					rating , ""+score , ""+noOfPositionsUsed.get(i) , flag, ""+(i+1)}); 
-//		}
 	}
 	
 	/**
@@ -302,7 +286,6 @@ public class QSigCompareDistance {
 	 */
 	public static double[] compareRatios(final Map<ChrPosition, double[]> file1Ratios,
 			final Map<ChrPosition, double[]> file2Ratios) {
-//		boolean debugMode = logger.isLevelEnabled(QLevel.DEBUG);
 		
 		int count = 0;
 		int noOfCalculations = 0;
@@ -318,13 +301,16 @@ public class QSigCompareDistance {
 				double tally = 0.0;
 				for (int i = 0 ; i < 4 ; i ++) {		// ACGT - should always have exactly 4 entries in arrays
 					final double file1Value =  file1Ratio[i];
-					if (Double.isNaN(file1Value)) continue;
+					if (Double.isNaN(file1Value)) {
+						continue;
+					}
 					final double file2Value =  file2Ratio[i];
-					if (Double.isNaN(file2Value)) continue;
+					if (Double.isNaN(file2Value)) {
+						continue;
+					}
 					
 					tally += Math.pow((file1Value - file2Value), 2);
 					noOfCalculations++;
-//					logger.info("tally: " + tally);
 				}
 				finalTally += Math.sqrt(tally);
 				count++;
@@ -346,10 +332,6 @@ public class QSigCompareDistance {
 	public static Comparison compareRatios(final Map<ChrPosition, double[]> file1Ratios, final Map<ChrPosition, double[]> file2Ratios, File file1, File file2) {
 		return compareRatios(file1Ratios, file2Ratios, file1, file2, null);
 	}
-//	public static Comparison compareRatios(final Map<ChrPosition, double[]> file1Ratios,
-//			final Map<ChrPosition, double[]> file2Ratios, File file1, File file2) {
-//		return compareRatios(file1Ratios, file2Ratios, file1, file2, null);
-//	}
 	
 	public static List<Comparison> compareRatios(Map<ChrPosition, double[]> file1Ratios, File f1,
 			ConcurrentMap<File, ConcurrentMap<ChrPosition, double[]>> mapOfRatios, Map<ChrPosition, ChrPosition>  positionsOfInterest) {
@@ -362,17 +344,6 @@ public class QSigCompareDistance {
 		
 		return comps;
 	}
-//	public static List<Comparison> compareRatios(Map<ChrPosition, double[]> file1Ratios, File f1,
-//			ConcurrentMap<File, ConcurrentMap<ChrPosition, double[]>> mapOfRatios, List<ChrPosition> positionsOfInterest) {
-//		
-//		List<Comparison> comps = new ArrayList<>();
-//		
-//		for (Entry<File, ConcurrentMap<ChrPosition, double[]>> entry : mapOfRatios.entrySet()) {
-//			comps.add(compareRatios(entry.getValue(), file1Ratios, entry.getKey(), f1, positionsOfInterest));
-//		}
-//		
-//		return comps;
-//	}
 	
 	/**
 	 * Compares the ratios of the 2 supplied maps, and returns a Comparison object
@@ -406,12 +377,8 @@ public class QSigCompareDistance {
 		boolean checkPositionsList = null != positionsOfInterest && ! positionsOfInterest.isEmpty();
 		
 		
-//		int overlapCount = 0, nonOverlapCount = 0;
 		int count = 0;
-//		int noOfCalculations = 0;
 		double finalTally = 0.0;
-//		long f1TotalCov = 0;
-//		long f2TotalCov = 0;
 		for (Entry<ChrPosition, double[]> file1RatiosEntry : file1Ratios.entrySet()) {
 			
 			// check to see if position is in the list of desired positions, if not continue
@@ -435,19 +402,12 @@ public class QSigCompareDistance {
 					if (Double.isNaN(file2Value)) continue;
 					
 					tally += FastMath.pow((file1Value - file2Value), 2);
-//					noOfCalculations++;
 				}
-//				System.out.println("about to add " + file1Ratio[4] + " to f1 tally at " + file1RatiosEntry.getKey().toString());
-//				System.out.println("about to add " + file2Ratio[4] + " to f2 tally at " + file1RatiosEntry.getKey().toString());
-//				f1TotalCov += file1Ratio[4];
-//				f2TotalCov += file2Ratio[4];
 				finalTally += FastMath.sqrt(tally);
 				count++;
 			}
 		}
 		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), finalTally, count);
-//		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), finalTally, count, noOfCalculations, f1TotalCov, f2TotalCov);
-//		System.out.println("overlapCount: " + overlapCount + ", nonOverlapCount: " + nonOverlapCount);
 		return comp;
 	}
 	public static Comparison compareRatiosFloat(final Map<ChrPosition, float[]> file1Ratios,
@@ -471,12 +431,8 @@ public class QSigCompareDistance {
 		boolean checkPositionsList = null != positionsOfInterest && ! positionsOfInterest.isEmpty();
 		
 		
-//		int overlapCount = 0, nonOverlapCount = 0;
 		int count = 0;
-//		int noOfCalculations = 0;
 		double finalTally = 0.0;
-//		long f1TotalCov = 0;
-//		long f2TotalCov = 0;
 		for (Entry<ChrPosition, float[]> file1RatiosEntry : file1Ratios.entrySet()) {
 			
 			// check to see if position is in the list of desired positions, if not continue
@@ -495,95 +451,25 @@ public class QSigCompareDistance {
 				float tally = 0.0f;
 				for (int i = 0 ; i < 4 ; i ++) {		// ACGT - should always have exactly 4 entries in arrays
 					final float file1Value =  file1Ratio[i];
-					if (Double.isNaN(file1Value)) continue;
+					if (Double.isNaN(file1Value)) {
+						continue;
+					}
 					final float file2Value =  file2Ratio[i];
-					if (Double.isNaN(file2Value)) continue;
+					if (Double.isNaN(file2Value)) {
+						continue;
+					}
 					
 					tally += FastMath.pow((file1Value - file2Value), 2);
-//					noOfCalculations++;
 				}
-//				System.out.println("about to add " + file1Ratio[4] + " to f1 tally at " + file1RatiosEntry.getKey().toString());
-//				System.out.println("about to add " + file2Ratio[4] + " to f2 tally at " + file1RatiosEntry.getKey().toString());
-//				f1TotalCov += file1Ratio[4];
-//				f2TotalCov += file2Ratio[4];
 				finalTally += FastMath.sqrt(tally);
 				count++;
 			}
 		}
 		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), finalTally, count);
-//		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), finalTally, count, noOfCalculations, f1TotalCov, f2TotalCov);
-//		System.out.println("overlapCount: " + overlapCount + ", nonOverlapCount: " + nonOverlapCount);
 		return comp;
 	}
-//	public static Comparison compareRatios(final Map<ChrPosition, double[]> file1Ratios,
-//			final Map<ChrPosition, double[]> file2Ratios, File file1, File file2, List<ChrPosition> positionsOfInterest) {
-//		
-//		if (null == file1Ratios || null == file2Ratios)
-//			throw new IllegalArgumentException("null maps passed to compareRatios");
-//		
-//		if (null == file1 || null == file2)
-//			throw new IllegalArgumentException("null files passed to compareRatios");
-//		
-//		if (file1Ratios.isEmpty() || file2Ratios.isEmpty())
-//			return  new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), 0, 0, 0);
-//		
-//		// if the files are the same, return a comparison object without doing the comparison
-//		if (file1.equals(file2)) {
-//			return  new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), 0, file1Ratios.size(), 0);
-//		}
-//		
-//		boolean checkPositionsList = null != positionsOfInterest && ! positionsOfInterest.isEmpty();
-//		
-////		int overlapCount = 0, nonOverlapCount = 0;
-//		int count = 0;
-//		int noOfCalculations = 0;
-//		double finalTally = 0.0;
-//		for (Entry<ChrPosition, double[]> file1RatiosEntry : file1Ratios.entrySet()) {
-//			
-//			// check to see if position is in the list of desired positions
-//			if (checkPositionsList) {
-//				boolean overlap = false;
-//				for (ChrPosition cp : positionsOfInterest) {
-//					if (ChrPositionUtils.doChrPositionsOverlap(file1RatiosEntry.getKey(), cp)) {
-//						// great
-//						overlap = true;
-//						break;
-//					}
-//				}
-//				if ( ! overlap)  {
-////					nonOverlapCount++;
-//					continue;
-//				} else {
-////					overlapCount++;
-//				}
-//			}
-//			
-//			// if coverage is zero, skip
-//			final double[] file1Ratio = file1RatiosEntry.getValue();
-//			final double[] file2Ratio = file2Ratios.get(file1RatiosEntry.getKey());
-//			if (null != file2Ratio) {
-//				
-//				double tally = 0.0;
-//				for (int i = 0 ; i < 4 ; i ++) {		// ACGT - should always have exactly 4 entries in arrays
-//					final double file1Value =  file1Ratio[i];
-//					if (Double.isNaN(file1Value)) continue;
-//					final double file2Value =  file2Ratio[i];
-//					if (Double.isNaN(file2Value)) continue;
-//					
-//					tally += FastMath.pow((file1Value - file2Value), 2);
-//					noOfCalculations++;
-//				}
-//				finalTally += FastMath.sqrt(tally);
-//				count++;
-//			}
-//		}
-//		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), finalTally, count, noOfCalculations);
-////		System.out.println("overlapCount: " + overlapCount + ", nonOverlapCount: " + nonOverlapCount);
-//		return comp;
-//	}
 	
 	private Map<ChrPosition, double[]> loadRatiosFromFile(File file) throws Exception {
-		//		private Map<ChrPosition, int[]> loadRatiosFromFile(TabbedFileReader reader) {
 		TabbedFileReader reader = new TabbedFileReader(file);
 		Map<ChrPosition, double[]> ratios = null;
 		int zeroCov = 0, invalidRefCount = 0;
@@ -592,14 +478,15 @@ public class QSigCompareDistance {
 			
 			boolean populateSnps = snps.isEmpty(); 
 			
-			ratios = new HashMap<ChrPosition, double[]>();
+			ratios = new HashMap<>();
 			
 			for (TabbedRecord vcfRecord : reader) {
 				String[] params = TabTokenizer.tokenize(vcfRecord.getData());
 				ChrPosition chrPos = ChrPointPosition.valueOf(params[0], Integer.parseInt(params[1]));
 				
-				if (populateSnps)
+				if (populateSnps) {
 					snps.add(chrPos);
+				}
 				
 				String coverage = params[7];
 				
@@ -612,15 +499,17 @@ public class QSigCompareDistance {
 				
 				char ref = params[3].charAt(0);
 				if ( ! BaseUtils.isACGTN(ref)) {
-					if ('-' != ref && '.' != ref)
+					if ('-' != ref && '.' != ref) {
 						logger.info("invalid reference base for record: " + Arrays.deepToString(params));
+					}
 					invalidRefCount++;
 					continue;
 				}
 				
 				double[] array = QSigCompare.getDiscretisedValuesFromCoverageString(coverage);
-				if (null != array)
+				if (null != array) {
 					ratios.put(chrPos, array);
+				}
 			}
 		} finally {
 			reader.close();
@@ -636,16 +525,17 @@ public class QSigCompareDistance {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 2;
-			if (null != logger)
+			if (null != logger) {
 				logger.error("Exception caught whilst running QSigCompareDistance:", e);
-			else {
+			} else {
 				System.err.println("Exception caught whilst running QSigCompareDistance: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
+		}
 		
 		System.exit(exitStatus);
 	}
@@ -691,14 +581,16 @@ public class QSigCompareDistance {
 			if (null != options.getOutputFileNames()) {
 				cmdLineOutputFiles = options.getOutputFileNames();
 				for (String outputFile : cmdLineOutputFiles) {
-					if ( ! FileUtils.canFileBeWrittenTo(outputFile))
+					if ( ! FileUtils.canFileBeWrittenTo(outputFile)) {
 						throw new QSignatureException("OUTPUT_FILE_WRITE_ERROR", outputFile);
+					}
 				}
 			}
 			
 			options.getMinCoverage().ifPresent(i -> {minCoverage = i.intValue();});
-			if (options.getCutoff() > 0.0f)
+			if (options.getCutoff() > 0.0f) {
 				cutoff =  options.getCutoff();
+			}
 			
 			logger.logInitialExecutionStats("QSigCompareDistance", QSigCompareDistance.class.getPackage().getImplementationVersion(), args);
 			logger.tool("Will use minCoverage of: " + minCoverage + ", and a cutoff of: " + cutoff);

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelated.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelated.java
@@ -46,6 +46,8 @@ import org.w3c.dom.Element;
  * If any comparison scores are less than the cutoff, they are added to a list, which is then emailed to interested parties informing them of the potential problem files
  *  
  * @author o.holmes
+ * 
+ * @deprecated Superseded by Compare
  *
  */
 public class SignatureCompareRelated {
@@ -57,7 +59,6 @@ public class SignatureCompareRelated {
 	
 	private float cutoff = 0.2f;
 	
-//	private String[] cmdLineInputFiles;
 	private String[] cmdLineOutputFiles;
 	private String outputXml;
 	private String[] paths;
@@ -71,11 +72,9 @@ public class SignatureCompareRelated {
 	private final Map<File, int[]> fileIdsAndCounts = new HashMap<>();
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
-//	private String email;
-//	private String emailSubject = "Qsignature Comparison: all bams vs donor snp chip";
 	private String logFile;
 	
-	List<String> suspiciousResults = new ArrayList<String>();
+	List<String> suspiciousResults = new ArrayList<>();
 	
 	private int engage() throws Exception {
 		
@@ -118,10 +117,10 @@ public class SignatureCompareRelated {
 		files = SignatureUtil.removeExcludedFilesFromList(files, excludes);
 		logger.info("Total number of files to be compared (minus excluded files): " + files.size());
 		
-		final Set<File> uniqueFiles = new HashSet<File>(files);
+		final Set<File> uniqueFiles = new HashSet<>(files);
 		logger.info("No of unique files: " + uniqueFiles.size());
 		
-		final List<File> orderedUniqueFiles = new ArrayList<File>();
+		final List<File> orderedUniqueFiles = new ArrayList<>();
 		for (File f : uniqueFiles) {
 			
 			if (null != additionalSearchStrings && additionalSearchStrings.length > 0) {
@@ -194,7 +193,6 @@ public class SignatureCompareRelated {
 				donorSnpChipData = SignatureUtil.getDonorSnpChipData(currentDonor, orderedSnpChipFiles);
 				if (donorSnpChipData.isEmpty()) {
 					logger.warn("No snp chip qsignature files for donor: " + currentDonor);
-//					suspiciousResults.add(currentDonor + "\t" + f.getName() + "\tNo snp chip qsignature files for donor: " + currentDonor);
 				} else {
 					donorSB.append("comparing against: \n");
 					for (File file : donorSnpChipData.keySet()) {
@@ -216,7 +214,9 @@ public class SignatureCompareRelated {
 					 // populate map with coverage details
 					 fileIdsAndCounts.get(f)[1] = ratios.size();
 					 
-					if (ratios.size() < 1000) logger.warn("low coverage (" + ratios.size() + ") for file " + f.getAbsolutePath());
+					if (ratios.size() < 1000) {
+						logger.warn("low coverage (" + ratios.size() + ") for file " + f.getAbsolutePath());
+					}
 				}
 				
 				List<Comparison> comparisons = new ArrayList<>();
@@ -248,12 +248,15 @@ public class SignatureCompareRelated {
 			logger.info("No suspicious results found");
 		} else {
 			logger.info("SUMMARY:");
-			for (String s : suspiciousResults) logger.info(s);
+			for (String s : suspiciousResults) {
+				logger.info(s);
+			}
 			//email();
 		}
 		
-		if (outputXml != null)
+		if (outputXml != null) {
 			writeXmlOutput();
+		}
 		
 		return exitStatus;
 	}
@@ -278,7 +281,6 @@ public class SignatureCompareRelated {
 		for (File f  : keys) {
 			int[] value = fileIdsAndCounts.get(f);
 			
-//			logger.info(value[0] + " : " +  f.getAbsolutePath() + " : " + value[1]);
 			Element fileE = doc.createElement("file");
 			fileE.setAttribute("id", value[0] + "");
 			fileE.setAttribute("name", f.getAbsolutePath());
@@ -286,7 +288,6 @@ public class SignatureCompareRelated {
 			filesE.appendChild(fileE);
 		}
 		// and now the comparisons
-//		logger.info("COMPARISONS: ");
 		
 		// list files
 		Element compsE = doc.createElement("comparisons");
@@ -294,13 +295,11 @@ public class SignatureCompareRelated {
 		for (Comparison comp : allComparisons) {
 			int id1 = fileIdsAndCounts.get(new File(comp.getMain()))[0];
 			int id2 = fileIdsAndCounts.get(new File(comp.getTest()))[0];
-//			logger.info(id1 + " vs " + id2 + " - score: " + comp.getScore() + " overlaping coverage: " + comp.getOverlapCoverage() + " no of calcs: " + comp.getNumberOfCalculations());
 			
 			String id = "id_" + id1 + "_vs_" + id2;
 			Element compE = doc.createElement(id);
 			compE.setAttribute("score", comp.getScore() + "");
 			compE.setAttribute("overlap", comp.getOverlapCoverage() + "");
-//			compE.setAttribute("calcs", comp.getNumberOfCalculations() + "");
 			compsE.appendChild(compE);
 		}
 		
@@ -332,17 +331,17 @@ public class SignatureCompareRelated {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 2;
-			if (null != logger)
+			if (null != logger) {
 				logger.error("Exception caught whilst running SignatureCompareRelated:", e);
-			else {
+			} else {
 				System.err.println("Exception caught whilst running SignatureCompareRelated: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
-		
+		}
 		System.exit(exitStatus);
 	}
 	
@@ -377,23 +376,25 @@ public class SignatureCompareRelated {
 			if (null != paths && paths.length > 0) {
 				this.paths = paths;
 			}
-			if (null == paths) throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			if (null == paths) {
+				throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			}
 			
-			if (options.hasCutoff())
+			if (options.hasCutoff()) {
 				cutoff = options.getCutoff();
-			
-			if (options.hasSearchSuffixOption())
+			}
+			if (options.hasSearchSuffixOption()) {
 				searchSuffix = options.getSearchSuffix();
-			
-			if (options.hasSnpChipSearchSuffixOption())
+			}
+			if (options.hasSnpChipSearchSuffixOption()) {
 				snpChipSearchSuffix = options.getSnpChipSearchSuffix();
-			
-			if (options.hasAdditionalSearchStringOption())
+			}
+			if (options.hasAdditionalSearchStringOption()) {
 				additionalSearchStrings = options.getAdditionalSearchString();
-			
-			if (options.hasExcludeVcfsFileOption())
+			}
+			if (options.hasExcludeVcfsFileOption()) {
 				excludeVcfsFile = options.getExcludeVcfsFile();
-			
+			}
 			logger.logInitialExecutionStats("SignatureCompareRelated", SignatureCompareRelated.class.getPackage().getImplementationVersion(), args);
 			
 			return engage();

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelated.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelated.java
@@ -50,6 +50,7 @@ import org.w3c.dom.Element;
  * @deprecated Superseded by Compare
  *
  */
+@Deprecated
 public class SignatureCompareRelated {
 	
 	private static QLogger logger;
@@ -251,7 +252,6 @@ public class SignatureCompareRelated {
 			for (String s : suspiciousResults) {
 				logger.info(s);
 			}
-			//email();
 		}
 		
 		if (outputXml != null) {

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimple.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimple.java
@@ -6,8 +6,6 @@
  */
 package org.qcmg.sig;
 
-import gnu.trove.map.hash.THashMap;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,7 +18,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
@@ -30,6 +27,8 @@ import org.qcmg.common.util.LoadReferencedClasses;
 import org.qcmg.sig.model.Comparison;
 import org.qcmg.sig.util.SignatureUtil;
 
+import gnu.trove.map.hash.THashMap;
+
 /**
  * This class gets a list of all .qsig.vcf files from the supplied path.
  * It then performs a comparison between them all, regardless of whether they are bam or snp chip files
@@ -38,6 +37,7 @@ import org.qcmg.sig.util.SignatureUtil;
  *  
  * @author o.holmes
  *
+ *@deprecated Superseded by Compare
  */
 public class SignatureCompareRelatedSimple {
 	
@@ -54,7 +54,6 @@ public class SignatureCompareRelatedSimple {
 	private String [] paths;
 	private String [] additionalSearchStrings;
 	private String donor;
-//	private static final String QSIG_SUFFIX = ".qsig.vcf";
 	
 	private String excludeVcfsFile;
 	private List<String> excludes;
@@ -64,7 +63,6 @@ public class SignatureCompareRelatedSimple {
 	private final List<Comparison> allComparisons = new ArrayList<>();
 	
 	private final Map<File, Map<ChrPosition, float[]>> cache = new THashMap<>(cacheSize * 2);
-//	private final Map<File, TIntShortHashMap> cache = new THashMap<>(cacheSize * 2);
 	
 	List<String> suspiciousResults = new ArrayList<>();
 	
@@ -98,8 +96,6 @@ public class SignatureCompareRelatedSimple {
 		}
 		
 		
-		
-		
 		/*
 		 * Match files on additionalSearchStrings
 		 */
@@ -130,27 +126,23 @@ public class SignatureCompareRelatedSimple {
 		
 		int size = files.size();
 		
-		for (int i = 0 ; i < size -1 ; i++) {
+		for (int i = 0 ; i < size - 1 ; i++) {
 			
 			File f1 = files.get(i);
 			Map<ChrPosition, float[]> ratios1 = getSignatureData(f1);
-//			TIntShortHashMap ratios1 = getSignatureData(f1);
 			
 			for (int j = i + 1 ; j < size ; j++) {
 				File f2 = files.get(j);
 				Map<ChrPosition, float[]> ratios2 = getSignatureData(f2);
-//				TIntShortHashMap ratios2 = getSignatureData(f2);
 				
 				Comparison comp = QSigCompareDistance.compareRatiosFloat(ratios1, ratios2, f1, f2, null);
 				logger.info(comp.toString());
-//				Comparison comp = ComparisonUtil.(ratios1, ratios2, f1, f2);
 				donorSB.append(comp.toString()).append("\n");
 				allComparisons.add(comp);
 			}
 			
 			// can now remove f1 from the cache as it is no longer required
 			Map<ChrPosition, float[]> m = cache.remove(f1);
-//			TIntShortHashMap m = cache.remove(f1);
 			m.clear();
 			m = null;
 		}
@@ -173,39 +165,12 @@ public class SignatureCompareRelatedSimple {
 			for (String s : suspiciousResults) logger.info(s);
 		}
 		
-		if (outputXml != null)
+		if (outputXml != null) {
 			SignatureUtil.writeXmlOutput(fileIdsAndCounts, allComparisons, outputXml);
-//		writeXmlOutput();
-		
+		}
 		return exitStatus;
 	}
 	
-//	TIntShortHashMap getSignatureData(File f) throws Exception {
-//		// check map to see if this data has already been loaded
-//		// if not - load
-//		TIntShortHashMap result = cache.get(f);
-//		if (result == null) {
-//			result = SignatureUtil.loadSignatureRatiosFloat(f, minimumCoverage);
-//			
-//			if (result.size() < 1000) {
-//				logger.warn("low coverage (" + result.size() + ") for file " + f.getAbsolutePath());
-//			}
-//			
-//			if (cache.size() < cacheSize) {
-//				cache.put(f, result);
-//			}
-//			fileIdsAndCounts.get(f)[1] = result.size();
-//			/*
-//			 * average coverage
-//			 */
-//			//TODO put this back in
-////			IntSummaryStatistics iss = result.values().stream()
-////				.mapToInt(array -> (int) array[4])
-////				.summaryStatistics();
-////			fileIdsAndCounts.get(f)[2] = (int) iss.getAverage();
-//		}
-//		return result;
-//	}
 	Map<ChrPosition, float[]> getSignatureData(File f) throws Exception {
 		// check map to see if this data has already been loaded
 		// if not - load
@@ -249,17 +214,17 @@ public class SignatureCompareRelatedSimple {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 2;
-			if (null != logger)
+			if (null != logger) {
 				logger.error("Exception caught whilst running SignatureCompareRelatedSimple:", e);
-			else {
+			} else {
 				System.err.println("Exception caught whilst running SignatureCompareRelatedSimple: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
-		
+		}
 		System.exit(exitStatus);
 	}
 	
@@ -287,27 +252,29 @@ public class SignatureCompareRelatedSimple {
 			
 			
 			String [] cmdLineOutputFiles = options.getOutputFileNames();
-			if (null != cmdLineOutputFiles && cmdLineOutputFiles.length > 0)
+			if (null != cmdLineOutputFiles && cmdLineOutputFiles.length > 0) {
 				outputXml = cmdLineOutputFiles[0];
-			
+			}
 			String[] paths = options.getDirNames(); 
 			if (null != paths && paths.length > 0) {
 				this.paths = paths;
 			}
-			if (null == paths) throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			if (null == paths) {
+				throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			}
 			
-			if (options.hasCutoff())
+			if (options.hasCutoff()) {
 				cutoff = options.getCutoff();
-			
+			}
 			options.getMinCoverage().ifPresent(i -> {minimumCoverage = i.intValue();});
 			logger.tool("Setting minumim coverage to: " + minimumCoverage);
 			
 			additionalSearchStrings = options.getAdditionalSearchString();
 			logger.tool("Setting additionalSearchStrings to: " + Arrays.deepToString(additionalSearchStrings));
 			
-			if (options.hasExcludeVcfsFileOption())
+			if (options.hasExcludeVcfsFileOption()) {
 				excludeVcfsFile = options.getExcludeVcfsFile();
-			
+			}
 			logger.logInitialExecutionStats("SignatureCompareRelatedSimple", SignatureCompareRelatedSimple.class.getPackage().getImplementationVersion(), args);
 			
 			return engage();

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimple.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimple.java
@@ -39,6 +39,7 @@ import gnu.trove.map.hash.THashMap;
  *
  *@deprecated Superseded by Compare
  */
+@Deprecated
 public class SignatureCompareRelatedSimple {
 	
 	private static QLogger logger;

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotype.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotype.java
@@ -6,10 +6,6 @@
  */
 package org.qcmg.sig;
 
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntByteHashMap;
-import gnu.trove.map.hash.TIntShortHashMap;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,7 +16,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.util.DonorUtils;
@@ -29,6 +24,9 @@ import org.qcmg.common.util.LoadReferencedClasses;
 import org.qcmg.sig.model.Comparison;
 import org.qcmg.sig.util.ComparisonUtil;
 import org.qcmg.sig.util.SignatureUtil;
+
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 
 /**
  * This class gets a list of all .qsig.vcf files from the supplied path.

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
@@ -6,9 +6,6 @@
  */
 package org.qcmg.sig;
 
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntByteHashMap;
-
 import java.io.File;
 import java.util.AbstractQueue;
 import java.util.ArrayList;
@@ -37,6 +34,9 @@ import org.qcmg.sig.model.Comparison;
 import org.qcmg.sig.util.ComparisonUtil;
 import org.qcmg.sig.util.SignatureUtil;
 
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
+
 /**
  * This class gets a list of all .qsig.vcf files from the supplied path.
  * It then performs a comparison between them all, regardless of whether they are bam or snp chip files
@@ -44,6 +44,8 @@ import org.qcmg.sig.util.SignatureUtil;
  * If any comparison scores are less than the cutoff, they are added to a list, which is then emailed to interested parties informing them of the potential problem files
  *  
  * @author o.holmes
+ * 
+ * @Deprecated Superseded by Compare
  *
  */
 public class SignatureCompareRelatedSimpleGenotypeMT {
@@ -100,12 +102,10 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 		logger.info("Total number of files to be compared (minus excluded files): " + files.size());
 		
 		
-		
 		if (files.isEmpty()) {
 			logger.warn("No files left after removing exlcuded files");
 			return 0;
 		}
-		
 		
 		/*
 		 * Match files on additionalSearchStrings
@@ -151,9 +151,9 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 		
 		logger.info("number of comparisons created: " + allComparisons.size());
 		logger.info("writing xml output");
-		if (outputXml != null)
+		if (outputXml != null) {
 			SignatureUtil.writeXmlOutput(fileIdsAndCounts, allComparisons, outputXml);
-//		writeXmlOutput();
+		}
 		
 		return exitStatus;
 	}
@@ -171,7 +171,9 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 					List<Comparison> myComps = new ArrayList<>();
 					while (true) {
 						Integer in = queue.poll();
-						if (null == in) break;
+						if (null == in) {
+							break;
+						}
 				
 						logger.info("performing comparison for : " + in.intValue());
 						
@@ -209,7 +211,9 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 			service.execute(() -> {
 					while (true) {
 						File f = queue.poll();
-						if (null == f) break;
+						if (null == f) {
+							break;
+						}
 				
 						logger.info("loading data from: " + f.getAbsolutePath());
 						
@@ -265,9 +269,9 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 		} catch (Exception e) {
 			exitStatus = 2;
 			if (null != logger)
-				logger.error("Exception caught whilst running SignatureCompareRelatedSimple:", e);
+				logger.error("Exception caught whilst running SignatureCompareRelatedSimpleGenotypeMT:", e);
 			else {
-				System.err.println("Exception caught whilst running SignatureCompareRelatedSimple: " + e.getMessage());
+				System.err.println("Exception caught whilst running SignatureCompareRelatedSimpleGenotypeMT: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
 		}
@@ -303,14 +307,16 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 			
 			
 			String [] cmdLineOutputFiles = options.getOutputFileNames();
-			if (null != cmdLineOutputFiles && cmdLineOutputFiles.length > 0)
+			if (null != cmdLineOutputFiles && cmdLineOutputFiles.length > 0) {
 				outputXml = cmdLineOutputFiles[0];
-			
+			}
 			String[] paths = options.getDirNames(); 
 			if (null != paths && paths.length > 0) {
 				this.paths = paths;
 			}
-			if (null == paths) throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			if (null == paths) {
+				throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			}
 			
 			options.getMinCoverage().ifPresent(i -> {minimumCoverage = i.intValue();});
 			options.getNoOfThreads().ifPresent(i -> {nThreads = Math.max(i.intValue(), nThreads);});
@@ -333,9 +339,9 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 			additionalSearchStrings = options.getAdditionalSearchString();
 			logger.tool("Setting additionalSearchStrings to: " + Arrays.deepToString(additionalSearchStrings));
 			
-			if (options.hasExcludeVcfsFileOption())
+			if (options.hasExcludeVcfsFileOption()) {
 				excludeVcfsFile = options.getExcludeVcfsFile();
-			
+			}
 			logger.logInitialExecutionStats("SignatureCompareRelatedSimpleGenotypeMT", SignatureCompareRelatedSimpleGenotypeMT.class.getPackage().getImplementationVersion(), args);
 			
 			return engage();

--- a/qsignature/src/org/qcmg/sig/SignatureFindRelated.java
+++ b/qsignature/src/org/qcmg/sig/SignatureFindRelated.java
@@ -45,6 +45,7 @@ import org.qcmg.sig.util.SignatureUtil;
  * @deprecated Superseded by Compare
  *
  */
+@Deprecated
 public class SignatureFindRelated {
 	
 	private static QLogger logger;

--- a/qsignature/src/org/qcmg/sig/SignatureFindRelated.java
+++ b/qsignature/src/org/qcmg/sig/SignatureFindRelated.java
@@ -41,6 +41,8 @@ import org.qcmg.sig.util.SignatureUtil;
  * 
  * 
  * @author o.holmes
+ * 
+ * @deprecated Superseded by Compare
  *
  */
 public class SignatureFindRelated {
@@ -56,7 +58,6 @@ public class SignatureFindRelated {
 	
 	private String[] cmdLineInputFiles;
 	private String path;
-	private String searchSuffix = ".qsig.vcf";
 	private String snpChipSearchSuffix = ".txt.qsig.vcf";
 	private String [] additionalSearchStrings;
 	
@@ -65,7 +66,6 @@ public class SignatureFindRelated {
 	
 	private Map<ChrPosition, ChrPosition>  positionsOfInterest;
 	
-	private String email;
 	private String logFile;
 	
 	private final AtomicInteger counter = new AtomicInteger();
@@ -108,19 +108,6 @@ public class SignatureFindRelated {
 		
 		for (File f : orderedSnpChipFiles) {
 			inputQueue.add(f);
-//			logger.debug("Will compare against: " + f.getAbsolutePath());
-//			
-//			Map<ChrPosition, double[]> ratios = SignatureUtil.loadSignatureRatios(f);
-//			if (ratios.size() < 1000) logger.warn("low coverage (" + ratios.size() + ") for file " + f.getAbsolutePath());
-//			
-//			Comparison comp = QSigCompareDistance.compareRatios(lostPatientRatio, ratios, patientQsigVcfFile, f, positionsOfInterest);
-//			comparisons.add(comp);
-//			
-//			logger.info(comp.toString());
-//		
-//			if (++noOfProcessedFiles % 100 == 0) {
-//				logger.info("hit " + noOfProcessedFiles + " files");
-//			}
 		}
 		
 		ExecutorService service = Executors.newFixedThreadPool(nThreads);		
@@ -131,7 +118,9 @@ public class SignatureFindRelated {
 			public void run() {
 				while (true) {
 					File f = inputQueue.poll();
-					if (null == f) break;
+					if (null == f) {
+						break;
+					}
 					
 					if (counter.incrementAndGet() % 100 == 0) {
 						logger.info("hit " + counter.get() + " files");
@@ -153,7 +142,9 @@ public class SignatureFindRelated {
 							e.printStackTrace();
 							break;
 						}
-					if (ratios.size() < 1000) logger.warn("low coverage (" + ratios.size() + ") for file " + f.getAbsolutePath());
+					if (ratios.size() < 1000) {
+						logger.warn("low coverage (" + ratios.size() + ") for file " + f.getAbsolutePath());
+					}
 					
 					Comparison comp = QSigCompareDistance.compareRatios(lostPatientRatio, ratios, patientQsigVcfFile, f, positionsOfInterest);
 					outputQueue.add(comp);
@@ -167,12 +158,6 @@ public class SignatureFindRelated {
 			logger.info("Timed out getting data from threads");
 			return -1;
 		}
-		
-		
-//		List<String> sortedList = new ArrayList<String>();
-//		for (Comparison comp : comparisons) {
-////			sortedList.add(result + " : " + comp.getTest().getAbsolutePath());
-//		}
 		
 		// interrogate results
 		List<Comparison> comparisons = new ArrayList<>(outputQueue);
@@ -236,12 +221,6 @@ public class SignatureFindRelated {
 			emailContent.append("No potential matches were found!");
 		}
 		
-		if (emailContent.length() > 0) {
-			// send email
-//			SignatureUtil.sendEmail("Qsignature Comparison: " + cmdLineInputFiles[0] + " vs the world", emailContent.toString(), email, logger);
-//			email(emailContent.toString());
-		}
-		
 		double totalSumOfSquares = 0.0;
 		for (Comparison comp : comparisons) {
 			double result = comp.getScore();
@@ -254,7 +233,9 @@ public class SignatureFindRelated {
 		for (Comparison comp : comparisons) {
 			double result = comp.getScore();
 			
-			if (result > cutoff) subSumOfSquares += FastMath.pow(result - mean, 2.0);
+			if (result > cutoff) {
+				subSumOfSquares += FastMath.pow(result - mean, 2.0);
+			}
 		}
 		logger.info("subSumOfSquares : " + subSumOfSquares);
 		double subSumOfSquaresTimes2 = (subSumOfSquares * 2.5);
@@ -272,17 +253,17 @@ public class SignatureFindRelated {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 2;
-			if (null != logger)
+			if (null != logger) {
 				logger.error("Exception caught whilst running SignatureFindRelated:", e);
-			else {
+			} else {
 				System.err.println("Exception caught whilst running SignatureFindRelated: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
-		
+		}
 		System.exit(exitStatus);
 	}
 	
@@ -328,26 +309,22 @@ public class SignatureFindRelated {
 			if (null != paths && paths.length > 0) {
 				path = paths[0];
 			}
-			if (null == path) throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			if (null == path) {
+				throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			}
 			
-			if (options.hasCutoff())
+			if (options.hasCutoff()) {
 				cutoff = options.getCutoff();
-			
-			if (options.hasSearchSuffixOption())
-				searchSuffix = options.getSearchSuffix();
-			
-			if (options.hasSnpChipSearchSuffixOption())
+			}
+			if (options.hasSnpChipSearchSuffixOption()) {
 				snpChipSearchSuffix = options.getSnpChipSearchSuffix();
-			
-			if (options.hasAdditionalSearchStringOption())
+			}
+			if (options.hasAdditionalSearchStringOption()) {
 				additionalSearchStrings = options.getAdditionalSearchString();
-			
-			if (options.hasEmailOption())
-				email = options.getEmail();
-			
-			if (options.hasExcludeVcfsFileOption())
+			}
+			if (options.hasExcludeVcfsFileOption()) {
 				excludeVcfsFile = options.getExcludeVcfsFile();
-			
+			}
 			options.getNoOfThreads().ifPresent(i -> {nThreads = Math.max(i.intValue(), nThreads);});
 			
 			String [] positions = options.getPositions();

--- a/qsignature/src/org/qcmg/sig/SignatureFindRelatedMulti.java
+++ b/qsignature/src/org/qcmg/sig/SignatureFindRelatedMulti.java
@@ -48,8 +48,11 @@ import org.qcmg.sig.util.SignatureUtil;
  * 
  * 
  * @author o.holmes
+ * 
+ * @deprecated Superseded by Compare
  *
  */
+@Deprecated
 public class SignatureFindRelatedMulti {
 	
 	private static QLogger logger;

--- a/qsignature/src/org/qcmg/sig/SignatureFindRelatedMulti.java
+++ b/qsignature/src/org/qcmg/sig/SignatureFindRelatedMulti.java
@@ -55,7 +55,6 @@ public class SignatureFindRelatedMulti {
 	private static QLogger logger;
 	private int exitStatus;
 	
-//	private ConcurrentMap<ChrPosition, double[]> lostPatientRatio = new ConcurrentHashMap<>();
 	private final ConcurrentMap<File, ConcurrentMap<ChrPosition, double[]>> lostPatientRatios = new ConcurrentHashMap<>();
 	
 	private List<File> orderedSnpChipFiles;
@@ -73,7 +72,6 @@ public class SignatureFindRelatedMulti {
 	
 	private Map<ChrPosition, ChrPosition>  positionsOfInterest;
 	
-//	private String email;
 	private String logFile;
 	
 	private final AtomicInteger counter = new AtomicInteger();
@@ -118,7 +116,6 @@ public class SignatureFindRelatedMulti {
 			logger.info( (ratios.size() < 1000 ? "low" : "") +  "coverage (" + ratios.size() + ") for file " + s);
 			
 			lostPatientRatios.put(f, ratios);
-			
 		}
 		
 		for (File f : orderedSnpChipFiles) {
@@ -294,7 +291,9 @@ public class SignatureFindRelatedMulti {
 				for (Comparison comp : fileSpecificComparisons) {
 					double result = comp.getScore();
 					
-					if (result > cutoff) subSumOfSquares += FastMath.pow(result - mean, 2.0);
+					if (result > cutoff) {
+						subSumOfSquares += FastMath.pow(result - mean, 2.0);
+					}
 				}
 				writer.write("subSumOfSquares : " + subSumOfSquares);
 				writer.newLine();
@@ -315,9 +314,9 @@ public class SignatureFindRelatedMulti {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 2;
-			if (null != logger)
+			if (null != logger) {
 				logger.error("Exception caught whilst running SignatureFindRelated:", e);
-			else {
+			} else {
 				System.err.println("Exception caught whilst running SignatureFindRelated: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
@@ -388,7 +387,6 @@ public class SignatureFindRelatedMulti {
 			if (options.hasExcludeVcfsFileOption())
 				excludeVcfsFile = options.getExcludeVcfsFile();
 			
-//			if (options.getNoOfThreads() > 0) nThreads = options.getNoOfThreads(); 
 			options.getNoOfThreads().ifPresent(i -> {nThreads = Math.max(i.intValue(), nThreads);});
 			
 			String [] positions = options.getPositions();

--- a/qsignature/src/org/qcmg/sig/SignatureGenerator.java
+++ b/qsignature/src/org/qcmg/sig/SignatureGenerator.java
@@ -77,6 +77,7 @@ import htsjdk.samtools.SamReader;
  *
  *@deprecated Superseded by SignatureGeneratorBespoke
  */
+@Deprecated
 public class SignatureGenerator {
 	
 	static QLogger logger;

--- a/qsignature/src/org/qcmg/sig/SignatureWTFExomes.java
+++ b/qsignature/src/org/qcmg/sig/SignatureWTFExomes.java
@@ -49,6 +49,7 @@ import gnu.trove.set.hash.TIntHashSet;
  *
  *@deprecated
  */
+@Deprecated
 public class SignatureWTFExomes {
 	
 	private static QLogger logger;

--- a/qsignature/src/org/qcmg/sig/SignatureWTFExomes.java
+++ b/qsignature/src/org/qcmg/sig/SignatureWTFExomes.java
@@ -3,12 +3,8 @@
  */
 package org.qcmg.sig;
 
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntByteHashMap;
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
-
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,14 +36,18 @@ import org.qcmg.sig.util.SignatureUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
 /**
- * This class gets a list of all .qsig.vcf files from the supplied path.
- * It then performs a comparison between them all, regardless of whether they are bam or snp chip files
- * An xml output file is produced
- * If any comparison scores are less than the cutoff, they are added to a list, which is then emailed to interested parties informing them of the potential problem files
+ * This class was originally conceived to try and find out why values for wxs and wgs differed so much.
+ * We have since accepted this difference and so this class is no longer required.
  *  
  * @author o.holmes
  *
+ *@deprecated
  */
 public class SignatureWTFExomes {
 	
@@ -73,7 +73,7 @@ public class SignatureWTFExomes {
 	
 	private final Map<File, TIntByteHashMap> cache = new THashMap<>(cacheSize * 2);
 	
-	List<String> suspiciousResults = new ArrayList<String>();
+	List<String> suspiciousResults = new ArrayList<>();
 	
 	private int engage() throws Exception {
 		
@@ -119,7 +119,7 @@ public class SignatureWTFExomes {
 			return 1;
 		}
 		
-		logger.info("Should have " + (files.size() -1) + " + " + (files.size() -2) + " ...  comparisons");
+		logger.info("Should have " + (files.size() - 1) + " + " + (files.size() - 2) + " ...  comparisons");
 		
 		Collections.sort(files, FileUtils.FILE_COMPARATOR);
 		
@@ -188,13 +188,13 @@ public class SignatureWTFExomes {
 			for (String s : suspiciousResults) logger.info(s);
 		}
 		
-		if (outputXml != null)
+		if (outputXml != null) {
 			writeXmlOutput();
-		
+		}
 		return exitStatus;
 	}
 	
-	TIntByteHashMap getSignatureData(File f) throws Exception {
+	TIntByteHashMap getSignatureData(File f) throws IOException {
 		// check map to see if this data has already been loaded
 		// if not - load
 		TIntByteHashMap result = cache.get(f);
@@ -210,15 +210,6 @@ public class SignatureWTFExomes {
 			cache.put(f, result);
 		}
 		fileIdsAndCounts.get(f)[1] = result.size();
-			/*
-			 * average coverage
-			 */
-			//TODO put this back in
-//			IntSummaryStatistics iss = result.values().stream()
-//				.mapToInt(array -> (int) array[4])
-//				.summaryStatistics();
-//			fileIdsAndCounts.get(f)[2] = (int) iss.getAverage();
-//		}
 		return result;
 	}
 	
@@ -291,17 +282,17 @@ public class SignatureWTFExomes {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 2;
-			if (null != logger)
-				logger.error("Exception caught whilst running SignatureCompareRelatedSimple:", e);
-			else {
-				System.err.println("Exception caught whilst running SignatureCompareRelatedSimple: " + e.getMessage());
+			if (null != logger) {
+				logger.error("Exception caught whilst running SignatureWTFExomes:", e);
+			} else {
+				System.err.println("Exception caught whilst running SignatureWTFExomes: " + e.getMessage());
 				System.err.println(Messages.USAGE);
 			}
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
-		
+		}
 		System.exit(exitStatus);
 	}
 	
@@ -329,28 +320,30 @@ public class SignatureWTFExomes {
 			
 			
 			String [] cmdLineOutputFiles = options.getOutputFileNames();
-			if (null != cmdLineOutputFiles && cmdLineOutputFiles.length > 0)
+			if (null != cmdLineOutputFiles && cmdLineOutputFiles.length > 0) {
 				outputXml = cmdLineOutputFiles[0];
-			
+			}
 			String[] paths = options.getDirNames(); 
 			if (null != paths && paths.length > 0) {
 				this.paths = paths;
 			}
-			if (null == paths) throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			if (null == paths) {
+				throw new QSignatureException("MISSING_DIRECTORY_OPTION");
+			}
 			
-			if (options.hasCutoff())
+			if (options.hasCutoff()) {
 				cutoff = options.getCutoff();
-			
+			}
 			options.getMinCoverage().ifPresent(i -> {minimumCoverage = i.intValue();});
 			logger.tool("Setting minumim coverage to: " + minimumCoverage);
 			
 			additionalSearchStrings = options.getAdditionalSearchString();
 			logger.tool("Setting additionalSearchStrings to: " + Arrays.deepToString(additionalSearchStrings));
 			
-			if (options.hasExcludeVcfsFileOption())
+			if (options.hasExcludeVcfsFileOption()) {
 				excludeVcfsFile = options.getExcludeVcfsFile();
-			
-			logger.logInitialExecutionStats("SignatureCompareRelatedSimple", SignatureWTFExomes.class.getPackage().getImplementationVersion(), args);
+			}
+			logger.logInitialExecutionStats("SignatureWTFExomes", SignatureWTFExomes.class.getPackage().getImplementationVersion(), args);
 			
 			return engage();
 		}

--- a/qsignature/src/org/qcmg/sig/SnpFileDetails.java
+++ b/qsignature/src/org/qcmg/sig/SnpFileDetails.java
@@ -7,6 +7,7 @@
 package org.qcmg.sig;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,22 +20,26 @@ import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.tab.TabbedFileReader;
 import org.qcmg.tab.TabbedRecord;
 
+/**
+ * This class returns some (very) basic details on the snp positions file.
+ * 
+ * @author oliverh
+ *
+ */
 public class SnpFileDetails {
 	
 	private static QLogger logger;
 	private String logFile;
 	private String[] cmdLineInputFiles;
 	private int exitStatus;
-	private final List<VcfRecord> snps = new ArrayList<VcfRecord>();
+	private final List<VcfRecord> snps = new ArrayList<>();
 	
-	private int engage() throws Exception {
-		
+	private int engage() throws IOException {
 		loadRandomSnpPositions(cmdLineInputFiles[0]);
-		
 		return exitStatus;
 	}
 	
-	private void loadRandomSnpPositions(String randomSnpsFile) throws Exception {
+	private void loadRandomSnpPositions(String randomSnpsFile) throws IOException {
 		TabbedFileReader reader = new TabbedFileReader(new File(randomSnpsFile));
 		try {
 			int count = 0, emptyRefCount = 0, dashRef = 0;
@@ -57,16 +62,11 @@ public class SnpFileDetails {
 				String chr = params[0];
 				int position = Integer.parseInt(params[1]);
 						
-						//VcfUtils.createVcfRecord(chr, position, ref);
 				String alt = params.length > 5 ? params[5].replaceAll("/", ",") : null;
 
 				// Lynns new files are 1-based - no need to do any processing on th position
-				snps.add(new VcfRecord(new String[] {chr, position+"", params[2], ref, alt}));
+				snps.add(new VcfRecord(new String[] {chr, position + "", params[2], ref, alt}));
 			}
-			
-			// sort - this step is now done after retrieving the sequences from the bam header
-//			Collections.sort(snps, new VcfPositionComparator());
-			
 			
 			logger.info("Loaded " + snps.size() + " positions into map (should be equal to: " + count + ") empty refs: " + emptyRefCount
 					+ ", dash refs: " + dashRef);
@@ -82,15 +82,17 @@ public class SnpFileDetails {
 			exitStatus = sp.setup(args);
 		} catch (Exception e) {
 			exitStatus = 1;
-			if (null != logger)
-				logger.error("Exception caught whilst running QSignatureSequential:", e);
-			else System.err.println("Exception caught whilst running QSignatureSequential");
+			if (null != logger) {
+				logger.error("Exception caught whilst running SnpFileDetails:", e);
+			} else {
+				System.err.println("Exception caught whilst running SnpFileDetails");
+			}
 			e.printStackTrace();
 		}
 		
-		if (null != logger)
+		if (null != logger) {
 			logger.logFinalExecutionStats(exitStatus);
-		
+		}
 		System.exit(exitStatus);
 	}
 	

--- a/qsignature/src/org/qcmg/sig/model/Comparison.java
+++ b/qsignature/src/org/qcmg/sig/model/Comparison.java
@@ -17,12 +17,8 @@ public class Comparison implements Comparable<Comparison> {
 	
 	private final int mainCoverage;
 	private final int testCoverage;
-//	private final long mainCovAtOverlaps;
-//	private final long testCovAtOverlaps;
 	private final int overlapCoverage;
-//	private final double totalScore;
 	private final double score;
-	//private final int numberOfCalculations;
 	
 	public String getMain() {
 		return main;
@@ -44,50 +40,31 @@ public class Comparison implements Comparable<Comparison> {
 		return overlapCoverage;
 	}
 
-//	public double getTotalScore() {
-//		return totalScore;
-//	}
-
 	public double getScore() {
 		return score;
 	}
 	
-//	public int getMainAveCovAtOverlaps() {
-////		System.out.println("mainCovAtOverlaps: " + mainCovAtOverlaps);
-////		System.out.println("overlapCoverage: " + overlapCoverage);
-//		return overlapCoverage > 0 ? (int)(mainCovAtOverlaps / overlapCoverage) : -1; 
-//	}
-//	public int getTestAveCovAtOverlaps() {
-////		System.out.println("testCovAtOverlaps: " + testCovAtOverlaps);
-////		System.out.println("overlapCoverage: " + overlapCoverage);
-//		return overlapCoverage > 0 ? (int)(testCovAtOverlaps / overlapCoverage) : -1; 
-//	}
-//	
 	public Comparison(File file1, int size, File file2, int size2, double finalTally, int count) {
 		this(file1 != null ? file1.getAbsolutePath() : null, size, file2 != null ? file2.getAbsolutePath() : null, size2, finalTally, count);
 	}
 
 	public Comparison(String file1, int size, String file2, int size2, double finalTally, int count) {
 		
-		if (null == file1 || null == file2) 
+		if (null == file1 || null == file2) { 
 			throw new IllegalArgumentException("null files passed to Comparison constructor");
-		
-		if (finalTally > 0.0 && count == 0)
+		}
+		if (finalTally > 0.0 && count == 0) {
 			throw new IllegalArgumentException("non-zero tally but zero count passed to Comparison constructor");
-		
-		if (size < 0 || size2 < 0 || finalTally < 0.0 || count < 0)
+		}
+		if (size < 0 || size2 < 0 || finalTally < 0.0 || count < 0) {
 			throw new IllegalArgumentException("negative value(s) passed to Comparison constructor");
-		
+		}
 		this.main = file1;
 		this.test = file2;
 		this.mainCoverage = size;
 		this.testCoverage = size2;
-//		this.totalScore = finalTally;
 		this.overlapCoverage = count;
-		//this.numberOfCalculations = noOfCalculations;
 		this.score = finalTally / overlapCoverage;
-	//	mainCovAtOverlaps = l;
-	//	testCovAtOverlaps = m;
 	}
 	
 	public String toSummaryString() {
@@ -107,15 +84,18 @@ public class Comparison implements Comparable<Comparison> {
 		sb.append(test).append(" (").append(testCoverage).append(") : ");
 		sb.append(Double.isNaN(score) ? "NaN" : score);
 		sb.append(", ").append(overlapCoverage);
-//		sb.append(", ").append(numberOfCalculations);
 		return sb.toString();
 	}
 
 	@Override
 	public int compareTo(Comparison o) {
 		
-		if (score < o.score) return -1;
-		if (score > o.score) return 1;
+		if (score < o.score) {
+			return -1;
+		}
+		if (score > o.score) {
+			return 1;
+		}
 		
 		// scores are equal - check overlapCoverage - greatest coverage wins
 		return overlapCoverage - o.overlapCoverage;

--- a/qsignature/src/org/qcmg/sig/model/Comparison.java
+++ b/qsignature/src/org/qcmg/sig/model/Comparison.java
@@ -90,15 +90,11 @@ public class Comparison implements Comparable<Comparison> {
 	@Override
 	public int compareTo(Comparison o) {
 		
-		if (score < o.score) {
-			return -1;
+		if (score == o.score) {
+			// scores are equal - check overlapCoverage - greatest coverage wins
+			return overlapCoverage - o.overlapCoverage;
 		}
-		if (score > o.score) {
-			return 1;
-		}
-		
-		// scores are equal - check overlapCoverage - greatest coverage wins
-		return overlapCoverage - o.overlapCoverage;
+		return score > o.score ? 1 : -1;
 	}
 	 
 }

--- a/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
@@ -22,9 +22,7 @@ import gnu.trove.map.hash.TIntShortHashMap;
 
 public class ComparisonUtil {
 	
-	public static final int MINIMUM_NO_OF_CALCULATIONS = 25000;
 	private static final QLogger logger = QLoggerFactory.getLogger(ComparisonUtil.class);
-	
 	
 	public static String getComparisonsBody(List<Comparison> comparisons) {
 		if (null == comparisons || comparisons.isEmpty()) {
@@ -53,10 +51,9 @@ public class ComparisonUtil {
 		}
 		
 		for (Comparison comp : comparisons) {
-			// only care about comparisons that had a large number of calculations
-//			if (comp.getNumberOfCalculations() < MINIMUM_NO_OF_CALCULATIONS)
-//				continue;
-			if (comp.getScore() > cutoff) return true;
+			if (comp.getScore() > cutoff) {
+				return true;
+			}
 		}
 		return false;
 	}

--- a/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/ComparisonUtil.java
@@ -6,9 +6,6 @@
  */
 package org.qcmg.sig.util;
 
-import gnu.trove.map.hash.TIntByteHashMap;
-import gnu.trove.map.hash.TIntShortHashMap;
-
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +16,9 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.sig.model.Comparison;
+
+import gnu.trove.map.hash.TIntByteHashMap;
+import gnu.trove.map.hash.TIntShortHashMap;
 
 public class ComparisonUtil {
 	
@@ -64,89 +64,89 @@ public class ComparisonUtil {
 	public static Comparison compareRatiosUsingSnps(final Map<ChrPosition, double[]> file1Ratios,
 				final Map<ChrPosition, double[]> file2Ratios, File file1, File file2, Map<ChrPosition, ChrPosition> positionsOfInterest) {
 			
-			if (null == file1Ratios || null == file2Ratios) {
-				throw new IllegalArgumentException("null maps passed to compareRatios");
-			}
-			if (null == file1 || null == file2) {
-				throw new IllegalArgumentException("null files passed to compareRatios");
-			}
-			if (file1Ratios.isEmpty() || file2Ratios.isEmpty()) {
-				return  new Comparison(file1.getAbsolutePath(), file1Ratios.size(), file2.getAbsolutePath(), file2Ratios.size(), 0, 0);
-			}
-			
-			// if the files are the same, return a comparison object without doing the comparison
-			if (file1.equals(file2)) {
-				return  new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), 0, file1Ratios.size());
-			}
-			
-			boolean checkPositionsList = null != positionsOfInterest && ! positionsOfInterest.isEmpty();
-			
-			int match = 0;
-			int totalCompared = 0;
-			for (Entry<ChrPosition, double[]> file1RatiosEntry : file1Ratios.entrySet()) {
-				
-				// check to see if position is in the list of desired positions, if not continue
-				if (checkPositionsList) {
-					boolean overlap = positionsOfInterest.containsKey(file1RatiosEntry.getKey());
-					if ( ! overlap)  {
-						continue;
-					}
-				}
-				
-				// if coverage is zero, skip
-				final double[] file1Ratio = file1RatiosEntry.getValue();
-				
-				/*
-				 * See if we can get a clear genotype from file1Ratios before retrieving ratios from file2
-				 */
-				int g1 = 0;
-				for (int i = 0 ; i < 4 ; i++) {
-					double d = file1Ratio[i];
-					if (d > 0.90000) {
-						// this is all we care about
-						g1 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
-						break;
-					} else if (d >= 0.40000 && d <= 0.60000) {
-						g1 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
-					}
-				}
-				
-				if (g1 > 0) {
-					
-					final double[] file2Ratio = file2Ratios.get(file1RatiosEntry.getKey());
-					if (null != file2Ratio) {
-						int g2 = 0;
-						for (int i = 0 ; i < 4 ; i++) {
-							double d = file2Ratio[i];
-							if (d > 0.90000) {
-								// this is all we care about
-								g2 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
-								break;
-							} else if (d >= 0.40000 && d <= 0.60000) {
-								g2 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
-							}
-						}
-						
-						if ( g2 > 0) {
-							if (g1 == g2) {
-								match++;
-							}
-							totalCompared++;
-						}
-					}
-				}
-			}
-			double concordance = totalCompared > 0 ? ((double)match / totalCompared) * 100 : 0;
-			logger.info("match: " + match + ", totalCompared: " + totalCompared + " percentage concordance: " + concordance);
-			
-			Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), match, totalCompared);
-			return comp;
+		if (null == file1Ratios || null == file2Ratios) {
+			throw new IllegalArgumentException("null maps passed to compareRatios");
 		}
-	
-	public static Comparison compareRatiosUsingSnpsFloat(TIntShortHashMap file1Ratios,TIntShortHashMap file2Ratios, File file1, File file2) {
-		return compareRatiosUsingSnpsFloat(file1Ratios,file2Ratios, file1.getAbsolutePath(), file2.getAbsolutePath()); 
+		if (null == file1 || null == file2) {
+			throw new IllegalArgumentException("null files passed to compareRatios");
+		}
+		if (file1Ratios.isEmpty() || file2Ratios.isEmpty()) {
+			return  new Comparison(file1.getAbsolutePath(), file1Ratios.size(), file2.getAbsolutePath(), file2Ratios.size(), 0, 0);
+		}
+		
+		// if the files are the same, return a comparison object without doing the comparison
+		if (file1.equals(file2)) {
+			return  new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), 0, file1Ratios.size());
+		}
+		
+		boolean checkPositionsList = null != positionsOfInterest && ! positionsOfInterest.isEmpty();
+		
+		int match = 0;
+		int totalCompared = 0;
+		for (Entry<ChrPosition, double[]> file1RatiosEntry : file1Ratios.entrySet()) {
+			
+			// check to see if position is in the list of desired positions, if not continue
+			if (checkPositionsList) {
+				boolean overlap = positionsOfInterest.containsKey(file1RatiosEntry.getKey());
+				if ( ! overlap)  {
+					continue;
+				}
+			}
+			
+			// if coverage is zero, skip
+			final double[] file1Ratio = file1RatiosEntry.getValue();
+			
+			/*
+			 * See if we can get a clear genotype from file1Ratios before retrieving ratios from file2
+			 */
+			int g1 = 0;
+			for (int i = 0 ; i < 4 ; i++) {
+				double d = file1Ratio[i];
+				if (d > 0.90000) {
+					// this is all we care about
+					g1 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
+					break;
+				} else if (d >= 0.40000 && d <= 0.60000) {
+					g1 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
+				}
+			}
+			
+			if (g1 > 0) {
+				
+				final double[] file2Ratio = file2Ratios.get(file1RatiosEntry.getKey());
+				if (null != file2Ratio) {
+					int g2 = 0;
+					for (int i = 0 ; i < 4 ; i++) {
+						double d = file2Ratio[i];
+						if (d > 0.90000) {
+							// this is all we care about
+							g2 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
+							break;
+						} else if (d >= 0.40000 && d <= 0.60000) {
+							g2 += i == 0 ? 1 : i == 1 ? 10 : i == 2 ? 100 : 1000;
+						}
+					}
+					
+					if ( g2 > 0) {
+						if (g1 == g2) {
+							match++;
+						}
+						totalCompared++;
+					}
+				}
+			}
+		}
+		double concordance = totalCompared > 0 ? ((double)match / totalCompared) * 100 : 0;
+		logger.info("match: " + match + ", totalCompared: " + totalCompared + " percentage concordance: " + concordance);
+		
+		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), match, totalCompared);
+		return comp;
 	}
-	public static Comparison compareRatiosUsingSnpsFloat(TIntShortHashMap file1Ratios,TIntShortHashMap file2Ratios, String file1, String file2) {
+	
+	public static Comparison compareRatiosUsingSnpsFloat(TIntShortHashMap file1Ratios, TIntShortHashMap file2Ratios, File file1, File file2) {
+		return compareRatiosUsingSnpsFloat(file1Ratios, file2Ratios, file1.getAbsolutePath(), file2.getAbsolutePath()); 
+	}
+	public static Comparison compareRatiosUsingSnpsFloat(TIntShortHashMap file1Ratios, TIntShortHashMap file2Ratios, String file1, String file2) {
 		if (null == file1Ratios || null == file2Ratios) {
 			throw new IllegalArgumentException("null maps passed to compareRatios");
 		}
@@ -179,10 +179,10 @@ public class ComparisonUtil {
 		Comparison comp = new Comparison(file1, file1Ratios.size(), file2, file2Ratios.size(), match.get(), totalCompared.get());
 		return comp;
 	}
-	public static Comparison compareRatiosUsingSnpsFloat(TIntByteHashMap file1Ratios,TIntByteHashMap file2Ratios, File file1, File file2) {
-		return compareRatiosUsingSnpsFloat(file1Ratios,file2Ratios, file1.getAbsolutePath(), file2.getAbsolutePath()); 
+	public static Comparison compareRatiosUsingSnpsFloat(TIntByteHashMap file1Ratios, TIntByteHashMap file2Ratios, File file1, File file2) {
+		return compareRatiosUsingSnpsFloat(file1Ratios, file2Ratios, file1.getAbsolutePath(), file2.getAbsolutePath()); 
 	}
-	public static Comparison compareRatiosUsingSnpsFloat(TIntByteHashMap file1Ratios,TIntByteHashMap file2Ratios, String file1, String file2) {
+	public static Comparison compareRatiosUsingSnpsFloat(TIntByteHashMap file1Ratios, TIntByteHashMap file2Ratios, String file1, String file2) {
 		if (null == file1Ratios || null == file2Ratios) {
 			throw new IllegalArgumentException("null maps passed to compareRatios");
 		}

--- a/qsignature/src/org/qcmg/sig/util/Quartile.java
+++ b/qsignature/src/org/qcmg/sig/util/Quartile.java
@@ -27,7 +27,7 @@ public class Quartile {
 	}
 	
 	public static List<Number> getPassingValues(List<? extends Number> numbers, double iQRMultiplier) {
-		List<Number> passingValues = new ArrayList<Number>();
+		List<Number> passingValues = new ArrayList<>();
 		
 		// get quartiles
 		double [] quartiles = quartile(numbers);
@@ -35,7 +35,9 @@ public class Quartile {
 		double cutoff = quartiles[0] - (iQRMultiplier * iqr);
 		
 		for (Number n : numbers) {
-			if (n.doubleValue() < cutoff) passingValues.add(n.doubleValue());
+			if (n.doubleValue() < cutoff) {
+				passingValues.add(n.doubleValue());
+			}
 		}
 		
 		return passingValues;
@@ -50,48 +52,13 @@ public class Quartile {
 	 * @return
 	 */
 	public static List<Number> getPassingValuesString(List<Comparison> comparisons, double iQRMultiplier) {
-//		List<Number> passingValues = new ArrayList<Number>();
 		
 		// get doubles from string
-		List<Double> doubles = new ArrayList<Double>();
+		List<Double> doubles = new ArrayList<>();
 		for (Comparison c : comparisons) {
 			doubles.add(c.getScore());
 		}
 		return getPassingValues(doubles, iQRMultiplier);
 		
-//		// get quartiles
-//		double [] quartiles = quartile(doubles);
-//		double iqr = quartiles[2] - quartiles[0];
-//		double cutoff = quartiles[0] - (iQRMultiplier * iqr);
-//		
-//		for (Number n : doubles) {
-//			if (n.doubleValue() < cutoff) passingValues.add(n.doubleValue());
-//		}
-//		
-//		return passingValues;
 	}
-//	public static List<Number> getPassingValuesString(List<String> numbers, double iQRMultiplier) {
-////		List<Number> passingValues = new ArrayList<Number>();
-//		
-//		// get doubles from string
-//		List<Double> doubles = new ArrayList<Double>();
-//		for (String s : numbers) {
-//			double d = Double.valueOf(s.substring(0, s.indexOf(":")));
-//			doubles.add(d);
-//			
-//		}
-//		return getPassingValues(doubles, iQRMultiplier);
-//		
-////		// get quartiles
-////		double [] quartiles = quartile(doubles);
-////		double iqr = quartiles[2] - quartiles[0];
-////		double cutoff = quartiles[0] - (iQRMultiplier * iqr);
-////		
-////		for (Number n : doubles) {
-////			if (n.doubleValue() < cutoff) passingValues.add(n.doubleValue());
-////		}
-////		
-////		return passingValues;
-//	}
-
 }

--- a/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
+++ b/qsignature/src/org/qcmg/sig/util/SignatureUtil.java
@@ -7,9 +7,6 @@
 package org.qcmg.sig.util;
 
 import static java.util.Comparator.comparing;
-import gnu.trove.map.TMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntByteHashMap;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,6 +62,10 @@ import org.qcmg.tab.TabbedRecord;
 import org.qcmg.vcf.VCFFileReader;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import gnu.trove.map.TMap;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntByteHashMap;
 
 public class SignatureUtil {
 	
@@ -131,11 +132,11 @@ public class SignatureUtil {
 			
 			for (char c : BASES_NO_N) {
 				if (c1 == c && c2 == c) {
-					StringUtils.updateStringBuilder(sb, ""+(i1+i2), '-');
+					StringUtils.updateStringBuilder(sb, "" + (i1 + i2), '-');
 				} else if (c1 == c) {
-					StringUtils.updateStringBuilder(sb, ""+i1, '-');
+					StringUtils.updateStringBuilder(sb, "" + i1, '-');
 				} else if (c2 == c) {
-					StringUtils.updateStringBuilder(sb, ""+i2, '-');
+					StringUtils.updateStringBuilder(sb, "" + i2, '-');
 				} else {
 					StringUtils.updateStringBuilder(sb, "0", '-');
 				}
@@ -275,13 +276,19 @@ public class SignatureUtil {
 			
 			for (TabbedRecord vcfRecord : reader) {
 				line = vcfRecord.getData();
-				if (line.startsWith(Constants.HASH_STRING)) continue;
+				if (line.startsWith(Constants.HASH_STRING)) {
+					continue;
+				}
 				//do a brute force search for the empty coverage string before passing to tokenizer
 				// only populate ratios with non-zero values
 				// attempt to keep memory usage down...
-				if (line.indexOf(SHORT_CUT_EMPTY_COVERAGE) > -1) continue;
+				if (line.indexOf(SHORT_CUT_EMPTY_COVERAGE) > -1) {
+					continue;
+				}
 				// ignore entries that have nan in there
-				if (line.indexOf(NAN) > -1) continue;
+				if (line.indexOf(NAN) > -1) {
+					continue;
+				}
 				
 				String[] params = TabTokenizer.tokenize(line);
 				String coverage = params[7];
@@ -307,13 +314,19 @@ public class SignatureUtil {
 			
 			for (TabbedRecord vcfRecord : reader) {
 				line = vcfRecord.getData();
-				if (line.startsWith(Constants.HASH_STRING)) continue;
+				if (line.startsWith(Constants.HASH_STRING)) {
+					continue;
+				}
 				//do a brute force search for the empty coverage string before passing to tokenizer
 				// only populate ratios with non-zero values
 				// attempt to keep memory usage down...
-				if (line.indexOf(SHORT_CUT_EMPTY_COVERAGE) > -1) continue;
+				if (line.indexOf(SHORT_CUT_EMPTY_COVERAGE) > -1) {
+					continue;
+				}
 				// ignore entries that have nan in there
-				if (line.indexOf(NAN) > -1) continue;
+				if (line.indexOf(NAN) > -1) {
+					continue;
+				}
 				
 				String[] params = TabTokenizer.tokenize(line);
 				String coverage = params[7];
@@ -816,7 +829,7 @@ public class SignatureUtil {
 		String arrayGenotypoe = "";
 		if (BaseUtils.isAT(snpChar1) && BaseUtils.isCG(snpChar2)) {
 			if (illRec.getFirstAlleleCall() == 'A') {
-				arrayGenotypoe = ""+snpChar1;
+				arrayGenotypoe = "" + snpChar1;
 				
 				if (illRec.getSecondAlleleCall() == 'A') {
 					arrayGenotypoe += snpChar1;
@@ -824,7 +837,7 @@ public class SignatureUtil {
 					arrayGenotypoe += snpChar2;
 				}
 			} else if (illRec.getFirstAlleleCall() == 'B') {
-				arrayGenotypoe = ""+ snpChar2 + snpChar2;
+				arrayGenotypoe = "" + snpChar2 + snpChar2;
 			}
 		}
 		/*
@@ -841,7 +854,7 @@ public class SignatureUtil {
 				|| (snpChar1 == 'G' && snpChar2 == 'C')) {
 			
 			if (illRec.getFirstAlleleCall() == 'A' && "TOP".equalsIgnoreCase(illRec.getStrand())) {
-				arrayGenotypoe = ""+snpChar1;
+				arrayGenotypoe = "" + snpChar1;
 				
 				if (illRec.getSecondAlleleCall() == 'A') {
 					arrayGenotypoe += snpChar1;
@@ -849,14 +862,14 @@ public class SignatureUtil {
 					arrayGenotypoe += snpChar2;
 				}
 			} else if (illRec.getFirstAlleleCall() == 'A' && "BOT".equalsIgnoreCase(illRec.getStrand())) {
-				arrayGenotypoe = ""+snpChar2;
+				arrayGenotypoe = "" + snpChar2;
 				if (illRec.getSecondAlleleCall() == 'A') {
 					arrayGenotypoe += snpChar2;
 				} else if  (illRec.getSecondAlleleCall() == 'B') {
 					arrayGenotypoe += snpChar1;
 				}
 			} else if (illRec.getFirstAlleleCall() == 'B') {
-				arrayGenotypoe = ""+ snpChar2 + snpChar2;
+				arrayGenotypoe = "" + snpChar2 + snpChar2;
 			}
 		} else {
 			//# shouldn't happen, but here as a warning just in case


### PR DESCRIPTION
# Description


There are currently many compare classes within the `qsignature` project that do very similar things.
This PR has deprecated many of them, with a view to deleting them in a future version.
One class has been renamed. `CompareRGGenotype` is now `CompareRG` (the genotype part was meaning less).
Documentation has also been added to help the user understand what the class does.
And finally, changes to adhere to the checkstyle plugin used have been incorporated.

Fixes #122 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The project has been built with no issues

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
