### PR TITLE
fix(qsv): incorrect index value was being passed to method

### DIFF
--- a/q3tiledaligner/src/au/edu/qimr/tiledaligner/util/TiledAlignerUtil.java
+++ b/q3tiledaligner/src/au/edu/qimr/tiledaligner/util/TiledAlignerUtil.java
@@ -1336,7 +1336,7 @@ public class TiledAlignerUtil {
 		return nonOverlappingRecs;
 	}
 
-	public static Map<ChrPosition, LongRange> loadReferenceIndexMap(String refFile, String refIndexFile) {
+	static Map<ChrPosition, LongRange> loadReferenceIndexMap(String refFile, String refIndexFile) {
 		Map<ChrPosition, LongRange> headerMap = null;
 		if (null == refIndexFile) {
 			/*

--- a/q3tiledaligner/src/au/edu/qimr/tiledaligner/util/TiledAlignerUtil.java
+++ b/q3tiledaligner/src/au/edu/qimr/tiledaligner/util/TiledAlignerUtil.java
@@ -1336,7 +1336,7 @@ public class TiledAlignerUtil {
 		return nonOverlappingRecs;
 	}
 
-	private static Map<ChrPosition, LongRange> loadReferenceIndexMap(String refFile, String refIndexFile) {
+	public static Map<ChrPosition, LongRange> loadReferenceIndexMap(String refFile, String refIndexFile) {
 		Map<ChrPosition, LongRange> headerMap = null;
 		if (null == refIndexFile) {
 			/*
@@ -1346,7 +1346,7 @@ public class TiledAlignerUtil {
 			Path indexPath = ReferenceSequenceFileFactory.getFastaIndexFileName(Paths.get(refFile));
 			if (Files.isReadable(indexPath)) {
 				logger.info("loading reference index file from " + indexPath);
-				headerMap = PositionChrPositionMap.loadMap(refIndexFile);
+				headerMap = PositionChrPositionMap.loadMap(indexPath.toString());
 			} else {
 				logger.warn("Could not find reference index file from " + refFile + ", will default to GRCh37!");
 				headerMap = PositionChrPositionMap.loadGRCh37Map();

--- a/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TiledAlignerUtilTest.java
+++ b/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TiledAlignerUtilTest.java
@@ -3,6 +3,8 @@ package au.edu.qimr.tiledaligner.util;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -13,7 +15,9 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.Range;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.model.ChrPositionName;
 import org.qcmg.common.string.StringUtils;
@@ -32,6 +36,9 @@ public class TiledAlignerUtilTest {
 	
 	public static Map<ChrPosition, LongRange> pcpm;
 	
+	@Rule
+	public TemporaryFolder testFolder = new TemporaryFolder();
+	
 	@BeforeClass
 	public static void setup() {
 		/*
@@ -40,6 +47,29 @@ public class TiledAlignerUtilTest {
 		pcpm = PositionChrPositionMap.loadGRCh37Map();
 	}
 	
+	@Test
+	public void useIndexFileIfPresent() throws IOException {
+		File fa = testFolder.newFile("test.fa");
+		/*
+		 * no index so should load default positions - no exception
+		 */
+		Map<ChrPosition, LongRange> map = TiledAlignerUtil.loadReferenceIndexMap(fa.getAbsolutePath(), null);
+		assertEquals(false, map.isEmpty());
+		
+		/*
+		 * add an index file - should use this rather than default
+		 */
+		File index = testFolder.newFile("test.fa.fai");
+		map = TiledAlignerUtil.loadReferenceIndexMap(fa.getAbsolutePath(), null);
+		assertEquals(true, map.isEmpty());
+		
+		/*
+		 * and finally with the explicit call to the index
+		 */
+		map = TiledAlignerUtil.loadReferenceIndexMap(fa.getAbsolutePath(), index.getAbsolutePath());
+		assertEquals(true, map.isEmpty());
+		
+	}
 	
 	@Test
 	public void getAlternatives() {


### PR DESCRIPTION
# Description

In `TiledAlignerUtil.loadReferenceIndexMap` a check is performed on the supplied index file. If this is null, an attempt to locate the index file is then done based on the reference file. If this is found then that should be used.
Unfortunately the code was using the supplied index value (which was null) rather than the located index file (not null).

This was introduced in PR #313 


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New test added, existing tests pass

# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
