### PR TITLE
check isPresent before calling get on Optional

### DIFF
--- a/q3vcftools/src/au/edu/qimr/vcftools/util/MergeUtils.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/util/MergeUtils.java
@@ -423,7 +423,7 @@ public class MergeUtils {
 			 */
 			
 			Optional<String> combinedAlts = getCombinedAlt(caller1, caller2);
-			mr = getBaseVcfRecordDetails(caller1, combinedAlts.isPresent() ? combinedAlts.get() : null);
+			mr = getBaseVcfRecordDetails(caller1, combinedAlts.orElse(null));
 			
 			Map<String, String> caller1Rules = null != rules ? rules.get(0) : null;
 			if (null != caller1Rules && ! caller1Rules.isEmpty()) {
@@ -531,7 +531,7 @@ public class MergeUtils {
 		 */
 		
 		Optional<String> combinedAltO = getCombinedAlt(records);
-		String combinedAlt = combinedAltO.isPresent() ? combinedAltO.get() : null;
+		String combinedAlt = combinedAltO.orElse(null);
 		
 		/*
 		 * Get common values from 1st record

--- a/q3vcftools/src/au/edu/qimr/vcftools/util/MergeUtils.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/util/MergeUtils.java
@@ -423,7 +423,7 @@ public class MergeUtils {
 			 */
 			
 			Optional<String> combinedAlts = getCombinedAlt(caller1, caller2);
-			mr = getBaseVcfRecordDetails(caller1, combinedAlts.get());
+			mr = getBaseVcfRecordDetails(caller1, combinedAlts.isPresent() ? combinedAlts.get() : null);
 			
 			Map<String, String> caller1Rules = null != rules ? rules.get(0) : null;
 			if (null != caller1Rules && ! caller1Rules.isEmpty()) {
@@ -530,14 +530,14 @@ public class MergeUtils {
 		 * build up alt string
 		 */
 		
-		Optional<String> combinedAlt = getCombinedAlt(records);
-//		assert combinedAlt.isPresent() : "Null returned from getCombinedAlt";
+		Optional<String> combinedAltO = getCombinedAlt(records);
+		String combinedAlt = combinedAltO.isPresent() ? combinedAltO.get() : null;
 		
 		/*
 		 * Get common values from 1st record
 		 */ 
 		VcfRecord mergedRecord =  new VcfRecord.Builder(records[0].getChrPosition(), records[0].getRef())
-									.id(records[0].getId()).allele(combinedAlt.get()).build();
+									.id(records[0].getId()).allele(combinedAlt).build();
 				
 		
 		/*
@@ -556,7 +556,7 @@ public class MergeUtils {
 			 * if the combinedAlts is different from the alt for this record, we may need to update the GT field
 			 */
 			String aa = r.getAlt();
-			if ( ! aa.equals(combinedAlt.get())) {
+			if ( ! aa.equals(combinedAlt)) {
 				
 				Map<String, String[]> ffMap = VcfUtils.getFormatFieldsAsMap(rFF);
 				String[] existingGTs = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE);
@@ -567,7 +567,7 @@ public class MergeUtils {
 				for (int z = 0 ; z < existingGTs.length ; z++) {
 					String gt = existingGTs[z];
 					if ( ! gt.equals(Constants.MISSING_DATA_STRING)) {
-						String newGT = getGT(combinedAlt.get(), aa, gt);
+						String newGT = getGT(combinedAlt, aa, gt);
 						if ( ! newGT.equals(gt)) {
 							existingGTs[z] = newGT;
 							needToUpdate = true;

--- a/qsnp/test/org/qcmg/snp/util/PipelineUtilTest.java
+++ b/qsnp/test/org/qcmg/snp/util/PipelineUtilTest.java
@@ -1,17 +1,7 @@
 package org.qcmg.snp.util;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.TLongList;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.list.array.TLongArrayList;
-import gnu.trove.map.TIntIntMap;
-import gnu.trove.map.TLongIntMap;
-import gnu.trove.map.TMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TLongIntHashMap;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,6 +21,17 @@ import org.qcmg.common.util.Pair;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
+
+import gnu.trove.list.TIntList;
+import gnu.trove.list.TLongList;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.list.array.TLongArrayList;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.TLongIntMap;
+import gnu.trove.map.TMap;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.map.hash.TLongIntHashMap;
 
 public class PipelineUtilTest {
 	
@@ -305,7 +306,7 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		snps.add(VcfUtils.createVcfRecord(new ChrPointPosition("1", 101), null, "B", null));
 		snps.add(VcfUtils.createVcfRecord(new ChrPointPosition("1", 102), null, "C", null));
 		
-		assertEquals("ABC", PipelineUtil.getReference(snps).get());
+		assertEquals("ABC", PipelineUtil.getReference(snps).orElse(null));
 	}
 	
 	@Test
@@ -528,9 +529,9 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		Map<String, short[]> basesAndCounts = new HashMap<>();
 		
 		basesAndCounts.put("XYZ", new short[]{10,5,15,6});
-		assertEquals("XYZ10[]15[]", PipelineUtil.getOABS(basesAndCounts).get());
+		assertEquals("XYZ10[]15[]", PipelineUtil.getOABS(basesAndCounts).orElse(null));
 		basesAndCounts.put("ABC", new short[]{21,2,14,1});
-		assertEquals("ABC21[]14[];XYZ10[]15[]", PipelineUtil.getOABS(basesAndCounts).get());
+		assertEquals("ABC21[]14[];XYZ10[]15[]", PipelineUtil.getOABS(basesAndCounts).orElse(null));
 	}
 	
 	@Test
@@ -616,7 +617,7 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		Map<VcfRecord, Pair<Accumulator, Accumulator>> map = new HashMap<>();
 		map.put(origV, new Pair<>(controlAcc100, testAcc100));
 		
-		VcfRecord v = PipelineUtil.createCompoundSnp(map, cRules,tRules, true, 3, 3).get();
+		VcfRecord v = PipelineUtil.createCompoundSnp(map, cRules,tRules, true, 3, 3).orElse(null);
 		assertEquals(origV.getChrPosition(), v.getChrPosition());
 		assertEquals("C", v.getAlt());
 		assertEquals("A", v.getRef());
@@ -654,7 +655,7 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		map.put(origV, new Pair<>(controlAcc100, testAcc100));
 		map.put(origV2, new Pair<>(controlAcc101, testAcc101));
 		
-		VcfRecord v = PipelineUtil.createCompoundSnp(map, cRules,tRules, true, 3, 3).get();
+		VcfRecord v = PipelineUtil.createCompoundSnp(map, cRules,tRules, true, 3, 3).orElse(null);
 		assertEquals(2, v.getChrPosition().getLength());
 		assertEquals("GT", v.getAlt());
 		assertEquals("AC", v.getRef());
@@ -669,7 +670,7 @@ Exception in thread "main" java.lang.IllegalArgumentException: List of Accumulat
 		controlAcc100.addBase((byte)'T', (byte) 1, false, 100, 100, 200, 5);
 		controlAcc100.addBase((byte)'T', (byte) 1, false, 100, 100, 200, 6);
 		
-		 v = PipelineUtil.createCompoundSnp(map, cRules,tRules, true, 3, 3).get();
+		 v = PipelineUtil.createCompoundSnp(map, cRules,tRules, true, 3, 3).orElse(null);
 		assertEquals(2, v.getChrPosition().getLength());
 		assertEquals("GT", v.getAlt());
 //		assertEquals("T_,GT", v.getAlt());
@@ -1057,9 +1058,9 @@ chr4    8046421 .       A       T       .       .       BaseQRankSum=0.727;Clipp
 		 * 
 		 * This should not be 1/2 in the test - only 1 read supporting the second alt
 		 */
-		VcfRecord v1 = VcfUtils.createVcfRecord(new ChrPointPosition("1", 154701381),null,"G","A");
+		VcfRecord v1 = VcfUtils.createVcfRecord(new ChrPointPosition("1", 154701381), null, "G", "A");
 		v1.setInfo(VcfHeaderUtils.INFO_SOMATIC);
-		VcfRecord v2 = VcfUtils.createVcfRecord(new ChrPointPosition("1", 154701382),null,"G","A");
+		VcfRecord v2 = VcfUtils.createVcfRecord(new ChrPointPosition("1", 154701382), null, "G", "A");
 		v2.setInfo(VcfHeaderUtils.INFO_SOMATIC);
 		final Accumulator tumour100 = new Accumulator(154701381);
 		final Accumulator tumour101 = new Accumulator(154701382);


### PR DESCRIPTION
# Description

Fixes instances where `Optional.get()` is called without a prior `isPresent()` call.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing unit tests pass

# Are WDL Updates Required?

No wdl updates required
