### PR TITLE
build(all): update htsjdk jar from 2.14.1 to 2.24.1

### DIFF
--- a/q3indel/build.gradle
+++ b/q3indel/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     api project(':qbamfilter')
     api project(':qpicard')
 
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'org.scala-lang:scala-library:2.12.3'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'

--- a/q3indel/build.gradle
+++ b/q3indel/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     api project(':qbamfilter')
     api project(':qpicard')
 
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'org.scala-lang:scala-library:2.12.3'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'

--- a/q3panel/build.gradle
+++ b/q3panel/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     api 'org.apache.commons:commons-lang3:3.4'
     api 'net.sf.trove4j:core:3.1.0'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
 
     api group: 'com.io7m.xom',name: 'xom', version: '1.2.10'
 }

--- a/q3tiledaligner/build.gradle
+++ b/q3tiledaligner/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api project(':qcommon')
     api project(':qio')
 
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.trove4j:core:3.1.0'
     api 'org.apache.commons:commons-lang3:3.4'
     api 'net.sf.jopt-simple:jopt-simple:4.6'

--- a/q3vcftools/build.gradle
+++ b/q3vcftools/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api project(':qcommon')
     api project(':qio')
 
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api 'net.sf.trove4j:core:3.1.0'
     api group: 'com.jcraft', name: 'jsch', version: '0.1.54'

--- a/qannotate/build.gradle
+++ b/qannotate/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api project(':qio')
     api project(':qbamfilter')
 
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api name: 'snpEff', version: '4.0e'	
 }

--- a/qbamannotate/build.gradle
+++ b/qbamannotate/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':qpicard')
 	
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
-    implementation 'com.github.samtools:htsjdk:2.14.1'
+    implementation 'com.github.samtools:htsjdk:2.24.1'
 
     //testCompile project(':qtesting')
     testImplementation  project(':qtesting')

--- a/qbamannotate/build.gradle
+++ b/qbamannotate/build.gradle
@@ -12,9 +12,7 @@ dependencies {
     implementation project(':qpicard')
 	
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
-    implementation 'com.github.samtools:htsjdk:2.24.1'
 
-    //testCompile project(':qtesting')
     testImplementation  project(':qtesting')
 }
 

--- a/qbamfilter/build.gradle
+++ b/qbamfilter/build.gradle
@@ -12,6 +12,6 @@ dependencies {
 
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api 'org.antlr:antlr:3.2'
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
 }
 

--- a/qbamfilter/build.gradle
+++ b/qbamfilter/build.gradle
@@ -12,6 +12,5 @@ dependencies {
 
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api 'org.antlr:antlr:3.2'
-    api 'com.github.samtools:htsjdk:2.24.1'
 }
 

--- a/qbamfix/build.gradle
+++ b/qbamfix/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     api project(':qcommon')
     api project(':qpicard')
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'commons-cli:commons-cli:1.2'
 }
 

--- a/qbamfix/build.gradle
+++ b/qbamfix/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
     api project(':qcommon')
     api project(':qpicard')
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'commons-cli:commons-cli:1.2'
 }
 

--- a/qbammerge/build.gradle
+++ b/qbammerge/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qpicard')    
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
-    implementation 'com.github.samtools:htsjdk:2.14.1'
+    implementation 'com.github.samtools:htsjdk:2.24.1'
 	
     testImplementation project(':qtesting')
     testImplementation project(':qsplit')

--- a/qbammerge/build.gradle
+++ b/qbammerge/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qpicard')    
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
-    implementation 'com.github.samtools:htsjdk:2.24.1'
 	
     testImplementation project(':qtesting')
     testImplementation project(':qsplit')

--- a/qbasepileup/build.gradle
+++ b/qbasepileup/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qpileup')
     implementation project(':qbamfilter')
-    implementation 'com.github.samtools:htsjdk:2.14.1'
+    implementation 'com.github.samtools:htsjdk:2.24.1'
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
     testImplementation  'org.easymock:easymock:3.1'
 }

--- a/qcnv/build.gradle
+++ b/qcnv/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':qbamfilter')
 
     api 'commons-cli:commons-cli:1.2'	
-    api group: 'com.github.samtools', name: 'htsjdk', version: '2.14.1'
+    api group: 'com.github.samtools', name: 'htsjdk', version: '2.24.1'
     api group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
 }
 

--- a/qcnv/build.gradle
+++ b/qcnv/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     api project(':qbamfilter')
 
     api 'commons-cli:commons-cli:1.2'	
-    api group: 'com.github.samtools', name: 'htsjdk', version: '2.24.1'
     api group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
 }
 

--- a/qcoverage/build.gradle
+++ b/qcoverage/build.gradle
@@ -12,6 +12,5 @@ dependencies {
     implementation project(':qbamfilter')
     implementation project(':qpicard')
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
-    implementation 'com.github.samtools:htsjdk:2.24.1'
 }
 

--- a/qcoverage/build.gradle
+++ b/qcoverage/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     implementation project(':qbamfilter')
     implementation project(':qpicard')
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
-    implementation 'com.github.samtools:htsjdk:2.14.1'
+    implementation 'com.github.samtools:htsjdk:2.24.1'
 }
 

--- a/qmaftools/build.gradle
+++ b/qmaftools/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     api project(':qpicard')
     api project(':qbamfilter')
 	
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'	
 }
 

--- a/qmaftools/build.gradle
+++ b/qmaftools/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':qpicard')
     api project(':qbamfilter')
 	
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'	
 }
 

--- a/qmito/build.gradle
+++ b/qmito/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     api project(':qcommon')
     api project(':qbamfilter')
 
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
 }

--- a/qmotif/build.gradle
+++ b/qmotif/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     api project(':qpicard')
            
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
-    api 'com.github.samtools:htsjdk:2.24.1'	
     api 'net.sf.jopt-simple:jopt-simple:4.6'	
 }
 

--- a/qmotif/build.gradle
+++ b/qmotif/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api project(':qpicard')
            
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
-    api 'com.github.samtools:htsjdk:2.14.1'	
+    api 'com.github.samtools:htsjdk:2.24.1'	
     api 'net.sf.jopt-simple:jopt-simple:4.6'	
 }
 

--- a/qmule/build.gradle
+++ b/qmule/build.gradle
@@ -13,11 +13,5 @@ dependencies {
     api 'com.google.code.findbugs:findbugs:1.3.9'	
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     
-    //we used picard 1.130, it calls older htsjdk and throw exception
-    //picard:2.17.8 Update htsjdk version to 2.14.2; 
-    //picard:2.17.7 use htsjdk 2.14.0 listed in build file, which is most close to our 2.14.1
-    api 'com.github.broadinstitute:picard:2.17.7'
-        
-    //picard:2.17.7 requires barclay:2.0.0 listed in build file
-    api 'org.broadinstitute:barclay:2.0.0'   
+    api 'com.github.broadinstitute:picard:2.24.1'
 }

--- a/qmule/build.gradle
+++ b/qmule/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     api project(':qpicard')
     api 'com.google.code.findbugs:findbugs:1.3.9'	
     api 'net.sf.jopt-simple:jopt-simple:4.6'
-    
     api 'com.github.broadinstitute:picard:2.24.1'
+    api 'org.broadinstitute:barclay:2.0.0'
 }

--- a/qpicard/build.gradle
+++ b/qpicard/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(':qio')
 	  
     //released on Nov, 2015
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
 }

--- a/qpicard/build.gradle
+++ b/qpicard/build.gradle
@@ -5,6 +5,5 @@ dependencies {
     api project(':qcommon')
     api project(':qio')
 	  
-    //released on Nov, 2015
     api 'com.github.samtools:htsjdk:2.24.1'
 }

--- a/qpileup/build.gradle
+++ b/qpileup/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     api project(':qbamfilter')
 	
     ant {  untar(src: "../lib/hdf-java-2.8-bin.tar", dest: "build/deps") }
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
     api name: 'jhdf'

--- a/qpileup/build.gradle
+++ b/qpileup/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api project(':qbamfilter')
 	
     ant {  untar(src: "../lib/hdf-java-2.8-bin.tar", dest: "build/deps") }
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
     api name: 'jhdf'

--- a/qprofiler/build.gradle
+++ b/qprofiler/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     api project(':qvisualise')
 
     api 'org.apache.commons:commons-math3:3.3'
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
 	
 }

--- a/qprofiler/build.gradle
+++ b/qprofiler/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     api project(':qvisualise')
 
     api 'org.apache.commons:commons-math3:3.3'
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
 	
 }

--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     api project(':qpicard')
     api project(':qio')
 
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
 }
 

--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api project(':qpicard')
     api project(':qio')
 
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
 }
 

--- a/qsignature/build.gradle
+++ b/qsignature/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     api project(':qio')
     
     api 'org.apache.commons:commons-math3:3.3'
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
 	

--- a/qsignature/build.gradle
+++ b/qsignature/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     api project(':qio')
     
     api 'org.apache.commons:commons-math3:3.3'
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
 	

--- a/qsnp/build.gradle
+++ b/qsnp/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
     api 'net.sf.trove4j:core:3.1.0'
     api 'org.apache.commons:commons-lang3:3.4'
-    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api 'org.lz4:lz4-java:1.5.0'
     api 'org.scala-lang:scala-library:2.12.3'

--- a/qsnp/build.gradle
+++ b/qsnp/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
     api 'net.sf.trove4j:core:3.1.0'
     api 'org.apache.commons:commons-lang3:3.4'
-    api 'com.github.samtools:htsjdk:2.14.1'
+    api 'com.github.samtools:htsjdk:2.24.1'
     api 'net.sf.jopt-simple:jopt-simple:4.6'
     api 'org.lz4:lz4-java:1.5.0'
     api 'org.scala-lang:scala-library:2.12.3'

--- a/qsplit/build.gradle
+++ b/qsplit/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':qpicard')
     testImplementation  project(':qtesting')
 	
-    api group: 'com.github.samtools', name: 'htsjdk', version: '2.14.1'
+    api group: 'com.github.samtools', name: 'htsjdk', version: '2.24.1'
     api group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
 }
 

--- a/qsplit/build.gradle
+++ b/qsplit/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     api project(':qpicard')
     testImplementation  project(':qtesting')
 	
-    api group: 'com.github.samtools', name: 'htsjdk', version: '2.24.1'
     api group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
 }
 

--- a/qsv/build.gradle
+++ b/qsv/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':qpicard')
     api project(':q3tiledaligner')
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'	
-    api 'com.github.samtools:htsjdk:2.14.1'	
+    api 'com.github.samtools:htsjdk:2.24.1'	
     api 'net.sf.jopt-simple:jopt-simple:4.6'	
 		
     testImplementation  'org.easymock:easymock:3.1'

--- a/qsv/build.gradle
+++ b/qsv/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':qpicard')
     api project(':q3tiledaligner')
     api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'	
-    api 'com.github.samtools:htsjdk:2.24.1'	
+    //api 'com.github.samtools:htsjdk:2.14.1'	
     api 'net.sf.jopt-simple:jopt-simple:4.6'	
 		
     testImplementation  'org.easymock:easymock:3.1'

--- a/qsv/test/org/qcmg/qsv/util/TestUtil.java
+++ b/qsv/test/org/qcmg/qsv/util/TestUtil.java
@@ -268,19 +268,29 @@ public class TestUtil {
     		createSamFile(samFile, sort, true);
     	}
     	
-        SamReader reader = SAMFileReaderFactory.createSAMFileReader(new File(samFile));
-        SAMFileHeader header = reader.getFileHeader();
-        
-		SAMFileWriterFactory factory = new SAMFileWriterFactory();
-		factory.setCreateIndex(true);
-		try (SAMFileWriter writer = factory.makeBAMWriter(header, false, new File(inputFileName));) {
-		
-		for (SAMRecord r: reader) {
-			writer.addAlignment(r);
+    	/*
+    	 * load entries from SAM file into memory - this is to overcome an intermittent exception that is thrown
+    	 */
+    	List<SAMRecord> samRecords = new ArrayList<>();
+    	SAMFileHeader header = null;
+    	
+    	try ( SamReader reader = SAMFileReaderFactory.createSAMFileReader(new File(samFile)); ) {
+    		header = reader.getFileHeader();
+    		 for (SAMRecord r : reader) {
+    			 samRecords.add(r);
+ 		    }
+    	}
+    	/*
+    	 * now setup factory and writer
+    	 */
+    	SAMFileWriterFactory factory = new SAMFileWriterFactory();
+    	factory.setCreateIndex(true);
+    	
+        try (SAMFileWriter writer = factory.makeBAMWriter(header, false, new File(inputFileName));) {
+		    for (SAMRecord r : samRecords) {
+			    writer.addAlignment(r);
+		    }
 		}
-		}
-		reader.close();
-//		writer.close();
         
 		return new File(inputFileName);
 	}

--- a/qsv/test/org/qcmg/qsv/util/TestUtil.java
+++ b/qsv/test/org/qcmg/qsv/util/TestUtil.java
@@ -273,13 +273,14 @@ public class TestUtil {
         
 		SAMFileWriterFactory factory = new SAMFileWriterFactory();
 		factory.setCreateIndex(true);
-		SAMFileWriter writer = factory.makeBAMWriter(header, false, new File(inputFileName));
+		try (SAMFileWriter writer = factory.makeBAMWriter(header, false, new File(inputFileName));) {
 		
 		for (SAMRecord r: reader) {
 			writer.addAlignment(r);
 		}
+		}
 		reader.close();
-		writer.close();
+//		writer.close();
         
 		return new File(inputFileName);
 	}


### PR DESCRIPTION
# Description

Update the dependency on the htsjdk jar from from version 2.14.1 to 2.24.1.
This is the latest released version of htsjdk (March 2021) https://github.com/samtools/htsjdk
The previous version (2.14.1) had restricted access to the `FastaSequenceIndexEntry` class which will be required by the `q3tiledaligner` project when getting ready for GRCh38.

re #307

## Type of change

Please delete options that are not relevant.

- [X] External dependency update

# How Has This Been Tested?

Unit tests pass. 
Should the regression tests fail when running against this version of htsjdk, the differences will need to be examined, and potentially the version of htsjdk reverted back to 2.14.1.

# Are WDL Updates Required?

no

# Checklist:

- [X] New and existing unit tests pass locally with my changes
