### PR TITLE
build scala source in q3indel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ ext {
     adamalib = file('adama/build/lib').absolutePath
 
     //create version from verionId 
-    new File("version.txt").withReader { verionId = it.readLine() + "-" + revision }
+    file('version.txt').withReader { verionId = it.readLine() + "-" + revision }
 }
 allprojects {
     apply plugin: 'java-library'

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ ext {
     adamalib = file('adama/build/lib').absolutePath
 
     //create version from verionId 
+    // by using the file construct, we can access the version.txt from the subprojects
+    // its better groovy/gradle too
     file('version.txt').withReader { verionId = it.readLine() + "-" + revision }
 }
 allprojects {

--- a/q3indel/build.gradle
+++ b/q3indel/build.gradle
@@ -10,6 +10,7 @@ configurations {
     junit
   }
 
+// q3indel has some scala classes that require the following task (along with the scalal plugin and api dependency)
 sourceSets {
         main { java.srcDirs=['src']; resources.srcDirs=['src']; scala.srcDirs=['scala/src'] }
         test { java.srcDirs=['test']; test.resources.srcDirs=['test'];scala.srcDirs=['scala/test'] }

--- a/q3indel/build.gradle
+++ b/q3indel/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'application'
+apply plugin: 'scala'
 
 mainClassName = 'au.edu.qimr.indel.Main'
 def scriptname = 'q3indel'
@@ -9,6 +10,10 @@ configurations {
     junit
   }
 
+sourceSets {
+        main { java.srcDirs=['src']; resources.srcDirs=['src']; scala.srcDirs=['scala/src'] }
+        test { java.srcDirs=['test']; test.resources.srcDirs=['test'];scala.srcDirs=['scala/test'] }
+    }
 dependencies {
     configurations.compile.transitive = true
 
@@ -18,6 +23,7 @@ dependencies {
     api project(':qpicard')
 
     api 'com.github.samtools:htsjdk:2.14.1'
+    api 'org.scala-lang:scala-library:2.12.3'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
 }


### PR DESCRIPTION
# Description

PR #166 removed the ability for gradle to compile the scala code in q3indel.
This PR restores what was removed.

An update to the parent build.gradle file was also performed to load the version.txt at the parent project level. This is useful when running gradle from a subproject (it will fail unless you run at the parent level).

eg. If you want to build qsv at present, you need to be in the parent adamajava folder and run gradle :qsv:build. Running gradle build from within the qsv folder will result in an error.

This fix addresses that.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have run gradle build at the parent and subproject level.
I am able to access the scala class from within the q3indel jar file.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
