### PR TITLE
qsignature - allow snpPositions file to have headers

### DIFF
--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
@@ -187,7 +187,6 @@ public class SignatureGeneratorBespokeTest {
 	@Test
     public void runProcessWithHG19BamFile() throws Exception {
     	final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
-    	final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
     	final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
     	final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
     	final String outputFIleName = bamFile.getAbsolutePath() + ".qsig.vcf.gz";
@@ -195,10 +194,9 @@ public class SignatureGeneratorBespokeTest {
 	    	
 	//    	writeSnpChipFile(snpChipFile);
 	    SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
-	    SignatureGeneratorTest.writeIlluminaArraysDesignFile(illuminaArraysDesignFile);
 	    SignatureGeneratorTest.getBamFile(bamFile, true, false);
 	    	
-    	final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath(),  "-illuminaArraysDesign" , illuminaArraysDesignFile.getAbsolutePath()} );
+    	final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath()} );
     	assertEquals(0, exitStatus);
     	
     	assertTrue(outputFile.exists());
@@ -207,7 +205,7 @@ public class SignatureGeneratorBespokeTest {
     	try (VcfFileReader reader = new VcfFileReader(outputFile);) {    			
 	    	for (final VcfRecord rec : reader) {
 	    		recs.add(rec);
-	    		System.out.println("rec: " + rec.toString());
+//	    		System.out.println("rec: " + rec.toString());
 	    	}
 	    	VcfHeader header = reader.getVcfHeader();
 	    	assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg0=null")));
@@ -223,19 +221,19 @@ public class SignatureGeneratorBespokeTest {
     }
 	
 	@Test
-	public void runProcessWithReadGroupsSetInHeader() throws Exception {
-		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
-		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
-		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
-		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
-		final String outputFIleName = bamFile.getAbsolutePath() + ".qsig.vcf.gz";
-		final File outputFile = new File(outputFIleName);
+	public void runProcessWithSnpChipFile() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithSnpChipFile.snps.txt");
+		final File snpChipFile = testFolder.newFile("runProcessWithSnpChipFile.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithSnpChipFile.illumina.txt");
+		final File logFile = testFolder.newFile("runProcessWithSnpChipFile.log");
+		final String outputFileName = snpChipFile.getAbsolutePath() + ".qsig.vcf.gz";
+		final File outputFile = new File(outputFileName);
 		
-		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
+		SignatureGeneratorTest.writeSnpChipFile(snpChipFile);
+		SignatureGeneratorTest.writeSnpPositionsFileWithHeader(positionsOfInterestFile);
 		SignatureGeneratorTest.writeIlluminaArraysDesignFile(illuminaArraysDesignFile);
-		SignatureGeneratorTest.getBamFile(bamFile, true, false, true);
 		
-		final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath(),  "-illuminaArraysDesign" , illuminaArraysDesignFile.getAbsolutePath()} );
+		final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , snpChipFile.getAbsolutePath(),"-illuminaArraysDesign", illuminaArraysDesignFile.getAbsolutePath()} );
 		assertEquals(0, exitStatus);
 		
 		assertTrue(outputFile.exists());
@@ -244,10 +242,78 @@ public class SignatureGeneratorBespokeTest {
 		try (VcfFileReader reader = new VcfFileReader(outputFile);) {    			
 			for (final VcfRecord rec : reader) {
 				recs.add(rec);
-				System.out.println("rec: " + rec.toString());
+//	    		System.out.print("rec: " + rec.toString());
 			}
 			VcfHeader header = reader.getVcfHeader();
-	    	header.getAllMetaRecords().stream().forEach(System.out::println);
+			assertEquals(false, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg0=null")));	// no rgs in snp chips
+		}
+		
+		assertEquals(3, recs.size());
+		assertEquals("QAF=t:0-0-0-30", recs.get(0).getInfo());
+		assertEquals("QAF=t:0-0-24-0", recs.get(1).getInfo());
+		assertEquals("QAF=t:10-0-10-0", recs.get(2).getInfo());
+	}
+	
+	@Test
+	public void runProcessWithSnpPositionsHeader() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithSnpPositionsHeader.snps.txt");
+		final File bamFile = testFolder.newFile("runProcessWithSnpPositionsHeader.bam");
+		final File logFile = testFolder.newFile("runProcessWithSnpPositionsHeader.log");
+		final String outputFIleName = bamFile.getAbsolutePath() + ".qsig.vcf.gz";
+		final File outputFile = new File(outputFIleName);
+		
+		//    	writeSnpChipFile(snpChipFile);
+		SignatureGeneratorTest.writeSnpPositionsFileWithHeader(positionsOfInterestFile);
+		SignatureGeneratorTest.getBamFile(bamFile, true, false);
+		
+		final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath()} );
+		assertEquals(0, exitStatus);
+		
+		assertTrue(outputFile.exists());
+		
+		final List<VcfRecord> recs = new ArrayList<>();
+		try (VcfFileReader reader = new VcfFileReader(outputFile);) {    			
+			for (final VcfRecord rec : reader) {
+				recs.add(rec);
+//				System.out.print("rec: " + rec.toString());
+			}
+			VcfHeader header = reader.getVcfHeader();
+			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg0=null")));
+		}
+		
+		assertEquals(6, recs.size());
+		assertEquals("QAF=t:0-0-0-10,rg0:0-0-0-10", recs.get(0).getInfo());
+		assertEquals("QAF=t:20-0-0-0,rg0:20-0-0-0", recs.get(1).getInfo());
+		assertEquals("QAF=t:0-10-0-0,rg0:0-10-0-0", recs.get(2).getInfo());
+		assertEquals("QAF=t:0-0-0-20,rg0:0-0-0-20", recs.get(3).getInfo());
+		assertEquals("QAF=t:0-10-0-0,rg0:0-10-0-0", recs.get(4).getInfo());
+		assertEquals("QAF=t:0-20-0-0,rg0:0-20-0-0", recs.get(5).getInfo());
+	}
+	
+	@Test
+	public void runProcessWithReadGroupsSetInHeader() throws Exception {
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithReadGroupsSetInHeader.snps.txt");
+		final File bamFile = testFolder.newFile("runProcessWithReadGroupsSetInHeader.bam");
+		final File logFile = testFolder.newFile("runProcessWithReadGroupsSetInHeader.log");
+		final String outputFIleName = bamFile.getAbsolutePath() + ".qsig.vcf.gz";
+		final File outputFile = new File(outputFIleName);
+		
+		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
+		SignatureGeneratorTest.getBamFile(bamFile, true, false, true);
+		
+		final int exitStatus = qss.setup(new String[] {"--log" , logFile.getAbsolutePath(), "-snpPositions" , positionsOfInterestFile.getAbsolutePath(), "-i" , bamFile.getAbsolutePath()} );
+		assertEquals(0, exitStatus);
+		
+		assertTrue(outputFile.exists());
+		
+		final List<VcfRecord> recs = new ArrayList<>();
+		try (VcfFileReader reader = new VcfFileReader(outputFile);) {    			
+			for (final VcfRecord rec : reader) {
+				recs.add(rec);
+//				System.out.println("rec: " + rec.toString());
+			}
+			VcfHeader header = reader.getVcfHeader();
+//	    	header.getAllMetaRecords().stream().forEach(System.out::println);
 			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg0=null")));
 			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg1=20130325103517169")));
 			assertEquals(true, header.getAllMetaRecords().contains(new VcfHeaderRecord("##rg2=20130325112045146")));
@@ -265,10 +331,10 @@ public class SignatureGeneratorBespokeTest {
 	
 	@Test
 	public void runProcessWithNoOutputOption() throws Exception {
-		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
-		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
-		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
-		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithNoOutputOption.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithNoOutputOption.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithNoOutputOption.bam");
+		final File logFile = testFolder.newFile("runProcessWithNoOutputOption.log");
 		
 		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
 		
@@ -288,10 +354,10 @@ public class SignatureGeneratorBespokeTest {
 		
 	@Test
 	public void runProcessWithOutputOptionFile() throws Exception {
-		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
-		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
-		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
-		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithOutputOptionFile.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithOutputOptionFile.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithOutputOptionFile.bam");
+		final File logFile = testFolder.newFile("runProcessWithOutputOptionFile.log");
 		
 		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
 		/*
@@ -311,10 +377,10 @@ public class SignatureGeneratorBespokeTest {
 	
 	@Test
 	public void runProcessWithOutputOptionDir() throws Exception {
-		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
-		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
-		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
-		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithOutputOptionDir.snps.txt");
+		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithOutputOptionDir.illuminaarray.txt");
+		final File bamFile = testFolder.newFile("runProcessWithOutputOptionDir.bam");
+		final File logFile = testFolder.newFile("runProcessWithOutputOptionDir.log");
 		
 		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
 		/*
@@ -331,14 +397,12 @@ public class SignatureGeneratorBespokeTest {
 		assertTrue(new File(outputFolder + File.separator + bamFile.getName() + ".qsig.vcf.gz").exists());
 		assertTrue(new File(outputFolder + File.separator + bamFile.getName() + ".qsig.vcf.gz").length() > 0);
 	}
-		
-		
+
 	@Test
 	public void runProcessWithDirOption() throws Exception {
-		final File positionsOfInterestFile = testFolder.newFile("runProcessWithHG19BamFile.snps.txt");
-		final File illuminaArraysDesignFile = testFolder.newFile("runProcessWithHG19BamFile.illuminaarray.txt");
-		final File bamFile = testFolder.newFile("runProcessWithHG19BamFile.bam");
-		final File logFile = testFolder.newFile("runProcessWithHG19BamFile.log");
+		final File positionsOfInterestFile = testFolder.newFile("runProcessWithDirOption.snps.txt");
+		final File bamFile = testFolder.newFile("runProcessWithDirOption.bam");
+		final File logFile = testFolder.newFile("runProcessWithDirOption.log");
 		
 		SignatureGeneratorTest.writeSnpPositionsFile(positionsOfInterestFile);
 		/*
@@ -349,8 +413,7 @@ public class SignatureGeneratorBespokeTest {
 		int exitStatus = qss.setup(new String[] {"--log", logFile.getAbsolutePath(), 
 				"-snpPositions", positionsOfInterestFile.getAbsolutePath(), 
 				"-i", bamFile.getAbsolutePath(),  
-				"-d", dir,  
-				"-illuminaArraysDesign", illuminaArraysDesignFile.getAbsolutePath()} );
+				"-d", dir});
 		assertEquals(0, exitStatus);
 		assertEquals(true, new File(dir + File.separator + bamFile.getName() + ".qsig.vcf.gz").exists());
 		assertTrue(new File(dir + File.separator + bamFile.getName() + ".qsig.vcf.gz").length() > 0);
@@ -389,12 +452,13 @@ public class SignatureGeneratorBespokeTest {
 		String name = dir + File.separator + bamFile.getName() + ".qsig.vcf.gz";
 		assertEquals(true, new File(name).exists());
 		assertTrue(new File(name).length() > 0);
-		VcfFileReader reader = new VcfFileReader(new File(name));
-		int vcfRecordCounter = 0;
-		for (VcfRecord rec : reader) {
-			vcfRecordCounter++;
+		try (VcfFileReader reader = new VcfFileReader(new File(name));) {
+			int vcfRecordCounter = 0;
+			for (VcfRecord rec : reader) {
+				vcfRecordCounter++;
+			}
+			assertEquals(97, vcfRecordCounter);
 		}
-		assertEquals(97, vcfRecordCounter);
 	}
 	
 	@Test
@@ -420,12 +484,13 @@ public class SignatureGeneratorBespokeTest {
 		String name = dir + File.separator + bamFile.getName() + ".qsig.vcf.gz";
 		assertEquals(true, new File(name).exists());
 		assertTrue(new File(name).length() > 0);
-		VcfFileReader reader = new VcfFileReader(new File(name));
-		int vcfRecordCounter = 0;
-		for (VcfRecord rec : reader) {
-			vcfRecordCounter++;
+		try (VcfFileReader reader = new VcfFileReader(new File(name));) {
+			int vcfRecordCounter = 0;
+			for (VcfRecord rec : reader) {
+				vcfRecordCounter++;
+			}
+			assertEquals(0, vcfRecordCounter);
 		}
-		assertEquals(0, vcfRecordCounter);
 	}
 	@Test
 	public void runProcessWithGenePositionsOptioPartialOverlap() throws Exception {
@@ -450,12 +515,13 @@ public class SignatureGeneratorBespokeTest {
 		String name = dir + File.separator + bamFile.getName() + ".qsig.vcf.gz";
 		assertEquals(true, new File(name).exists());
 		assertTrue(new File(name).length() > 0);
-		VcfFileReader reader = new VcfFileReader(new File(name));
-		int vcfRecordCounter = 0;
-		for (VcfRecord rec : reader) {
-			vcfRecordCounter++;
+		try (VcfFileReader reader = new VcfFileReader(new File(name));) {
+			int vcfRecordCounter = 0;
+			for (VcfRecord rec : reader) {
+				vcfRecordCounter++;
+			}
+			assertEquals(50, vcfRecordCounter);		// records start at position 150, gene ends at 200
 		}
-		assertEquals(50, vcfRecordCounter);		// records start at position 150, gene ends at 200
 	}
 	
 	

--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorBespokeTest.java
@@ -310,7 +310,7 @@ public class SignatureGeneratorBespokeTest {
 		try (VcfFileReader reader = new VcfFileReader(outputFile);) {    			
 			for (final VcfRecord rec : reader) {
 				recs.add(rec);
-//				System.out.println("rec: " + rec.toString());
+//				System.out.print("rec: " + rec.toString());
 			}
 			VcfHeader header = reader.getVcfHeader();
 //	    	header.getAllMetaRecords().stream().forEach(System.out::println);

--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorTest.java
@@ -294,12 +294,12 @@ public class SignatureGeneratorTest {
     }
     static void writeSnpPositionsFile(File snpPositions) throws IOException {
     	try (Writer writer = new FileWriter(snpPositions);) {
-    		writer.write("chr3	183635768	random_1016708	C	RANDOM_POSITION\n");
-    		writer.write("chr4	75406448	random_649440	A	RANDOM_POSITION\n");
-    		writer.write("chr4	95733906	random_1053689	G	RANDOM_POSITION\n");
-    		writer.write("chr4	108826383	random_1146989	T	RANDOM_POSITION\n");
-    		writer.write("chr4	159441457	random_1053689	G	RANDOM_POSITION\n");
-    		writer.write("chr12	126890980	random_169627	G	RANDOM_POSITION\n");
+    		writer.write("chr3	183635768	random_1016708		C		RANDOM_POSITION\n");
+    		writer.write("chr4	75406448	random_649440		A		RANDOM_POSITION\n");
+    		writer.write("chr4	95733906	random_1053689		G		RANDOM_POSITION\n");
+    		writer.write("chr4	108826383	random_1146989		T		RANDOM_POSITION\n");
+    		writer.write("chr4	159441457	random_1053689		G		RANDOM_POSITION\n");
+    		writer.write("chr12	126890980	random_169627		G		RANDOM_POSITION\n");
     	}
     }
     

--- a/qsignature/test/org/qcmg/sig/SignatureGeneratorTest.java
+++ b/qsignature/test/org/qcmg/sig/SignatureGeneratorTest.java
@@ -49,8 +49,6 @@ public class SignatureGeneratorTest {
 		qss.logger = QLoggerFactory.getLogger(SignatureGeneratorTest.class);
 	}
 	
-	
-	
 	@Test
 	public void testPatientRegex() {
 		Assert.assertEquals(true, "APGI_1992".matches(SignatureUtil.PATIENT_REGEX));
@@ -227,13 +225,14 @@ public class SignatureGeneratorTest {
    	
     	final List<VcfRecord> recs = new ArrayList<>();
     	try (VcfFileReader reader = new VcfFileReader(outputFile);) {    			
-	    	for (final VcfRecord rec : reader) 
+	    	for (final VcfRecord rec : reader) {
 	    		recs.add(rec);
+		    	System.out.print("rec: " + rec.toString());
+	    	}
     	}
        	
     	assertEquals(6, recs.size());
     }
-    
     
     @Test
     public void runProcessWithHG19BamFile() throws Exception {
@@ -257,7 +256,7 @@ public class SignatureGeneratorTest {
 	    	try (VcfFileReader reader = new VcfFileReader(outputFile);) {    			
 		    	for (final VcfRecord rec : reader) {
 		    		recs.add(rec);
-		    		System.out.println("rec: " + rec.toString());
+		    		System.out.print("rec: " + rec.toString());
 		    	}
 	    	}
 	       	
@@ -265,43 +264,59 @@ public class SignatureGeneratorTest {
     }
     
     static void writeSnpChipFile(File snpChipFile) throws IOException {
-	    	try (Writer writer = new FileWriter(snpChipFile);) {
-		    	writer.write("[Header]\n");
-		    	writer.write("GSGT Version    1.9.4\n");
-		    	writer.write("Processing Date 3/1/2013 9:06 PM\n");
-		    	writer.write("Content         HumanOmni2.5-8v1_A.bpm\n");
-		    	writer.write("Num SNPs        2379855\n");
-		    	writer.write("Total SNPs      2379855\n");
-		    	writer.write("Num Samples     57\n");
-		    	writer.write("Total Samples   57\n");
-		    	writer.write("File    31 of 57\n");
-		    	writer.write("[Data]\n");
-		    	writer.write("SNP Name        Sample ID       Allele1 - Top   Allele2 - Top   GC Score        Sample Name     Sample Group    Sample Index    SNP Index       SNP Aux Allele1 - Forward       Allele2 - Forward       Allele1 - Design        Allele2 - Design        Allele1 - AB    Allele2 - AB    Chr     Position        GT Score        Cluster Sep     SNP     ILMN Strand     Customer Strand Top Genomic Sequence    Theta   R       X       Y       X Raw   Y Raw   B Allele Freq   Log R Ratio\n");
-		    	writer.write("rs1000000	WG0227767_DNAG01_LP6005272_DNA_G01	A	G	0.8140	AOCS_094_5_6	G01	20	381565	0	T	C	T	C	A	B	12	126890980	0.7990	1.0000	[T/C]	BOT	BOT		0.444	2.019	1.099	0.920	13935	7437	0.5219	0.0314\n");
-		    	writer.write("rs10000023	WG0227769_DNAG01_LP6005274_DNA_G01	C	C	0.8221	AOCS_094_1_1	G01	31	691448	0	G	G	G	G	B	B	4	95733906	0.8042	1.0000	[T/G]	BOT	BOT		0.970	1.928	0.086	1.843	1593	18194	1.0000	0.1902\n");
-		    	writer.write("rs1000002	WG0227768_DNAG01_LP6005273_DNA_G01	A	A	0.8183	AOCS_094_6_7	UQueensland_Grimmond2	157	719472	0	A	A	A	A	A	A	3	183635768	0.8018	0.4106	[A/G]	TOP	TOP		0.039	0.745	0.702	0.043	5494	277	0.0000	0.4090\n");
-	    	}
+    	try (Writer writer = new FileWriter(snpChipFile);) {
+	    	writer.write("[Header]\n");
+	    	writer.write("GSGT Version    1.9.4\n");
+	    	writer.write("Processing Date 3/1/2013 9:06 PM\n");
+	    	writer.write("Content         HumanOmni2.5-8v1_A.bpm\n");
+	    	writer.write("Num SNPs        2379855\n");
+	    	writer.write("Total SNPs      2379855\n");
+	    	writer.write("Num Samples     57\n");
+	    	writer.write("Total Samples   57\n");
+	    	writer.write("File    31 of 57\n");
+	    	writer.write("[Data]\n");
+	    	writer.write("SNP Name        Sample ID       Allele1 - Top   Allele2 - Top   GC Score        Sample Name     Sample Group    Sample Index    SNP Index       SNP Aux Allele1 - Forward       Allele2 - Forward       Allele1 - Design        Allele2 - Design        Allele1 - AB    Allele2 - AB    Chr     Position        GT Score        Cluster Sep     SNP     ILMN Strand     Customer Strand Top Genomic Sequence    Theta   R       X       Y       X Raw   Y Raw   B Allele Freq   Log R Ratio\n");
+	    	writer.write("rs1000000	WG0227767_DNAG01_LP6005272_DNA_G01	A	G	0.8140	AOCS_094_5_6	G01	20	381565	0	T	C	T	C	A	B	12	126890980	0.7990	1.0000	[T/C]	BOT	BOT		0.444	2.019	1.099	0.920	13935	7437	0.5219	0.0314\n");
+	    	writer.write("rs10000023	WG0227769_DNAG01_LP6005274_DNA_G01	C	C	0.8221	AOCS_094_1_1	G01	31	691448	0	G	G	G	G	B	B	4	95733906	0.8042	1.0000	[T/G]	BOT	BOT		0.970	1.928	0.086	1.843	1593	18194	1.0000	0.1902\n");
+	    	writer.write("rs1000002	WG0227768_DNAG01_LP6005273_DNA_G01	A	A	0.8183	AOCS_094_6_7	UQueensland_Grimmond2	157	719472	0	A	A	A	A	A	A	3	183635768	0.8018	0.4106	[A/G]	TOP	TOP		0.039	0.745	0.702	0.043	5494	277	0.0000	0.4090\n");
+    	}
     }
     static void writeIlluminaArraysDesignFile(File illuminaArraysDesign) throws IOException {
-	    	try (Writer writer = new FileWriter(illuminaArraysDesign);) {
-	    		writer.write("#dbSNP Id	Reference Genome	dbSNP alleles	Chr	Position(hg19)	dbSNP Strand	IlluminaDesign	ComplementArrayCalls?\n");
+    	try (Writer writer = new FileWriter(illuminaArraysDesign);) {
+    		writer.write("#dbSNP Id	Reference Genome	dbSNP alleles	Chr	Position(hg19)	dbSNP Strand	IlluminaDesign	ComplementArrayCalls?\n");
 			writer.write("rs1000000	G	C/T	chr12	126890980	-	[T/C]	yes\n");
 			writer.write("rs10000004	A	A/G	chr4	75406448	+	[T/C]	yes\n");
 			writer.write("rs10000006	T	C/T	chr4	108826383	+	[A/G]	yes\n");
 			writer.write("rs1000002	C	A/G	chr3	183635768	-	[A/G]	yes\n");
 			writer.write("rs10000021	G	G/T	chr4	159441457	+	[A/C]	yes\n");
 			writer.write("rs10000023	G	G/T	chr4	95733906	+	[T/G]	no\n");
-	    	}
+    	}
     }
     static void writeSnpPositionsFile(File snpPositions) throws IOException {
-	    	try (Writer writer = new FileWriter(snpPositions);) {
-	    		writer.write("chr3	183635768	random_1016708	C	RANDOM_POSITION\n");
-	    		writer.write("chr4	75406448	random_649440	A	RANDOM_POSITION\n");
-	    		writer.write("chr4	95733906	random_1053689	G	RANDOM_POSITION\n");
-	    		writer.write("chr4	108826383	random_1146989	T	RANDOM_POSITION\n");
-	    		writer.write("chr4	159441457	random_1053689	G	RANDOM_POSITION\n");
-	    		writer.write("chr12	126890980	random_169627	G	RANDOM_POSITION\n");
-	    	}
+    	try (Writer writer = new FileWriter(snpPositions);) {
+    		writer.write("chr3	183635768	random_1016708	C	RANDOM_POSITION\n");
+    		writer.write("chr4	75406448	random_649440	A	RANDOM_POSITION\n");
+    		writer.write("chr4	95733906	random_1053689	G	RANDOM_POSITION\n");
+    		writer.write("chr4	108826383	random_1146989	T	RANDOM_POSITION\n");
+    		writer.write("chr4	159441457	random_1053689	G	RANDOM_POSITION\n");
+    		writer.write("chr12	126890980	random_169627	G	RANDOM_POSITION\n");
+    	}
+    }
+    
+    /*
+     * looks a little like a vcf file....
+     */
+    static void writeSnpPositionsFileWithHeader(File snpPositions) throws IOException {
+    	try (Writer writer = new FileWriter(snpPositions);) {
+    		writer.write("##fileformat=VCFv4.2\n");
+    		writer.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n");
+    		writer.write("chr3	183635768	random_1016708	C	.\t.\t.\t.\n");
+    		writer.write("chr4	75406448	random_649440	A	.\t.\t.\t.\n");
+    		writer.write("chr4	95733906	random_1053689	G	.\t.\t.\t.\n");
+    		writer.write("chr4	108826383	random_1146989	T	.\t.\t.\t.\n");
+    		writer.write("chr4	159441457	random_1053689	G	.\t.\t.\t.\n");
+    		writer.write("chr12	126890980	random_169627	G	.\t.\t.\t.\n");
+    	}
     }
     static void writeGenePositionsFile(File genePositions, String chr, int start, int stop) throws IOException {
     	try (Writer writer = new FileWriter(genePositions);) {
@@ -316,21 +331,24 @@ public class SignatureGeneratorTest {
     static void getBamFile(File bamFile, boolean validHeader, boolean useChrs) {
     	getBamFile(bamFile,  validHeader,  useChrs, false);
     }
+    
     static void getBamFile(File bamFile, boolean validHeader, boolean useChrs, boolean addReadGroupToHeaderAndRecords) {
-	    	final SAMFileHeader header = getHeader(validHeader, useChrs, addReadGroupToHeaderAndRecords);
-	    	List<SAMRecord> data = getRecords(useChrs, header, true, addReadGroupToHeaderAndRecords);
-	    	final SAMOrBAMWriterFactory factory = new SAMOrBAMWriterFactory(header, false, bamFile, false);
-	    	try {
-	    		final SAMFileWriter writer = factory.getWriter();
-	    		if (null != data)
-	    			for (final SAMRecord s : data) writer.addAlignment(s);
-	    	} finally {
-	    		factory.closeWriter();
-	    	}
+    	final SAMFileHeader header = getHeader(validHeader, useChrs, addReadGroupToHeaderAndRecords);
+    	List<SAMRecord> data = getRecords(useChrs, header, true, addReadGroupToHeaderAndRecords);
+    	final SAMOrBAMWriterFactory factory = new SAMOrBAMWriterFactory(header, false, bamFile, false);
+    	try {
+    		final SAMFileWriter writer = factory.getWriter();
+    		if (null != data)
+    			for (final SAMRecord s : data) writer.addAlignment(s);
+    	} finally {
+    		factory.closeWriter();
+    	}
     }
+    
     public static SAMFileHeader getHeader(boolean valid, boolean useChrs) {
     	return getHeader(valid, useChrs, false);
-    }    
+    }
+    
 	public static SAMFileHeader getHeader(boolean valid, boolean useChrs, boolean addReadGroups) {
 		final SAMFileHeader header = new SAMFileHeader();
 		
@@ -485,9 +503,7 @@ public class SignatureGeneratorTest {
 			if (addRG) {
 				sam.setAttribute("RG", "20130325112045146");
 			}
-		
 		}
-		
 		return records;
 	}
 	


### PR DESCRIPTION
# Description

`qsignature` fails if the snp positions file contains a header.
This has been fine in the past, because we only ever had a single snp positions file.
There is now some work being done to create a GRCh38 version of the snp positions file, and having a header in the file would be very useful.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Additional unit tests have been added to test that snp positions files with headers (as well as those without) can be loaded correctly
Additionally, the project was build and run against a production WGS bam file using a snp positions file with headers successfully.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
