### PR TITLE
set html output to enable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
         reports {
             html {
                 enabled = true
-                destination = file("$buildDir/reports/spotbugs/main/spotbugs.html")
+                destination = file("$buildDir/reports/spotbugs/spotbugs.html")
                 stylesheet = 'fancy-hist.xsl'
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,16 @@ subprojects {
 	ignoreFailures = true
 	spotbugsTest.enabled = false
     }
+    //output to html, the default is xml
+    spotbugsMain {
+        reports {
+            html {
+                enabled = true
+                destination = file("$buildDir/reports/spotbugs/main/spotbugs.html")
+                stylesheet = 'fancy-hist.xsl'
+            }
+        }
+    }
 
     //config checkstyle
     checkstyle {


### PR DESCRIPTION
# Description

The default output of spotbugs is XML file, here we set it to HTML which is easy to read by human eye. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

run gradle build and read the html output

# Checklist:

- [X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [X  ] New and existing unit tests pass locally with my changes
