### PR TITLE
removed version numbers from paths to jar files in adama/bin

### DIFF
--- a/adama/bin/qbamannotate
+++ b/adama/bin/qbamannotate
@@ -5,4 +5,4 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -jar ${ADAMA_HOME}/build/lib/qbamannotate-0.3pre.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qbamannotate.jar "$@"

--- a/adama/bin/qbamfilter
+++ b/adama/bin/qbamfilter
@@ -6,4 +6,4 @@ if [ -z "$ADAMA_HOME" ]; then
 fi
 
 #java -Dsamjdk.compression_level=1 -jar ${ADAMA_HOME}/build/lib/qbamfilter-1.0pre.jar "$@"
-java -Dsamjdk.compression_level=1 -jar ${ADAMA_HOME}/build/lib/qbamfilter-1.1pre.jar "$@"
+java -Dsamjdk.compression_level=1 -jar ${ADAMA_HOME}/build/lib/qbamfilter.jar "$@"

--- a/adama/bin/qbamfix
+++ b/adama/bin/qbamfix
@@ -5,5 +5,5 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -Dsamjdk.compression_level=1 -XX:ParallelGCThreads=2 -Xmx15g -jar ${ADAMA_HOME}/build/lib/qbamfix-0.2pre.jar "$@"
+java -Dsamjdk.compression_level=1 -XX:ParallelGCThreads=2 -Xmx15g -jar ${ADAMA_HOME}/build/lib/qbamfix.jar "$@"
 #java -Dsamjdk.compression_level=1 -jar ${ADAMA_HOME}/build/lib/qbamfix-0.1pre.jar "$@"

--- a/adama/bin/qbammerge
+++ b/adama/bin/qbammerge
@@ -5,4 +5,4 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -jar ${ADAMA_HOME}/build/lib/qbammerge-0.7pre.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qbammerge.jar "$@"

--- a/adama/bin/qbasepileup
+++ b/adama/bin/qbasepileup
@@ -5,4 +5,4 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -jar ${ADAMA_HOME}/build/lib/qbasepileup-0.1pre.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qbasepileup.jar "$@"

--- a/adama/bin/qcoverage
+++ b/adama/bin/qcoverage
@@ -7,4 +7,4 @@ fi
 
 #module load java/1.7.13
 
-java -Xmx14G -jar ${ADAMA_HOME}/build/lib/qcoverage-0.7pre.jar "$@"
+java -Xmx14G -jar ${ADAMA_HOME}/build/lib/qcoverage.jar "$@"

--- a/adama/bin/qmaftools
+++ b/adama/bin/qmaftools
@@ -12,5 +12,5 @@ fi
 
 #module load java/1.7.13
 
-java -cp ${ADAMA_HOME}/build/lib/qmaftools-0.2.jar "$@"
+java -cp ${ADAMA_HOME}/build/lib/qmaftools.jar "$@"
 #java -jar ${ADAMA_HOME}/build/lib/qmule-0.1pre.jar "$@"

--- a/adama/bin/qmule
+++ b/adama/bin/qmule
@@ -10,5 +10,5 @@ if [ ${#@} == 0 ]; then
     exit 1
 fi
 
-java -cp ${ADAMA_HOME}/build/lib/qmule-0.1pre.jar "$@"
+java -cp ${ADAMA_HOME}/build/lib/qmule.jar "$@"
 #java -jar ${ADAMA_HOME}/build/lib/qmule-0.1pre.jar "$@"

--- a/adama/bin/qpileup
+++ b/adama/bin/qpileup
@@ -5,4 +5,4 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -jar ${ADAMA_HOME}/build/lib/qpileup-0.1pre.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qpileup.jar "$@"

--- a/adama/bin/qprofiler
+++ b/adama/bin/qprofiler
@@ -7,4 +7,4 @@ fi
 
 ###module load java/1.7.13
 
-java -jar ${ADAMA_HOME}/build/lib/qprofiler-1.0.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qprofiler.jar "$@"

--- a/adama/bin/qsignature
+++ b/adama/bin/qsignature
@@ -12,5 +12,5 @@ fi
 
 #module load java/1.7.13
 
-java -cp ${ADAMA_HOME}/build/lib/qsignature-1.0.jar "$@"
+java -cp ${ADAMA_HOME}/build/lib/qsignature.jar "$@"
 #java -jar ${ADAMA_HOME}/build/lib/qmule-0.1pre.jar "$@"

--- a/adama/bin/qsnp
+++ b/adama/bin/qsnp
@@ -5,5 +5,5 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -jar ${ADAMA_HOME}/build/lib/qsnp-1.0.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qsnp.jar "$@"
 #java -jar ${ADAMA_HOME}/build/lib/qsnp-0.1pre.jar "$@"

--- a/adama/bin/qsplit
+++ b/adama/bin/qsplit
@@ -5,4 +5,4 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -jar ${ADAMA_HOME}/build/lib/qsplit-0.1pre.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qsplit.jar "$@"

--- a/adama/bin/qsv
+++ b/adama/bin/qsv
@@ -5,4 +5,4 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -Xmx40g -jar ${ADAMA_HOME}/build/lib/qsv-0.3.jar "$@"
+java -Xmx40g -jar ${ADAMA_HOME}/build/lib/qsv.jar "$@"

--- a/adama/bin/qvisualise
+++ b/adama/bin/qvisualise
@@ -5,4 +5,4 @@ if [ -z "$ADAMA_HOME" ]; then
     exit 1
 fi
 
-java -jar ${ADAMA_HOME}/build/lib/qvisualise-1.0.jar "$@"
+java -jar ${ADAMA_HOME}/build/lib/qvisualise.jar "$@"


### PR DESCRIPTION
# Description

Removed hard coded version number from the wrapper scripts provided in ${ADAMA_HOME}/build/bin

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Confirmed that all files referred to as "`${ADAMA_HOME}/build/lib/*.jar` exist in the most recent deployment of an adamajava build (adamajava-current)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
