### PR TITLE
fix bug in qpileup view mode

### DIFF
--- a/docs/qpileup/hdf.md
+++ b/docs/qpileup/hdf.md
@@ -60,7 +60,7 @@ MapQual | Long | Sum of the mapping qualities of all reads that provide bases at
 StartAll | Integer | Count of all reads where alignment starts at this base (obeys clipping)
 StartNondup | Integer | As for StartAll except that we only count non-duplicate reads (obeys clipping)
 StopAll | Integer | Count of all reads where alignment stops at this base (obeys clipping)
-Dup | Integer | Count of reads that were flagged as duplicate and have a base at this position
+DupCount | Integer | Count of reads that were flagged as duplicate and have a base at this position
 MateUnmapped | Integer | Count of reads at this position that have an unmapped mate
 CigarI | Integer | Count of reads that have an "I" in the CIGAR string at this position. Only is counted at the first position at which the insertion occurs. Defined as where there is an insertion between this reference position and the next reference position.
 CigarD | Integer | Count of reads that have an "D" in the CIGAR string at this position
@@ -70,6 +70,7 @@ CigarN | Integer | Count of reads that have an "N" in the CIGAR string at this p
 CigarD_start | Integer | Count of reads that have an "D" in the CIGAR string that starts at this position
 CigarS_start | Integer | Count of reads that have an "S" in the CIGAR string that starts at this position
 CigarH_start | Integer | Count of reads that have an "H" in the CIGAR string that starts at this position
+CigarN_start | Integer | Count of reads that have an "N" in the CIGAR string that starts at this position
 LowReadCount | Integer | Count of the number of BAMs that have a low number of reads covering this position. By default LowReadCOunt is set to 10 but the `lowreadcount` option in thr INI file can be used to set this in `bootstrap` mode. If a BAM has a lowreadcount at a position, it is not used when calculating HighNonreference base count.
 ReferenceNo | Integer | Count of the number of bases at this position which are the same as the reference base
 NonreferenceNo | Integer | Count of the number of bases at this position which are not the same as the reference base

--- a/qpileup/src/org/qcmg/pileup/model/QPileupRecord.java
+++ b/qpileup/src/org/qcmg/pileup/model/QPileupRecord.java
@@ -176,7 +176,9 @@ public class QPileupRecord {
 			sb.append(getReverseElementString(null));
 		} else {
 			if (viewElements.size() > 0) {
-				sb.append(getForwardElementString(viewElements));
+				//delimiter was missing, it cause mergig last forward and first reverse element.
+				//eg. "037" is error, here fixed to "0\t37"
+				sb.append(getForwardElementString(viewElements)).append(DELIMITER);
 				sb.append(getReverseElementString(viewElements));
 			} else {
 				if (groupElements.size() > 0) {

--- a/qpileup/src/org/qcmg/pileup/model/QPileupRecord.java
+++ b/qpileup/src/org/qcmg/pileup/model/QPileupRecord.java
@@ -176,7 +176,7 @@ public class QPileupRecord {
 			sb.append(getReverseElementString(null));
 		} else {
 			if (viewElements.size() > 0) {
-				//delimiter was missing, it cause mergig last forward and first reverse element.
+				//delimiter was missing, it causes the merging of last forward and first reverse element.
 				//eg. "037" is error, here fixed to "0\t37"
 				sb.append(getForwardElementString(viewElements)).append(DELIMITER);
 				sb.append(getReverseElementString(viewElements));


### PR DESCRIPTION
# Description

We found there is one column missing on qpileup view output.  In below example, "LowReadCount_for" shown on the header but counts are missing.  We expect 
```
## Reference     Position        Ref_base        ...     HighNonreference_for    LowReadCount_for        A_rev  ...
chrMT   1       G       ...      0       0       4 ...
```
but we got 
```
## Reference     Position        Ref_base        ...     HighNonreference_for    LowReadCount_for        A_rev  ...
chrMT   1       G       ...      0       4 ...
```
This bug is fixed, there is a tab delimiter is missing between the forward and reverse elements. 

Meanwhile, the document is updated: fixted hdf column name error ("Dup" should be "DupCount"); and missing column "CigarN_start".

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested on a testing data set

# Are WDL Updates Required?

no

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes