### PR TITLE
remove class loading

### DIFF
--- a/q3indel/src/au/edu/qimr/indel/Main.java
+++ b/q3indel/src/au/edu/qimr/indel/Main.java
@@ -22,7 +22,6 @@ public class Main {
 			System.exit( 0 );
 		} 
 
-		LoadReferencedClasses.loadClasses(Main.class);
 		QLogger logger = options.getLogger();
 		int exitStatus = 0;
 		try {

--- a/q3panel/src/au/edu/qimr/panel/Q3ClinVar.java
+++ b/q3panel/src/au/edu/qimr/panel/Q3ClinVar.java
@@ -1549,8 +1549,6 @@ public class Q3ClinVar {
 	
 	
 	public static void main(String[] args) throws Exception {
-		// loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(Q3ClinVar.class);
 		
 		Q3ClinVar qp = new Q3ClinVar();
 		int exitStatus = qp.setup(args);

--- a/q3panel/src/au/edu/qimr/panel/Q3Panel.java
+++ b/q3panel/src/au/edu/qimr/panel/Q3Panel.java
@@ -1599,8 +1599,6 @@ public class Q3Panel {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		// loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(Q3Panel.class);
 		
 		Q3Panel qp = new Q3Panel();
 		int exitStatus = qp.setup(args);

--- a/q3tiledaligner/src/au/edu/qimr/tiledaligner/GenerateTiledAlignerFile.java
+++ b/q3tiledaligner/src/au/edu/qimr/tiledaligner/GenerateTiledAlignerFile.java
@@ -205,8 +205,6 @@ public class GenerateTiledAlignerFile {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		// loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(GenerateTiledAlignerFile.class);
 		
 		GenerateTiledAlignerFile qp = new GenerateTiledAlignerFile();
 		int exitStatus = qp.setup(args);

--- a/q3vcftools/src/au/edu/qimr/vcftools/AmalAnalyser.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/AmalAnalyser.java
@@ -444,8 +444,6 @@ public class AmalAnalyser {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		//loads all classes in referenced jars into memory to avoid nightly build shenanegans
-		LoadReferencedClasses.loadClasses(AmalAnalyser.class);
 		
 		AmalAnalyser qp = new AmalAnalyser();
 		int exitStatus = qp.setup(args);

--- a/q3vcftools/src/au/edu/qimr/vcftools/Amalgamator.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Amalgamator.java
@@ -306,8 +306,6 @@ public class Amalgamator {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		//loads all classes in referenced jars into memory to avoid nightly build shenanegans
-		LoadReferencedClasses.loadClasses(Amalgamator.class);
 		
 		Amalgamator qp = new Amalgamator();
 		int exitStatus = qp.setup(args);

--- a/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
@@ -518,8 +518,6 @@ public class AmalgamatorGS {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		//loads all classes in referenced jars into memory to avoid nightly build shenanegans
-		LoadReferencedClasses.loadClasses(AmalgamatorGS.class);
 		
 		AmalgamatorGS qp = new AmalgamatorGS();
 		int exitStatus = qp.setup(args);

--- a/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
@@ -334,8 +334,6 @@ public class Classify {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		//loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(Classify.class);
 		
 		Classify qp = new Classify();
 		int exitStatus = qp.setup(args);

--- a/q3vcftools/src/au/edu/qimr/vcftools/GoldStandardGenerator.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/GoldStandardGenerator.java
@@ -234,8 +234,6 @@ public class GoldStandardGenerator {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		//loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(GoldStandardGenerator.class);
 		
 		GoldStandardGenerator qp = new GoldStandardGenerator();
 		int exitStatus = qp.setup(args);

--- a/q3vcftools/src/au/edu/qimr/vcftools/MergeSameSamples.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/MergeSameSamples.java
@@ -210,8 +210,6 @@ public class MergeSameSamples {
 
 
 	public static void main(String[] args) throws Exception {
-		//loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(MergeSameSamples.class);
 		
 		MergeSameSamples qp = new MergeSameSamples();
 		int exitStatus = qp.setup(args);

--- a/q3vcftools/src/au/edu/qimr/vcftools/Overlap.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Overlap.java
@@ -832,8 +832,6 @@ public class Overlap {
 //	}
 	
 	public static void main(String[] args) throws Exception {
-		//loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(Overlap.class);
 		
 		Overlap qp = new Overlap();
 		int exitStatus = qp.setup(args);

--- a/qbamfilter/src/org/qcmg/qbamfilter/query/Query.java
+++ b/qbamfilter/src/org/qcmg/qbamfilter/query/Query.java
@@ -53,7 +53,6 @@ public class Query {
 	}
 	
 	public static void main(final String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(Query.class);
 		new Query(args);
 	}
 	

--- a/qbamfix/src/org/qcmg/qbamfix/Main.java
+++ b/qbamfix/src/org/qcmg/qbamfix/Main.java
@@ -19,7 +19,6 @@ import org.qcmg.picard.SAMFileReaderFactory;
 public class Main {	
 	private static QLogger logger;
 	public static void main(final String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(Main.class);
 		
 		NewOptions options = new NewOptions(args);			
 		if( options.hasHelp() || options.hasVersion() )

--- a/qbammerge/src/org/qcmg/bammerge/Main.java
+++ b/qbammerge/src/org/qcmg/bammerge/Main.java
@@ -20,8 +20,6 @@ public final class Main {
 
 	public static void main(final String[] args) {
 		try {
-			LoadReferencedClasses.loadClasses(Main.class);
-			
 			
 			Options options = new Options(args);
 			if (options.hasHelpOption()) {

--- a/qbasepileup/src/org/qcmg/qbasepileup/QBasePileup.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/QBasePileup.java
@@ -31,7 +31,6 @@ public class QBasePileup {
 	
 	public static void main(String[] args) throws Exception {
 		QBasePileup pileup = new QBasePileup();
-		LoadReferencedClasses.loadClasses(QBasePileup.class);
 		
 		int exitStatus = pileup.runBasePileup(args);
 

--- a/qcnv/src/org/qcmg/cnv/Main.java
+++ b/qcnv/src/org/qcmg/cnv/Main.java
@@ -14,7 +14,6 @@ import org.qcmg.common.util.LoadReferencedClasses;
 public class Main {
 	
 	 public static void main(final String[] args) throws Exception {
-        LoadReferencedClasses.loadClasses(Main.class);
         Options option = new Options(args);
         if(option.hasHelp() || option.hasVersion())
         	 System.exit(0); 

--- a/qcommon/src/org/qcmg/common/util/LoadReferencedClasses.java
+++ b/qcommon/src/org/qcmg/common/util/LoadReferencedClasses.java
@@ -19,6 +19,21 @@ import java.util.jar.JarFile;
 public class LoadReferencedClasses {
 	
 	
+	/**
+	 * The need for the methods in this class came about when we would execute long-running processes against jars that were overwritten nightly.
+	 * The effect of re-writing the jar files as a process was running would invariably kill the process.
+	 * The solution was to pre-load all the classes in the package and in the dependent jar files up front rather than when required.
+	 * This allows the process to continue despite the jar files being re-written.
+	 * 
+	 * I am happy to say that this method of running against an often updating jar is no longer common place and this method should not be used as a matter of course.
+	 * It remains in place (and un-deprecated) as there may arise instances where its utility may be useful.
+	 * 
+	 * @param <T>
+	 * @param clazz
+	 * @throws URISyntaxException
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 */
 	public static final <T> void loadClasses(final Class<T> clazz) throws URISyntaxException, IOException, ClassNotFoundException {
 		
 		final File thisJarFile = new File(clazz.getProtectionDomain().getCodeSource().getLocation().toURI());

--- a/qcoverage/src/org/qcmg/coverage/Coverage.java
+++ b/qcoverage/src/org/qcmg/coverage/Coverage.java
@@ -210,7 +210,6 @@ public final class Coverage {
 	private static QLogger mlogger = null;
 
 	public static void main(final String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(Coverage.class);
 		try {
 			moptions = new Options(args);
 			if (moptions.hasHelpOption()) {

--- a/qmito/src/au/edu/qimr/qmito/Mito.java
+++ b/qmito/src/au/edu/qimr/qmito/Mito.java
@@ -14,7 +14,6 @@ public class Mito {
 	
 		
 	public static void main(String[] args) throws Exception {		
-		LoadReferencedClasses.loadClasses(Mito.class);    
        try {
             Options options = new Options(args); 
             if(options.hasHelpOption()) return;

--- a/qmotif/src/org/qcmg/motif/Motif.java
+++ b/qmotif/src/org/qcmg/motif/Motif.java
@@ -302,7 +302,6 @@ public final class Motif {
 	private static QLogger mlogger = null;
 
 	public static void main(final String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(Motif.class);
 		try {
 			moptions = new Options(args);			
 			if (moptions.hasHelpOption()) {

--- a/qmotif/src/org/qcmg/motif/Summariser.java
+++ b/qmotif/src/org/qcmg/motif/Summariser.java
@@ -114,7 +114,6 @@ public class Summariser {
 	
 	
 	public static void main(final String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(Motif.class);
 		Summariser operation = new Summariser();
 		int exitStatus = operation.setup( args );
 		if (null != logger)

--- a/qmule/src/org/qcmg/qmule/AnnotateDCCWithGFFRegions.java
+++ b/qmule/src/org/qcmg/qmule/AnnotateDCCWithGFFRegions.java
@@ -637,7 +637,6 @@ public class AnnotateDCCWithGFFRegions {
 
 	public static void main(String[] args) throws Exception {
 		AnnotateDCCWithGFFRegions sp = new AnnotateDCCWithGFFRegions();
-		LoadReferencedClasses.loadClasses(AnnotateDCCWithGFFRegions.class);
 		sp.setup(args);
 		int exitStatus = sp.engage();
 		if (null != logger)

--- a/qmule/src/org/qcmg/qmule/IndelDCCHeader.java
+++ b/qmule/src/org/qcmg/qmule/IndelDCCHeader.java
@@ -383,7 +383,6 @@ public class IndelDCCHeader {
 
 	public static void main(String[] args) throws Exception {
 		IndelDCCHeader sp = new IndelDCCHeader();
-		LoadReferencedClasses.loadClasses(IndelDCCHeader.class);
 		sp.setup(args);
 		int exitStatus = sp.annotate();
 		if (null != logger)

--- a/qmule/src/org/qcmg/qmule/MAF2DCC1.java
+++ b/qmule/src/org/qcmg/qmule/MAF2DCC1.java
@@ -406,7 +406,6 @@ public class MAF2DCC1 {
 
 	public static void main(String[] args) throws Exception {
 		MAF2DCC1 sp = new MAF2DCC1();
-		LoadReferencedClasses.loadClasses(MAF2DCC1.class);
 		sp.setup(args);
 		
 		int exitStatus = sp.annotate();

--- a/qmule/src/org/qcmg/qmule/WiggleFromPileupTakeTwo.java
+++ b/qmule/src/org/qcmg/qmule/WiggleFromPileupTakeTwo.java
@@ -226,7 +226,6 @@ public class WiggleFromPileupTakeTwo {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(WiggleFromPileupTakeTwo.class);
 		WiggleFromPileupTakeTwo sp = new WiggleFromPileupTakeTwo();
 		int exitStatus = sp.setup(args);
 		if (null != logger)

--- a/qpileup/src/org/qcmg/pileup/QPileup.java
+++ b/qpileup/src/org/qcmg/pileup/QPileup.java
@@ -56,7 +56,6 @@ public final class QPileup {
 				ViewMT view = new ViewMT(options);
 				view.execute();
 			} else {
-				LoadReferencedClasses.loadClasses(QPileup.class);
 				//check to make sure there are no bad options
 				options.parseIniFile();
 				

--- a/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
+++ b/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
@@ -264,8 +264,6 @@ public class QProfiler {
 	}
 
 	public static void main(String args[]) throws Exception{
-		// loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(QProfiler.class);
 		
 		QProfiler qp = new QProfiler();
 		int exitStatus = qp.setup(args);

--- a/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
@@ -227,8 +227,6 @@ public class QProfiler2 {
 	}
 
 	public static void main(String args[]) throws Exception {
-		// loads all classes in referenced jars into memory to avoid nightly build sheninegans
-		LoadReferencedClasses.loadClasses(QProfiler2.class);
 		
 		QProfiler2 qp = new QProfiler2();
 		int exitStatus = qp.setup(args);

--- a/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
+++ b/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
@@ -235,8 +235,6 @@ public class CompareGenotypeBespoke {
 
 	
 	public static void main(String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(CompareGenotypeBespoke.class);
-		
 		CompareGenotypeBespoke sp = new CompareGenotypeBespoke();
 		int exitStatus = 0;
 		try {

--- a/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
+++ b/qsignature/src/org/qcmg/sig/SignatureCompareRelatedSimpleGenotypeMT.java
@@ -260,8 +260,6 @@ public class SignatureCompareRelatedSimpleGenotypeMT {
 
 	
 	public static void main(String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(SignatureCompareRelatedSimpleGenotypeMT.class);
-		
 		SignatureCompareRelatedSimpleGenotypeMT sp = new SignatureCompareRelatedSimpleGenotypeMT();
 		int exitStatus = 0;
 		try {

--- a/qsignature/src/org/qcmg/sig/VariantAlleleFreqDist.java
+++ b/qsignature/src/org/qcmg/sig/VariantAlleleFreqDist.java
@@ -177,8 +177,6 @@ public class VariantAlleleFreqDist {
 	}
 	
 	public static void main(String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(VariantAlleleFreqDist.class);
-		
 		VariantAlleleFreqDist sp = new VariantAlleleFreqDist();
 		int exitStatus = 0;
 		try {

--- a/qsnp/src/org/qcmg/snp/BuildCommonSnpsVcf.java
+++ b/qsnp/src/org/qcmg/snp/BuildCommonSnpsVcf.java
@@ -373,8 +373,6 @@ public class BuildCommonSnpsVcf {
 	 */
 	public static void main(final String[] args) throws Exception {
 		
-		LoadReferencedClasses.loadClasses(BuildCommonSnpsVcf.class);
-		
 		final BuildCommonSnpsVcf main = new BuildCommonSnpsVcf();
 		final int exitStatus = main.setup( args );
 		if (null != logger)

--- a/qsnp/src/org/qcmg/snp/Main.java
+++ b/qsnp/src/org/qcmg/snp/Main.java
@@ -38,8 +38,6 @@ public final class Main {
 	 */
 	public static void main(final String[] args) throws Exception {
 		
-		LoadReferencedClasses.loadClasses(Main.class);
-		
 		Main main = new Main();
 		int exitStatus = main.setup( args );
 		if (null != logger)

--- a/qsplit/src/org/qcmg/split/Main.java
+++ b/qsplit/src/org/qcmg/split/Main.java
@@ -16,7 +16,6 @@ public final class Main {
 	private static QLogger logger;
 
 	public static void main(final String[] args) throws URISyntaxException, IOException, ClassNotFoundException {
-		LoadReferencedClasses.loadClasses(Main.class);
 		try {
 			Options options = new Options(args);
 			if (options.hasHelpOption()) {

--- a/qvisualise/src/org/qcmg/qvisualise/QVisualise.java
+++ b/qvisualise/src/org/qcmg/qvisualise/QVisualise.java
@@ -92,7 +92,6 @@ public class QVisualise {
 	 * @throws Exception 
 	 */
 	public static void main(String[] args) throws Exception {
-		LoadReferencedClasses.loadClasses(QVisualise.class);
 		QVisualise qp = new QVisualise();
 		int exitStatus = qp.setup(args);
 		System.exit(exitStatus);


### PR DESCRIPTION
# Description

In days of old, we would execute long-running processes against jars that were overwritten nightly.
The effect of re-writing the jar files as a process was running would invariably kill the process.
The solution was to pre-load all the classes in the package and in the dependent jar files up front rather than when required.
This was done using the `LoadReferencedClasses.loadClasses` method.
This allowed the process to continue despite the jar files being re-written.

I am happy to say that this method of running against an often updating jar is no longer common place and so this method should not be used as a matter of course.
It remains in place (and un-deprecated) as there may arise instances where its utility may be useful.

All classes (apart from the test class) that called this method have been updated to remove the call to this method.

Fixes #213 

