### PR TITLE
Qmotif create writer thread that runs in background

### DIFF
--- a/qcommon/src/org/qcmg/common/model/ChrPositionName.java
+++ b/qcommon/src/org/qcmg/common/model/ChrPositionName.java
@@ -23,6 +23,7 @@ public class ChrPositionName extends ChrRangePosition implements ChrPosition {
 	
 	
 	private final String name;
+	private volatile int hashCode;
 
 	public ChrPositionName(String chromosome, int position, int endPosition, String name) {
 		super(chromosome, position, endPosition);
@@ -53,9 +54,14 @@ public class ChrPositionName extends ChrRangePosition implements ChrPosition {
 	 */
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = super.hashCode();
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
+	    int result = hashCode;
+	    if (result == 0) {
+	    	result = 17;
+			final int prime = 31;
+			result = super.hashCode();
+			result = prime * result + ((name == null) ? 0 : name.hashCode());
+			hashCode = result;
+	    }
 		return result;
 	}
 	/* (non-Javadoc)

--- a/qcommon/src/org/qcmg/common/model/ChrPositionName.java
+++ b/qcommon/src/org/qcmg/common/model/ChrPositionName.java
@@ -56,7 +56,7 @@ public class ChrPositionName extends ChrRangePosition implements ChrPosition {
 	public int hashCode() {
 	    int result = hashCode;
 	    if (result == 0) {
-	    	result = 17;
+			result = 17;
 			final int prime = 31;
 			result = super.hashCode();
 			result = prime * result + ((name == null) ? 0 : name.hashCode());

--- a/qmotif/src/org/qcmg/motif/JobQueue.java
+++ b/qmotif/src/org/qcmg/motif/JobQueue.java
@@ -342,14 +342,12 @@ public final class JobQueue {
 	
 	private class Writing implements Runnable {
 		
-//		private final File file;
 		private final AbstractQueue<SAMRecord> queue;
 		private final Thread mainThread;
 		private final CountDownLatch latch;
 
 		public Writing(AbstractQueue<SAMRecord> q,  Thread mainThread, CountDownLatch latch) {
 			queue = q;
-//			file = f;
 			this.mainThread = mainThread;
 			this.latch = latch;
 		}
@@ -361,7 +359,6 @@ public final class JobQueue {
 			SAMRecord record;
 			try (SAMFileWriter writer= bamWriterFactory.getWriter()) {
 				while (run) {
-					// when queue is empty,maybe filtering is done
 					if ((record = queue.poll()) == null) {
 						if (latch.getCount() == 0) {
 							/*

--- a/qmotif/src/org/qcmg/motif/JobQueue.java
+++ b/qmotif/src/org/qcmg/motif/JobQueue.java
@@ -170,7 +170,6 @@ public final class JobQueue {
 		logger.info("Performing final reduce step on results");
 		reduceResults();
 		logger.info("Final reduce step complete");
-//		logger.debug("Final reduced results: " + perIdPerCoverageBaseCounts);
 		executor.shutdown();
 		executor.awaitTermination(10, TimeUnit.HOURS);
 		

--- a/qmotif/src/org/qcmg/motif/MotifCoverageAlgorithm.java
+++ b/qmotif/src/org/qcmg/motif/MotifCoverageAlgorithm.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import htsjdk.samtools.SAMRecord;
-
 import org.qcmg.common.model.ChrPointPosition;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.string.StringUtils;
@@ -22,6 +20,8 @@ import org.qcmg.motif.util.MotifMode;
 import org.qcmg.motif.util.MotifUtils;
 import org.qcmg.motif.util.MotifsAndRegexes;
 import org.qcmg.motif.util.RegionCounter;
+
+import htsjdk.samtools.SAMRecord;
 
 public class MotifCoverageAlgorithm implements Algorithm {
 	
@@ -62,7 +62,9 @@ public class MotifCoverageAlgorithm implements Algorithm {
 
 	@Override
 	public boolean applyTo(final SAMRecord read, Map<ChrPosition, RegionCounter> regions) {
-		if (null == read) throw new IllegalArgumentException("Null SAMRecord passed to applyTo");
+		if (null == read) {
+			throw new IllegalArgumentException("Null SAMRecord passed to applyTo");
+		}
 		
 		String readString = read.getReadString();
 		
@@ -82,10 +84,14 @@ public class MotifCoverageAlgorithm implements Algorithm {
 			RegionCounter rc = getCounterFromMap(regions, cp);
 			
 			// throw exception if we don't have a region for this read
-			if (null == rc) throw new IllegalArgumentException("No RegionCounter exists for region: " + cp.toIGVString());
+			if (null == rc) {
+				throw new IllegalArgumentException("No RegionCounter exists for region: " + cp.toIGVString());
+			}
 			
 			// check that our region type can handle this type of read
-			if ( ! rc.getType().acceptRead( ! read.getReadUnmappedFlag())) return false;
+			if ( ! rc.getType().acceptRead( ! read.getReadUnmappedFlag())) {
+				return false;
+			}
 			
 			rc.updateStage1Coverage();
 			
@@ -138,7 +144,9 @@ public class MotifCoverageAlgorithm implements Algorithm {
 	}
 	
 	RegionCounter getCounterFromMap(Map<ChrPosition, RegionCounter> regions, ChrPosition read) {
-		if (null == regions) throw new IllegalArgumentException("Null map passed to getCounterFromMap");
+		if (null == regions) {
+			throw new IllegalArgumentException("Null map passed to getCounterFromMap");
+		}
 		
 		for (ChrPosition cp : regions.keySet()) {
 			if (ChrPositionUtils.doChrPositionsOverlapPositionOnly(read, cp)) {
@@ -155,7 +163,9 @@ public class MotifCoverageAlgorithm implements Algorithm {
  * @return
  */
 	boolean stageOneSearch(String readString) {
-		if (StringUtils.isNullOrEmpty(readString)) return false;
+		if (StringUtils.isNullOrEmpty(readString)) {
+			return false;
+		}
 		
 		boolean result = false;
 		

--- a/qmotif/src/org/qcmg/motif/ReferenceMotifFinder.java
+++ b/qmotif/src/org/qcmg/motif/ReferenceMotifFinder.java
@@ -9,18 +9,18 @@ package org.qcmg.motif;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import htsjdk.samtools.reference.FastaSequenceFile;
-import htsjdk.samtools.reference.ReferenceSequence;
-
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrRangePosition;
+
+import gnu.trove.map.hash.THashMap;
+import htsjdk.samtools.reference.FastaSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequence;
 
 
 public class ReferenceMotifFinder {
@@ -42,8 +42,8 @@ public class ReferenceMotifFinder {
 	QLogger logger;
 	String currentChr;
 	String currentRefSequence;
-	Map<ChrRangePosition, String> positionsWithMotifs = new HashMap<>(); 
-	Map<ChrRangePosition, String> positionsWithMotifsRegex = new HashMap<>(); 
+	Map<ChrRangePosition, String> positionsWithMotifs = new THashMap<>(); 
+	Map<ChrRangePosition, String> positionsWithMotifsRegex = new THashMap<>(); 
 	
 	public Map<ChrRangePosition, String> getPositionsWithMotifs() {
 		return positionsWithMotifsRegex;

--- a/qmotif/src/org/qcmg/motif/TerminationJob.java
+++ b/qmotif/src/org/qcmg/motif/TerminationJob.java
@@ -9,7 +9,6 @@ package org.qcmg.motif;
 import java.util.Map;
 
 import org.qcmg.common.model.ChrPosition;
-import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.motif.util.RegionCounter;
 
 class TerminationJob implements Job {

--- a/qmotif/src/org/qcmg/motif/WorkerThread.java
+++ b/qmotif/src/org/qcmg/motif/WorkerThread.java
@@ -6,7 +6,6 @@
  */
 package org.qcmg.motif;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.BlockingQueue;
@@ -14,12 +13,13 @@ import java.util.concurrent.BlockingQueue;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
-import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.motif.util.RegionCounter;
+
+import gnu.trove.map.hash.THashMap;
 
 class WorkerThread extends Thread {
 	private final BlockingQueue<Job> inputQueue;
-	private final Map<ChrPosition, RegionCounter> reducedResults = new HashMap<>();
+	private final Map<ChrPosition, RegionCounter> reducedResults = new THashMap<>();
 	private final QLogger logger;
 	private final Thread mainThread;
 

--- a/qmotif/src/org/qcmg/motif/util/MotifUtils.java
+++ b/qmotif/src/org/qcmg/motif/util/MotifUtils.java
@@ -16,8 +16,8 @@ import java.util.stream.Collectors;
 
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.model.ChrPositionComparator;
-import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.common.model.ChrPositionName;
+import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Constants;
@@ -29,8 +29,9 @@ public class MotifUtils {
 	public static final char M_D = Constants.COLON;
 	
 	public static Map<String, AtomicInteger> convertStringArrayToMap(String data) {
-		if (StringUtils.isNullOrEmpty(data))
+		if (StringUtils.isNullOrEmpty(data)) {
 			throw new IllegalArgumentException("Null or empty String array passed to convertStringArrayToMap");
+		}
 		
 		String [] arrayData = data.indexOf(M_D) == -1 ? new String[] {data} : TabTokenizer.tokenize(data, M_D);
 		

--- a/qmotif/test/org/qcmg/motif/MotifCoverageAlgorithmTest.java
+++ b/qmotif/test/org/qcmg/motif/MotifCoverageAlgorithmTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertNull;
 import java.util.HashMap;
 import java.util.Map;
 
-import htsjdk.samtools.SAMRecord;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.qcmg.common.model.ChrPosition;
@@ -15,6 +13,8 @@ import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.motif.util.MotifsAndRegexes;
 import org.qcmg.motif.util.RegionCounter;
 import org.qcmg.motif.util.RegionType;
+
+import htsjdk.samtools.SAMRecord;
 
 public class MotifCoverageAlgorithmTest {
 	
@@ -127,7 +127,7 @@ public class MotifCoverageAlgorithmTest {
 		assertEquals(true, rc.hasMotifs());
 		assertEquals(100, rc.getStage1Coverage());
 		assertEquals(100, rc.getStage2Coverage());
-		assertEquals(4 * 6 * 100 + 99, rc.getMotifsForwardStrand().length());
+//		assertEquals(4 * 6 * 100 + 99, rc.getMotifsForwardStrand().length());
 	}
 	
 	@Test
@@ -186,7 +186,7 @@ public class MotifCoverageAlgorithmTest {
 		assertEquals(true, mca.applyTo(sam, map));
 		// same as initial sequence apart from the first character and the last 4 characters
 		assertEquals("CCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAA"
-				, rc.getMotifsForwardStrand());
+				, rc.getMotifsForwardStrand().keySet().iterator().next());
 		
 	}
 

--- a/qmotif/test/org/qcmg/motif/util/MotifUtilsTest.java
+++ b/qmotif/test/org/qcmg/motif/util/MotifUtilsTest.java
@@ -18,8 +18,6 @@ import org.qcmg.common.util.ChrPositionUtils;
 
 public class MotifUtilsTest {
 	
-//	public static final int buffer = 1000;
-	
 	@Test(expected=IllegalArgumentException.class)
 	public void nullString() {
 		MotifUtils.convertStringArrayToMap(null);
@@ -76,23 +74,7 @@ public class MotifUtilsTest {
 		assertEquals(newMotif + ":" + newMotif, existingMotif.toString());
 		MotifUtils.addMotifToString(existingMotif, newMotif);
 		assertEquals("ABCDEFG:ABCDEFG:ABCDEFG", existingMotif.toString());
-//		assertEquals(newMotif + MotifUtils.M_D + newMotif, existingMotif.toString());
 	}
-//	@Test
-//	public void addMotifToString() {
-//		Map<String, AtomicInteger> existingMotif = null;
-//		MotifUtils.addMotifToString(existingMotif, null);
-//		assertEquals(null,  existingMotif);
-//		String newMotif = "ABCDEFG";
-//		MotifUtils.addMotifToString(existingMotif, newMotif);
-//		assertEquals(null,  existingMotif);
-//		existingMotif =new HashMap<>();
-//		MotifUtils.addMotifToString(existingMotif, newMotif);
-//		assertEquals(true, existingMotif.containsKey(newMotif));
-//		MotifUtils.addMotifToString(existingMotif, newMotif);
-//		assertEquals(2, existingMotif.get(newMotif).intValue());
-////		assertEquals(newMotif + MotifUtils.M_D + newMotif, existingMotif.toString());
-//	}
 	
 	@Test(expected=IllegalArgumentException.class)
 	public void nullChromosome() {
@@ -140,17 +122,15 @@ public class MotifUtilsTest {
 			existingPositions.add(cp);
 		}
 		
-		List<ChrPosition> newPositions = new ArrayList<>();
-		ChrRangePosition cp = new ChrRangePosition("1", 1, 1000000);
-		newPositions.add(cp);
+		List<ChrPosition> newPositions = new ArrayList<>(2);
+		newPositions.add(new ChrRangePosition("1", 1, 1000000));
 		
 		List<ChrPosition> overlap = MotifUtils.getExistingOverlappingPositions(existingPositions, newPositions);
 		assertEquals(99, overlap.size());
 		
 		// change so that only 1overlap is in place
-		cp = new ChrRangePosition("1", 6009, 6100);
 		newPositions.clear();
-		newPositions.add(cp);
+		newPositions.add(new ChrRangePosition("1", 6009, 6100));
 		overlap = MotifUtils.getExistingOverlappingPositions(existingPositions, newPositions);
 		assertEquals(1, overlap.size());
 	}
@@ -188,8 +168,13 @@ public class MotifUtilsTest {
 		regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, null, new ArrayList<ChrPosition>());
 		assertEquals((size ) / windowSize, regions.size());
 		
-		size = 1000000;
+		size = 10000;
 		windowSize = 1;
+		regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, null, null);
+		assertEquals((size ) / windowSize, regions.size());
+		
+		size = 1000000;
+		windowSize = 100;
 		regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, null, null);
 		assertEquals((size ) / windowSize, regions.size());
 		
@@ -213,13 +198,11 @@ public class MotifUtilsTest {
 	
 	@Test
 	public void includesCoversWholeContig() {
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(2);
 		ChrRangePosition includedCP = new ChrRangePosition("chr6_ssto_hap7", 1, 4928567);
 		includes.add(includedCP);
 		
 		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("chr6_ssto_hap7",1,  4928567), 100000, includes, null);
-		
-		//TODO this should be 1...
 		assertEquals(1, regions.size());
 		
 		// increase contig length by 1
@@ -234,15 +217,18 @@ public class MotifUtilsTest {
 	public void getRegionWithIncludesDirectSwap() {
 		int size = 100;
 		int windowSize = 10;
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(2);
 		ChrRangePosition includedCP = new ChrRangePosition("1", 11, 20);
 		includes.add(includedCP);
-		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("1",1, size), windowSize, includes, null);
+		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, includes, null);
 		assertEquals(((size ) / windowSize), regions.size());
 		
 		for (Entry<ChrPosition, RegionCounter> entry : regions.entrySet()) {
-			if (entry.getKey().equals(includedCP)) assertEquals(RegionType.INCLUDES, entry.getValue().getType());
-			else assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			if (entry.getKey().equals(includedCP)) {
+				assertEquals(RegionType.INCLUDES, entry.getValue().getType());
+			} else {
+				assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			}
 		}
 		
 		// want to check that I have uniform coverage over my region
@@ -254,15 +240,18 @@ public class MotifUtilsTest {
 	public void getRegionWithIncludesPartialSwap() {
 		int size = 100;
 		int windowSize = 10;
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(2);
 		ChrRangePosition includedCP = new ChrRangePosition("1", 12, 15);
 		includes.add(includedCP);
 		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, includes, null);
 		assertEquals(((size ) / windowSize) + 2, regions.size());
 		
 		for (Entry<ChrPosition, RegionCounter> entry : regions.entrySet()) {
-			if (entry.getKey().equals(includedCP)) assertEquals(RegionType.INCLUDES, entry.getValue().getType());
-			else assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			if (entry.getKey().equals(includedCP)) {
+				assertEquals(RegionType.INCLUDES, entry.getValue().getType());
+			} else {
+				assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			}
 		}
 		
 		// want to check that I have uniform coverage over my region
@@ -274,15 +263,18 @@ public class MotifUtilsTest {
 	public void getRegionWithIncludesMultipleSwap() {
 		int size = 100;
 		int windowSize = 10;
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(2);
 		ChrRangePosition includedCP = new ChrRangePosition("1", 10, 50);
 		includes.add(includedCP);
 		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, includes, null);
 		assertEquals(7, regions.size());
 		
 		for (Entry<ChrPosition, RegionCounter> entry : regions.entrySet()) {
-			if (entry.getKey().equals(includedCP)) assertEquals(RegionType.INCLUDES, entry.getValue().getType());
-			else assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			if (entry.getKey().equals(includedCP)) {
+				assertEquals(RegionType.INCLUDES, entry.getValue().getType());
+			} else {
+				assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			}
 		}
 		
 		// want to check that I have uniform coverage over my region
@@ -294,15 +286,18 @@ public class MotifUtilsTest {
 	public void getRegionWithExcludesDirectSwap() {
 		int size = 100;
 		int windowSize = 10;
-		List<ChrPosition> excludes = new ArrayList<>();
+		List<ChrPosition> excludes = new ArrayList<>(2);
 		ChrRangePosition excludedCP = new ChrRangePosition("1", 11, 20);
 		excludes.add(excludedCP);
 		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, null, excludes);
 		assertEquals(((size ) / windowSize), regions.size());
 		
 		for (Entry<ChrPosition, RegionCounter> entry : regions.entrySet()) {
-			if (entry.getKey().equals(excludedCP)) assertEquals(RegionType.EXCLUDES, entry.getValue().getType());
-			else assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			if (entry.getKey().equals(excludedCP)) {
+				assertEquals(RegionType.EXCLUDES, entry.getValue().getType());
+			} else {
+				assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			}
 		}
 		
 		// want to check that I have uniform coverage over my region
@@ -314,15 +309,18 @@ public class MotifUtilsTest {
 	public void getRegionWithExcludesPartialSwap() {
 		int size = 100;
 		int windowSize = 10;
-		List<ChrPosition> excludes = new ArrayList<>();
+		List<ChrPosition> excludes = new ArrayList<>(2);
 		ChrRangePosition excludedCP = new ChrRangePosition("1", 10, 15);
 		excludes.add(excludedCP);
 		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("1",1, size), windowSize, null, excludes);
 		assertEquals(11, regions.size());
 		
 		for (Entry<ChrPosition, RegionCounter> entry : regions.entrySet()) {
-			if (entry.getKey().equals(excludedCP)) assertEquals(RegionType.EXCLUDES, entry.getValue().getType());
-			else assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			if (entry.getKey().equals(excludedCP)) {
+				assertEquals(RegionType.EXCLUDES, entry.getValue().getType());
+			} else {
+				assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			}
 		}
 		
 		// want to check that I have uniform coverage over my region
@@ -334,15 +332,18 @@ public class MotifUtilsTest {
 	public void getRegionWithExcludesMultipleSwap() {
 		int size = 100;
 		int windowSize = 10;
-		List<ChrPosition> excludes = new ArrayList<>();
+		List<ChrPosition> excludes = new ArrayList<>(2);
 		ChrRangePosition excludedCP = new ChrRangePosition("1", 10, 50);
 		excludes.add(excludedCP);
 		Map<ChrPosition, RegionCounter> regions = MotifUtils.getRegionMap(new ChrRangePosition("1", 1, size), windowSize, null, excludes);
 		assertEquals(7, regions.size());
 		
 		for (Entry<ChrPosition, RegionCounter> entry : regions.entrySet()) {
-			if (entry.getKey().equals(excludedCP)) assertEquals(RegionType.EXCLUDES, entry.getValue().getType());
-			else assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			if (entry.getKey().equals(excludedCP)) {
+				assertEquals(RegionType.EXCLUDES, entry.getValue().getType());
+			} else {
+				assertEquals(RegionType.GENOMIC, entry.getValue().getType());
+			}
 		}
 		
 		// want to check that I have uniform coverage over my region
@@ -350,12 +351,11 @@ public class MotifUtilsTest {
 		testUniformCoverage(regionChrPos, size);
 	}
 	
-	
 	@Test
 	public void getRegionWithIncludesAndExcludes() {
 		int size = 100;
 		int windowSize = 10;
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(2);
 		ChrRangePosition includedCP = new ChrRangePosition("1", 5, 18);
 		includes.add(includedCP);
 		
@@ -374,7 +374,6 @@ public class MotifUtilsTest {
 		// want to check that I have uniform coverage over my region
 		Set<ChrPosition> regionChrPos = regions.keySet();
 		testUniformCoverage(regionChrPos, size);
-		
 	}
 	
 	
@@ -384,7 +383,7 @@ public class MotifUtilsTest {
 		ChrRangePosition contig = new ChrRangePosition("chr1", 1, 249250621);
 		
 		ChrRangePosition include = new ChrRangePosition("chr1", 10001,12464);
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(2);
 		includes.add(include);
 		
 		int expectedRegions = contig.getLength() / windowSize;
@@ -402,7 +401,7 @@ public class MotifUtilsTest {
 		ChrRangePosition include1 = new ChrRangePosition("chr16", 60001,62033);
 		ChrRangePosition include2 = new ChrRangePosition("chr16", 90292753,90294752);
 		
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(3);
 		includes.add(include1);
 		includes.add(include2);
 		Map<ChrPosition, RegionCounter> map = MotifUtils.getRegionMap(contig, windowSize, includes, null);
@@ -423,7 +422,6 @@ public class MotifUtilsTest {
 		Collections.reverse(list);
 		
 		assertEquals(expectedRegions + 4, map.size());
-		
 	}
 	
 	@Test
@@ -431,7 +429,7 @@ public class MotifUtilsTest {
 		int size = 59373566;
 		int windowSize = 10000;
 		
-		List<ChrPosition> includes = new ArrayList<>();
+		List<ChrPosition> includes = new ArrayList<>(3);
 		includes.add(ChrPositionUtils.getChrPositionFromString("chrY:10001-12033"));
 		includes.add(ChrPositionUtils.getChrPositionFromString("chrY:59360739-59363565"));
 		
@@ -444,7 +442,6 @@ public class MotifUtilsTest {
 		testUniformCoverage(regionChrPos, size, "chrY");
 	}
 
-	
 	private void testUniformCoverage(Set<ChrPosition> regionChrPos, int size) {
 		testUniformCoverage(regionChrPos, size, "1");
 	}
@@ -452,17 +449,20 @@ public class MotifUtilsTest {
 	private void testUniformCoverage(Set<ChrPosition> regionChrPos, int size, String chr) {
 		int[] coverage = new int[size];
 		// 1-based so populate the first entry
-		coverage[0] =1;
+		coverage[0] = 1;
 		
 		for (ChrPosition cp : regionChrPos) {
 			for (int i = cp.getStartPosition() ; i <= cp.getEndPosition() ; i++) {
-				if (i < size) coverage[i]++;
+				if (i < size) {
+					coverage[i]++;
+				}
 			}
 		}
 		
 		// each position in the array should be equal to 1
-		for (int i : coverage) assertEquals(1, i);
-		
+		for (int i : coverage) {
+			assertEquals(1, i);
+		}
 	}
 	
 }

--- a/qmotif/test/org/qcmg/motif/util/RegionCounterTest.java
+++ b/qmotif/test/org/qcmg/motif/util/RegionCounterTest.java
@@ -46,189 +46,72 @@ public class RegionCounterTest {
 		rcInc.addMotif("ABCD", true, false);
 		assertEquals(true, rcInc.hasMotifs());
 		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
-//		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
 		
 		rcInc.addMotif("ABCD", true, false);
 		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
-//		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
 		rcInc.addMotif("XYZ", true, false);
-//		assertEquals(2, rcInc.getMotifsForwardStrand().size());
 		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
 		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
-//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
 	}
-//	@Test
-//	public void includedRegionUnmappedReadsFS() {
-//		rcInc.addMotif("ABCD", true, false);
-//		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
-////		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
-//		
-//		rcInc.addMotif("ABCD", true, false);
-//		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
-////		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
-//		rcInc.addMotif("XYZ", true, false);
-//		assertEquals(2, rcInc.getMotifsForwardStrand().size());
-//		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
-////		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
-//	}
 	@Test
 	public void ncludedRegionMappedReadsFS() {
 		rcInc.addMotif("ABCD", true, true);
 		assertEquals(true, rcInc.hasMotifs());
 		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
-//		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
-//		assertEquals(null, rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("ABCD", true, true);
-//		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
 		rcInc.addMotif("XYZ", true, true);
-//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
 		assertEquals(2, rcInc.getMotifsForwardStrand().size());
 		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
 		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
 	}
-//	@Test
-//	public void ncludedRegionMappedReadsFS() {
-//		rcInc.addMotif("ABCD", true, true);
-//		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
-////		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
-//		assertEquals(null, rcInc.getMotifsReverseStrand());
-//		
-//		rcInc.addMotif("ABCD", true, true);
-////		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
-//		rcInc.addMotif("XYZ", true, true);
-////		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
-//		assertEquals(2, rcInc.getMotifsForwardStrand().size());
-//		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
-//	}
 	
 	@Test
 	public void includedRegionUnmappedReadsRS() {
 		rcInc.addMotif("ABCD", false, false);
 		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(null, rcInc.getMotifsForwardStrand());
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("ABCD", false, false);
-//		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
 		rcInc.addMotif("XYZ", false, false);
-//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
 		assertEquals(2, rcInc.getMotifsReverseStrand().size());
 		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
 		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
 	}
-//	@Test
-//	public void includedRegionUnmappedReadsRS() {
-//		rcInc.addMotif("ABCD", false, false);
-//		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(null, rcInc.getMotifsForwardStrand());
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-////		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
-//		
-//		rcInc.addMotif("ABCD", false, false);
-////		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
-//		rcInc.addMotif("XYZ", false, false);
-////		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().size());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
-//	}
 	@Test
 	public void includedRegionMappedReadsRS() {
 		rcInc.addMotif("ABCD", false, true);
 		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(null, rcInc.getMotifsForwardStrand());
-//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
 		
 		rcInc.addMotif("ABCD", false, true);
-//		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
 		rcInc.addMotif("XYZ", false, true);
-//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
 		assertEquals(2, rcInc.getMotifsReverseStrand().size());
 		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
 		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
 	}
-//	@Test
-//	public void includedRegionMappedReadsRS() {
-//		rcInc.addMotif("ABCD", false, true);
-//		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(null, rcInc.getMotifsForwardStrand());
-////		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		
-//		rcInc.addMotif("ABCD", false, true);
-////		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
-//		rcInc.addMotif("XYZ", false, true);
-////		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().size());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
-//	}
 	
 	@Test
 	public void includedRegion() {
 		rcInc.addMotif("ABCD", false, true);
 		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(null, rcInc.getMotifsForwardStrand());
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("DCBA", true, true);
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
 		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-//		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
-//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("123", false, false);
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
 		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-//		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
-//		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("321", true, false);
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
 		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
 		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
 		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("321"));
-//		assertEquals("DCBA:321", rcInc.getMotifsForwardStrand());
-//		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
 	}
-//	@Test
-//	public void includedRegion() {
-//		rcInc.addMotif("ABCD", false, true);
-//		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(null, rcInc.getMotifsForwardStrand());
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-////		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
-//		
-//		rcInc.addMotif("DCBA", true, true);
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-////		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
-////		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
-//		
-//		rcInc.addMotif("123", false, false);
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-////		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
-////		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
-//		
-//		rcInc.addMotif("321", true, false);
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("321"));
-////		assertEquals("DCBA:321", rcInc.getMotifsForwardStrand());
-////		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
-//	}
 	
 	@Test
 	public void unmappedRegion() {
@@ -240,36 +123,12 @@ public class RegionCounterTest {
 		
 		rcUn.addMotif("ABCD", true, false);
 		assertEquals(true, rcUn.hasMotifs());
-//		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
 		assertEquals(1, rcUn.getMotifsForwardStrand().get("ABCD").intValue());
 		
 		rcUn.addMotif("ABCD", false, false);
-//		assertEquals(true, rcUn.hasMotifs());
 		assertEquals(true, rcUn.getMotifsForwardStrand().containsKey("ABCD"));
 		assertEquals(true, rcUn.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
-//		assertEquals("ABCD", rcUn.getMotifsReverseStrand());
 	}
-//	@Test
-//	public void unmappedRegion() {
-//		rcUn.addMotif("ABCD", false, true);
-//		assertEquals(false, rcUn.hasMotifs());
-//		
-//		rcUn.addMotif("ABCD", true, true);
-//		assertEquals(false, rcUn.hasMotifs());
-//		
-//		rcUn.addMotif("ABCD", true, false);
-//		assertEquals(true, rcUn.hasMotifs());
-////		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
-//		assertEquals(true, rcUn.getMotifsForwardStrand().containsKey("ABCD"));
-//		
-//		rcUn.addMotif("ABCD", false, false);
-//		assertEquals(true, rcUn.hasMotifs());
-//		assertEquals(true, rcUn.getMotifsForwardStrand().containsKey("ABCD"));
-//		assertEquals(true, rcUn.getMotifsReverseStrand().containsKey("ABCD"));
-////		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
-////		assertEquals("ABCD", rcUn.getMotifsReverseStrand());
-//	}
 	
 	@Test
 	public void otherRegion() {
@@ -282,36 +141,11 @@ public class RegionCounterTest {
 		rcO.addMotif("ABCD", true, false);
 		assertEquals(true, rcO.hasMotifs());
 		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
-//		assertEquals("ABCD", rcO.getMotifsForwardStrand());
 		
 		rcO.addMotif("ABCD", false, false);
 		assertEquals(true, rcO.hasMotifs());
 		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
 		assertEquals(true, rcO.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals("ABCD", rcO.getMotifsForwardStrand());
-//		assertEquals("ABCD", rcO.getMotifsReverseStrand());
-		
 	}
-//	@Test
-//	public void otherRegion() {
-//		rcO.addMotif("ABCD", false, true);
-//		assertEquals(false, rcO.hasMotifs());
-//		
-//		rcO.addMotif("ABCD", true, true);
-//		assertEquals(false, rcO.hasMotifs());
-//		
-//		rcO.addMotif("ABCD", true, false);
-//		assertEquals(true, rcO.hasMotifs());
-//		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
-////		assertEquals("ABCD", rcO.getMotifsForwardStrand());
-//		
-//		rcO.addMotif("ABCD", false, false);
-//		assertEquals(true, rcO.hasMotifs());
-//		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
-//		assertEquals(true, rcO.getMotifsReverseStrand().containsKey("ABCD"));
-////		assertEquals("ABCD", rcO.getMotifsForwardStrand());
-////		assertEquals("ABCD", rcO.getMotifsReverseStrand());
-//		
-//	}
 	
 }

--- a/qmotif/test/org/qcmg/motif/util/RegionCounterTest.java
+++ b/qmotif/test/org/qcmg/motif/util/RegionCounterTest.java
@@ -45,17 +45,17 @@ public class RegionCounterTest {
 	public void includedRegionUnmappedReadsFS() {
 		rcInc.addMotif("ABCD", true, false);
 		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
-		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
+		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
 		
 		rcInc.addMotif("ABCD", true, false);
-//		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
-		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
+		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
+//		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
 		rcInc.addMotif("XYZ", true, false);
 //		assertEquals(2, rcInc.getMotifsForwardStrand().size());
-//		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
-		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
+		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
+		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
+//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
 	}
 //	@Test
 //	public void includedRegionUnmappedReadsFS() {
@@ -77,17 +77,17 @@ public class RegionCounterTest {
 	public void ncludedRegionMappedReadsFS() {
 		rcInc.addMotif("ABCD", true, true);
 		assertEquals(true, rcInc.hasMotifs());
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
-		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
-		assertEquals(null, rcInc.getMotifsReverseStrand());
+		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcInc.getMotifsForwardStrand());
+//		assertEquals(null, rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("ABCD", true, true);
-		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
+//		assertEquals("ABCD:ABCD", rcInc.getMotifsForwardStrand());
 		rcInc.addMotif("XYZ", true, true);
-		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
-//		assertEquals(2, rcInc.getMotifsForwardStrand().size());
-//		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
+//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsForwardStrand());
+		assertEquals(2, rcInc.getMotifsForwardStrand().size());
+		assertEquals(2, rcInc.getMotifsForwardStrand().get("ABCD").intValue());
+		assertEquals(1, rcInc.getMotifsForwardStrand().get("XYZ").intValue());
 	}
 //	@Test
 //	public void ncludedRegionMappedReadsFS() {
@@ -110,17 +110,17 @@ public class RegionCounterTest {
 	public void includedRegionUnmappedReadsRS() {
 		rcInc.addMotif("ABCD", false, false);
 		assertEquals(true, rcInc.hasMotifs());
-		assertEquals(null, rcInc.getMotifsForwardStrand());
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
+//		assertEquals(null, rcInc.getMotifsForwardStrand());
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("ABCD", false, false);
-		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
+//		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
 		rcInc.addMotif("XYZ", false, false);
-		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().size());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
+//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
+		assertEquals(2, rcInc.getMotifsReverseStrand().size());
+		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
+		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
 	}
 //	@Test
 //	public void includedRegionUnmappedReadsRS() {
@@ -142,17 +142,17 @@ public class RegionCounterTest {
 	public void includedRegionMappedReadsRS() {
 		rcInc.addMotif("ABCD", false, true);
 		assertEquals(true, rcInc.hasMotifs());
-		assertEquals(null, rcInc.getMotifsForwardStrand());
-		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
+//		assertEquals(null, rcInc.getMotifsForwardStrand());
+//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
 		
 		rcInc.addMotif("ABCD", false, true);
-		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
+//		assertEquals("ABCD:ABCD", rcInc.getMotifsReverseStrand());
 		rcInc.addMotif("XYZ", false, true);
-		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().size());
-//		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
-//		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
+//		assertEquals("ABCD:ABCD:XYZ", rcInc.getMotifsReverseStrand());
+		assertEquals(2, rcInc.getMotifsReverseStrand().size());
+		assertEquals(2, rcInc.getMotifsReverseStrand().get("ABCD").intValue());
+		assertEquals(1, rcInc.getMotifsReverseStrand().get("XYZ").intValue());
 	}
 //	@Test
 //	public void includedRegionMappedReadsRS() {
@@ -175,30 +175,30 @@ public class RegionCounterTest {
 	public void includedRegion() {
 		rcInc.addMotif("ABCD", false, true);
 		assertEquals(true, rcInc.hasMotifs());
-		assertEquals(null, rcInc.getMotifsForwardStrand());
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
+//		assertEquals(null, rcInc.getMotifsForwardStrand());
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("DCBA", true, true);
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
-		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
+		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
+//		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
+//		assertEquals("ABCD", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("123", false, false);
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
-		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
+		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
+//		assertEquals("DCBA", rcInc.getMotifsForwardStrand());
+//		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
 		
 		rcInc.addMotif("321", true, false);
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
-//		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
-//		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("321"));
-		assertEquals("DCBA:321", rcInc.getMotifsForwardStrand());
-		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("ABCD"));
+		assertEquals(true, rcInc.getMotifsReverseStrand().containsKey("123"));
+		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("DCBA"));
+		assertEquals(true, rcInc.getMotifsForwardStrand().containsKey("321"));
+//		assertEquals("DCBA:321", rcInc.getMotifsForwardStrand());
+//		assertEquals("ABCD:123", rcInc.getMotifsReverseStrand());
 	}
 //	@Test
 //	public void includedRegion() {
@@ -240,15 +240,15 @@ public class RegionCounterTest {
 		
 		rcUn.addMotif("ABCD", true, false);
 		assertEquals(true, rcUn.hasMotifs());
-		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
-//		assertEquals(true, rcUn.getMotifsForwardStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
+		assertEquals(1, rcUn.getMotifsForwardStrand().get("ABCD").intValue());
 		
 		rcUn.addMotif("ABCD", false, false);
 //		assertEquals(true, rcUn.hasMotifs());
-//		assertEquals(true, rcUn.getMotifsForwardStrand().containsKey("ABCD"));
-//		assertEquals(true, rcUn.getMotifsReverseStrand().containsKey("ABCD"));
-		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
-		assertEquals("ABCD", rcUn.getMotifsReverseStrand());
+		assertEquals(true, rcUn.getMotifsForwardStrand().containsKey("ABCD"));
+		assertEquals(true, rcUn.getMotifsReverseStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcUn.getMotifsForwardStrand());
+//		assertEquals("ABCD", rcUn.getMotifsReverseStrand());
 	}
 //	@Test
 //	public void unmappedRegion() {
@@ -281,15 +281,15 @@ public class RegionCounterTest {
 		
 		rcO.addMotif("ABCD", true, false);
 		assertEquals(true, rcO.hasMotifs());
-//		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
-		assertEquals("ABCD", rcO.getMotifsForwardStrand());
+		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcO.getMotifsForwardStrand());
 		
 		rcO.addMotif("ABCD", false, false);
 		assertEquals(true, rcO.hasMotifs());
-//		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
-//		assertEquals(true, rcO.getMotifsReverseStrand().containsKey("ABCD"));
-		assertEquals("ABCD", rcO.getMotifsForwardStrand());
-		assertEquals("ABCD", rcO.getMotifsReverseStrand());
+		assertEquals(true, rcO.getMotifsForwardStrand().containsKey("ABCD"));
+		assertEquals(true, rcO.getMotifsReverseStrand().containsKey("ABCD"));
+//		assertEquals("ABCD", rcO.getMotifsForwardStrand());
+//		assertEquals("ABCD", rcO.getMotifsReverseStrand());
 		
 	}
 //	@Test


### PR DESCRIPTION
# Description

During a recent piece of work where `qmotif` was run against a thousand bam files, it became apparent that it was running out of memory.
These runs were different to normal in that we were looking at all regions of the genome rather than just the starts and ends of chromosomes as is usually done.

What was happening was that the SAMRecords that contained the motifs of interest were being stored in a queue until all the processing was done, and then written to file. With much larger regions than normal, this meant that a large number of SAMRecords were stored in memory, resulting in the `OutOfMemoryErrors` and high thread use due to GC.

The solution was to create a thread that writes the SAMRecords to file at the start of the process. This writer thread picks up the SAMRecords as they are placed into the queue meaning that they don't sit in memory.

A couple of other minor fixes have also been included in this PR:

- cached the hashCode value in `ChrPositionName` - this was using a (relatively) large amount of cpu time as `ChrPositionName` is a key in a widely used map. Caching this reduces cpu use here.
 - Changed from having a `StringBuilder` to represent the motifs found in a region to a map. This is really weird as judging by the code, maps were used originally and then changed to StringBuilder. This is really not sensible as when running with large regions, there will be a huge number of (duplicated) entries in the `StringBuilder`. Reverted back.
 - fixed some styling on classes that were updated


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
Have run the updated code and compared against an existing output, and results were the same.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
