### PR TITLE
set default header discriminator hash

### DIFF
--- a/qio/src/org/qcmg/qio/record/RecordReader.java
+++ b/qio/src/org/qcmg/qio/record/RecordReader.java
@@ -71,7 +71,6 @@ public abstract class RecordReader<T> implements Closeable, Iterable<T> {
      */
     public String readHeaderAndReturnFirstNonHeaderLine(CharSequence headerPrefix ) throws IOException {
 
-
     	String nextLine = bin.readLine();
     	
     	//keep empty header and return first nonHeaderline

--- a/qio/src/org/qcmg/qio/record/StringFileReader.java
+++ b/qio/src/org/qcmg/qio/record/StringFileReader.java
@@ -2,6 +2,8 @@ package org.qcmg.qio.record;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+
 import org.qcmg.common.util.Constants;
 
 public class StringFileReader  extends RecordReader<String> {
@@ -9,16 +11,22 @@ public class StringFileReader  extends RecordReader<String> {
 	
  
 	public StringFileReader(File file) throws IOException {
-		super(file, HEADER_PREFIX);
+		super(file, DEFAULT_BUFFER_SIZE, HEADER_PREFIX, DEFAULT_CHARSET); 
 	}
 
 	public StringFileReader(File file, CharSequence headerPrefix) throws IOException {
-		super(file, headerPrefix);
+	 
+		super(file, DEFAULT_BUFFER_SIZE, headerPrefix, DEFAULT_CHARSET); 
 	}
 	
 	public StringFileReader(File file, int bufferSize) throws IOException {
-		super(file, bufferSize);
+		super(file, bufferSize, HEADER_PREFIX, DEFAULT_CHARSET); 
 	}
+	
+	public StringFileReader(final File file, int bufferSize, CharSequence headerPrefix, Charset charset) throws IOException {
+		super(file, bufferSize, headerPrefix, charset); 
+	}	
+	
 
 	@Override
 	/**

--- a/qio/test/org/qcmg/qio/record/RecordReaderWriterTest.java
+++ b/qio/test/org/qcmg/qio/record/RecordReaderWriterTest.java
@@ -19,7 +19,7 @@ import org.qcmg.qio.record.StringFileReader;
 import org.qcmg.qio.record.RecordWriter;
 import org.qcmg.common.util.Constants;
 
-public class RecordWriterTest {
+public class RecordReaderWriterTest {
 	
 	public static final String[] vcfStrings = new String[] {"##test=test", VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE};
 	public static final String[] parms = {"chrY","2675826",".","TG","CA",".","COVN12;MIUN","SOMATIC;NNS=4;END=2675826","ACCS","TG,5,37,CA,0,2","AA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1"};
@@ -72,8 +72,7 @@ public class RecordWriterTest {
 		} catch (Exception e) { 
 			//null is not allowed
 		}
-		
-		
+			
 		//now it become a valid vcf file
 		try(StringFileReader reader = new StringFileReader(file);){ 
 			int count = 0;
@@ -104,7 +103,6 @@ public class RecordWriterTest {
 			assertEquals( 0, count );				
 		} catch (Exception e) { fail();}		
 
-
 		//append to file
 		try(RecordWriter<VcfRecord> writer = new RecordWriter<>(file,true)   ){
 			 writer.addHeader(vcfStrings[1]);	
@@ -123,8 +121,6 @@ public class RecordWriterTest {
 				count++;
 			}
 			assertEquals(2,  count );		
-		} catch (Exception e) {fail(); }		
-		
+		} catch (Exception e) {fail(); }			
 	}
-
 }

--- a/qio/test/org/qcmg/qio/record/StringFileReaderTest.java
+++ b/qio/test/org/qcmg/qio/record/StringFileReaderTest.java
@@ -1,0 +1,79 @@
+package org.qcmg.qio.record;
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.util.Constants;
+import org.qcmg.common.vcf.VcfRecord;
+import org.qcmg.common.vcf.header.VcfHeaderUtils;
+
+ 
+public class StringFileReaderTest {
+
+	@Rule
+	public  TemporaryFolder testFolder = new TemporaryFolder();
+
+	public static final String[] vcfStrings = new String[] {"##test=test", VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE};
+	public static final String[] parms = {"chrY","2675826",".","TG","CA",".","COVN12;MIUN","SOMATIC;NNS=4;END=2675826","ACCS","TG,5,37,CA,0,2","AA,1,1,CA,4,1,CT,3,1,TA,11,76,TG,2,2,TG,0,1"};
+	
+	@Test
+	public void getHeaderFromtxtFile1() throws IOException {
+		File f = testFolder.newFile();
+		createFile(f);
+		
+		//test StringFileReader(File file)
+		try(StringFileReader reader = new StringFileReader(f);) {
+			assertEquals( 2, reader.getHeader().size());
+			int count = 0;
+			for(String rec : reader) { count ++; }
+			assertEquals( 1, count);
+		}
+		
+		//test StringFileReader(File file, CharSequence headerPrefix)
+		try(StringFileReader reader = new StringFileReader(f, "##");) {
+			assertEquals( 1, reader.getHeader().size());
+			int count = 0;
+			for(String rec : reader) { count ++; }
+			assertEquals( 2, count);
+		}
+		
+		//test StringFileReader(File file, int bufferSize)
+		try(StringFileReader reader = new StringFileReader(f, 512);) {
+			assertEquals( 2, reader.getHeader().size());
+			int count = 0;
+			for(String rec : reader) { count ++; }
+			assertEquals( 1, count);
+		}	
+		
+		//test StringFileReader(final File file, int bufferSize, CharSequence headerPrefix, Charset charset)
+		try(StringFileReader reader = new StringFileReader(f, 512, "##", StandardCharsets.UTF_8);) {
+			assertEquals( 1, reader.getHeader().size());
+			int count = 0;
+			for(String rec : reader) { count ++; }
+			assertEquals( 2, count);
+		}		
+		
+	}
+	
+	private void createFile(File f) throws IOException {
+		
+		
+		//append two string into file
+		try(RecordWriter<String> writer = new RecordWriter<>(f)) {
+			writer.addHeader(Arrays.stream(vcfStrings).collect(Collectors.joining("\n")));
+			writer.add(new VcfRecord(parms).toString());
+		}  
+
+	}
+
+}


### PR DESCRIPTION
# Description

The default file header discriminator is different between `StringFileReader` and its parent class `RecordReader`.  Constructor `StringFileReader(File file, int bufferSize)` uses the default header discriminator from the parent class, which is null. Here we fix it by changing it to `HASH_STRING`. 
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

new unit tests added.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

