### PR TITLE
to change hard coded xsd file name to qprofiler2.xsd, due to the version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext {
   timestamp = new java.text.SimpleDateFormat('yyyyMMddHHmmss').format(new
   java.util.Date()) 
 }
-version = 1.0
+System.properties['version'] = 1.0 
 
 def adamalib=file('adama/build/lib').absolutePath  
 subprojects {
@@ -62,6 +62,7 @@ subprojects {
       def classpath = project.configurations.runtime.collect { it.name }.join(' ')
       manifest {    
         attributes 'Implementation-Title': project.name,
+		   'Implementation-Version': System.properties['version'],
         	   'SVN-Version': revision,
                    'Built-By': System.properties['user.name'],
                    'Date': new java.util.Date().toString(),

--- a/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
@@ -127,7 +127,7 @@ public class QProfiler2 {
 		root.setAttribute( "user", System.getProperty("user.name") );
 		root.setAttribute( "operatingSystem", System.getProperty("os.name") );
 		root.setAttribute( "version", version );
-		root.setAttribute("validationSchema", "qprofiler_2_0.xsd");
+		root.setAttribute("validationSchema", "qprofiler2.xsd");
 		XmlElementUtils.asXmlText(root, outputFile);		
 		 			
 		return exitStatus;


### PR DESCRIPTION

# Description

Update the parent build file under the adamajava, apply version information into its sub-projects.  
Meanwhile, the version inside the schema file name is removed. 

Fixes #159

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To build projects and run it. 

- [ X] Test A:  "java -jar qprofiler2.jar --version"  shows "1.0"
- [ ] Test B

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
