### PR TITLE
Qsignature Compare - handle empty vcf files

### DIFF
--- a/qsignature/src/org/qcmg/sig/Compare.java
+++ b/qsignature/src/org/qcmg/sig/Compare.java
@@ -204,6 +204,15 @@ public class Compare {
 		if (result == null) {
 			Pair<SigMeta, TMap<String, TIntByteHashMap>> rgResults = SignatureUtil.loadSignatureGenotype(f, minimumCoverage, minimumRGCoverage);
 			
+			
+			/*
+			 * deal with empty file scenario first
+			 * In this instance, the second entry in the pair should be a map with size zero
+			 */
+			if (rgResults.getSecond().isEmpty()) {
+				logger.warn("zero coverage for file " + f.getAbsolutePath());
+				return  new Pair<>(rgResults.getKey(), new TIntByteHashMap());
+			}
 			/*
 			 * if we have multiple rgs (more than 2 entries in map) - perform comparison on them before adding overall ratios to cache
 			 * 


### PR DESCRIPTION
# Description

`Qsignature's` `Compare` class recently gave an error when comparing a vcf record that had no records. The file had a header and no records (part of the bone marrow monocytes project).

Instead of throwing an exception, the `Compare` class should be able to handle this scenario and produce appropriate output.


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

An additional unit test has beed added to cover this scenario, and the updated code has been run against the project in question and no exceptions were thrown.


# Are WDL Updates Required?

No wdl updates are required. The option parameters have not changed.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
