### PR TITLE
create tool to rescue fastq reads with empty sequence

### DIFF
--- a/qmule/src/org/qcmg/qmule/FixCutAdapter.java
+++ b/qmule/src/org/qcmg/qmule/FixCutAdapter.java
@@ -20,7 +20,7 @@ import java.io.InputStreamReader;
 import java.util.Date;
 
 public class FixCutAdapter extends CommandLineProgram {
-    static final String USAGE = "When cutadapt finds adapter sequence at the start of a read the option --trim-n results in empty sequence in the output. This tool replaces any empty sequence with a single base N with 0 base quality value.";    
+	static final String USAGE = "When cutadapt finds adapter sequence at the start of a read the default action of adapter sequence trimming results in empty sequence in the output. This tool replaces any empty sequence with a single base N with 0 base quality value.";
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input FASTQ file to be fixed. Default is STDIN.", optional=true)
     public File INPUT = null;
 

--- a/qmule/src/org/qcmg/qmule/FixCutAdapter.java
+++ b/qmule/src/org/qcmg/qmule/FixCutAdapter.java
@@ -16,17 +16,20 @@ import htsjdk.samtools.fastq.FastqWriterFactory;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 
 public class FixCutAdapter extends CommandLineProgram {
-    static final String USAGE = "A Fastq file may contains empty seqence and base quality after cutAdapter,  Here A base N is set to empty sequence with 0 base quality value";
+    static final String USAGE = "A Fastq file may contains empty seqence after cutAdapter,  Here A base N is set to empty sequence with 0 base quality value";
     
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input Fastq file to be fixed.")
     public File INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Where to write fixed fastq file.")
     public File OUTPUT;
+       
     
     private int line=1;
+    private int fixes = 0;
 
     public static void main(final String[] argv) {
     	
@@ -43,7 +46,6 @@ public class FixCutAdapter extends CommandLineProgram {
         try( BufferedReader reader = IOUtil.openFileForBufferedReading(INPUT);
         		FastqWriter writer =  (new FastqWriterFactory()).newWriter(OUTPUT);){
         	
-        	 
         	do {
         		
             	final String seqHeader = reader.readLine(); // read header             
@@ -52,9 +54,12 @@ public class FixCutAdapter extends CommandLineProgram {
                 String qualLine = reader.readLine(); // Read quality line
         	     
                 //end of file   
-            	if ( seqHeader == null || seqLine == null || qualHeader == null || qualLine == null ) {
-            		break ;          	
-            	}
+//            	if ( seqHeader == null || seqLine == null || qualHeader == null || qualLine == null ) {
+//            		break ;          	
+//            	}
+                
+                if(seqHeader == null) break;
+                
             	
                 if (!seqHeader.startsWith(FastqConstants.SEQUENCE_HEADER)) {
                     throw new SAMException(error("Sequence header must start with " + FastqConstants.SEQUENCE_HEADER + ": " + seqHeader));
@@ -62,20 +67,28 @@ public class FixCutAdapter extends CommandLineProgram {
                 if (!qualHeader.startsWith(FastqConstants.QUALITY_HEADER)) {
                     throw new SAMException(error("Quality header must start with " + FastqConstants.QUALITY_HEADER + ": "+ qualHeader));
                 }
-                if (StringUtil.isBlank(seqLine)) seqLine = "N";
-                if (StringUtil.isBlank(qualLine)) qualLine = "!";
+                if (StringUtil.isBlank(seqLine) || StringUtil.isBlank(qualLine)) { 
+                	seqLine = "N";
+                	qualLine = "!";
+                	fixes ++;
+                } 
+               
 
                 //output updated fastq record
-                FastqRecord frec = new FastqRecord(seqHeader, seqLine, qualHeader, qualLine);
+                final FastqRecord frec = new FastqRecord(seqHeader.substring(1, seqHeader.length()), seqLine,
+                        qualHeader.substring(1, qualHeader.length()), qualLine);
+
                 writer.write(frec); 
         		
                 line += 4 ;
         	} while( true );
         	        	
-        } catch (IOException e) {
+        } catch (IOException | SAMException e) {
 			e.printStackTrace();
 			return 1;
-		}        
+		}   
+        
+        System.err.println("[" + new Date() + "] Total " + (line / 4) + " fastq records are processed, " + fixes + " of them with empty sequence are fixed to single base N");
 		return 0;
 	}
 	

--- a/qmule/src/org/qcmg/qmule/FixCutAdapter.java
+++ b/qmule/src/org/qcmg/qmule/FixCutAdapter.java
@@ -1,0 +1,88 @@
+package org.qcmg.qmule;
+
+import picard.cmdline.CommandLineProgram;
+import org.broadinstitute.barclay.argparser.Argument;
+
+import picard.cmdline.StandardOptionDefinitions;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.StringUtil;
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.fastq.FastqConstants;
+
+import htsjdk.samtools.fastq.FastqRecord;
+import htsjdk.samtools.fastq.FastqWriter;
+import htsjdk.samtools.fastq.FastqWriterFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+
+public class FixCutAdapter extends CommandLineProgram {
+    static final String USAGE = "A Fastq file may contains empty seqence and base quality after cutAdapter,  Here A base N is set to empty sequence with 0 base quality value";
+    
+    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input Fastq file to be fixed.")
+    public File INPUT;
+
+    @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Where to write fixed fastq file.")
+    public File OUTPUT;
+    
+    private int line=1;
+
+    public static void main(final String[] argv) {
+    	
+     	
+     	int exitStatus = new FixCutAdapter().instanceMain(argv);
+     	
+        System.exit(exitStatus);
+    }
+	@Override
+	protected int doWork() {
+        IOUtil.assertFileIsReadable(INPUT);
+        IOUtil.assertFileIsWritable(OUTPUT);
+        
+        try( BufferedReader reader = IOUtil.openFileForBufferedReading(INPUT);
+        		FastqWriter writer =  (new FastqWriterFactory()).newWriter(OUTPUT);){
+        	
+        	 
+        	do {
+        		
+            	final String seqHeader = reader.readLine(); // read header             
+                String seqLine = reader.readLine(); // Read sequence line                          
+                final String qualHeader = reader.readLine(); // Read quality header                
+                String qualLine = reader.readLine(); // Read quality line
+        	     
+                //end of file   
+            	if ( seqHeader == null || seqLine == null || qualHeader == null || qualLine == null ) {
+            		break ;          	
+            	}
+            	
+                if (!seqHeader.startsWith(FastqConstants.SEQUENCE_HEADER)) {
+                    throw new SAMException(error("Sequence header must start with " + FastqConstants.SEQUENCE_HEADER + ": " + seqHeader));
+                }          
+                if (!qualHeader.startsWith(FastqConstants.QUALITY_HEADER)) {
+                    throw new SAMException(error("Quality header must start with " + FastqConstants.QUALITY_HEADER + ": "+ qualHeader));
+                }
+                if (StringUtil.isBlank(seqLine)) seqLine = "N";
+                if (StringUtil.isBlank(qualLine)) qualLine = "!";
+
+                //output updated fastq record
+                FastqRecord frec = new FastqRecord(seqHeader, seqLine, qualHeader, qualLine);
+                writer.write(frec); 
+        		
+                line += 4 ;
+        	} while( true );
+        	        	
+        } catch (IOException e) {
+			e.printStackTrace();
+			return 1;
+		}        
+		return 0;
+	}
+	
+	
+    /** Generates an error message with line number information. */
+    protected String error(final String msg) {
+        return msg + " at line " + line + " in fastq " + INPUT.getAbsolutePath();
+    }
+
+}

--- a/qmule/src/org/qcmg/qmule/FixCutAdapter.java
+++ b/qmule/src/org/qcmg/qmule/FixCutAdapter.java
@@ -20,12 +20,11 @@ import java.io.InputStreamReader;
 import java.util.Date;
 
 public class FixCutAdapter extends CommandLineProgram {
-    static final String USAGE = "A Fastq file may contains empty seqence after cutAdapter,  Here A base N is set to empty sequence with 0 base quality value";
-    
-    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input Fastq file to be fixed. Default is STDIN",optional=true)
+    static final String USAGE = "When cutadapt finds adapter sequence at the start of a read the option --trim-n results in empty sequence in the output. This tool replaces any empty sequence with a single base N with 0 base quality value.";    
+    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input FASTQ file to be fixed. Default is STDIN.", optional=true)
     public File INPUT = null;
 
-    @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Where to write fixed fastq file.Default is STDOUT", optional=true)
+    @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Where to write fixed fastq file. Default is STDOUT.", optional=true)
     public File OUTPUT = null;
        
     

--- a/qmule/test/org/qcmg/qmule/FixCutAdapterTest.java
+++ b/qmule/test/org/qcmg/qmule/FixCutAdapterTest.java
@@ -34,7 +34,8 @@ public class FixCutAdapterTest {
 	
 	@BeforeClass
 	public static void setup() throws IOException {
-		INPUT = testFolder.newFile("input.fastq");		
+		INPUT = testFolder.newFile("input.fastq");	
+		INPUT = new File("input.fastq");
 		OUTPUT = testFolder.newFile("output.fastq");
 		
 		ArrayList<FastqRecord> data = new ArrayList<>(Arrays.asList( r1,r2,r3 ) );	
@@ -46,6 +47,14 @@ public class FixCutAdapterTest {
 	private int execute() throws Exception {
 		String command = " -I " + INPUT.getAbsolutePath() + " -O " + OUTPUT.getAbsolutePath();
 		return (new Executor(command, "org.qcmg.qmule.FixCutAdapter")).getErrCode();
+	}
+	
+	@Test
+	public void stdTest() throws Exception{
+		
+		String command = " -I " + INPUT.getAbsolutePath();
+		
+		assertEquals(0 ,(new Executor(command, "org.qcmg.qmule.FixCutAdapter")).getErrCode());
 	}
 		
 	@Test

--- a/qmule/test/org/qcmg/qmule/FixCutAdapterTest.java
+++ b/qmule/test/org/qcmg/qmule/FixCutAdapterTest.java
@@ -1,0 +1,94 @@
+package org.qcmg.qmule;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.commandline.Executor;
+
+import htsjdk.samtools.fastq.FastqReader;
+import htsjdk.samtools.fastq.FastqRecord;
+import htsjdk.samtools.fastq.FastqWriter;
+import htsjdk.samtools.fastq.FastqWriterFactory;
+
+public class FixCutAdapterTest {
+	
+	
+	@ClassRule
+	public static TemporaryFolder testFolder = new TemporaryFolder();
+	public static File INPUT;
+	public static File OUTPUT;
+	
+	private final static FastqRecord r1 = new FastqRecord("ST-E00129:529:HF5FTALXX:4:2206:13200:50656 1:N:0:TCCGCGAA", "ATGCATGC","", "AAFFFJJJ");
+	private final static FastqRecord r2 = new FastqRecord("ST-E00129:529:HF5FTALXX:4:2206:15899:50656", "","", "");
+	private final static FastqRecord r3 = new FastqRecord("others", "ATGCATGC","", "");
+	
+	@BeforeClass
+	public static void setup() throws IOException {
+		INPUT = testFolder.newFile("input.fastq");		
+		OUTPUT = testFolder.newFile("output.fastq");
+		
+		ArrayList<FastqRecord> data = new ArrayList<>(Arrays.asList( r1,r2,r3 ) );	
+	    try( FastqWriter writer = (new FastqWriterFactory()).newWriter(INPUT);) {			 
+			 for (FastqRecord re : data)  writer.write(re);      	
+	    }  
+	}
+	
+	private int execute() throws Exception {
+		String command = " -I " + INPUT.getAbsolutePath() + " -O " + OUTPUT.getAbsolutePath();
+		return (new Executor(command, "org.qcmg.qmule.FixCutAdapter")).getErrCode();
+	}
+		
+	@Test
+	public void inValidTest() throws Exception{
+  		
+		//different length bwt seq and qual  
+		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\nATGC\n+\nA");	} 		
+		assertEquals(0 , execute());
+		
+		//missing qual 
+		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\nATGC\n");	} 
+		assertEquals(1 , execute());
+		
+		//two seq line
+		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\n\nATGC\n+\nA");	} 		
+		assertEquals(1 , execute());
+		
+		//two records but one is wrong
+		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\nATGC\n+\nA\n@f2\nATGC\n");	} 
+		assertEquals(1 , execute());		
+	}
+	
+	@Test
+	public void emptyTest() throws Exception{
+		
+		assertEquals(0 , execute());
+		
+		int i = 0;
+		try (FastqReader reader =  new FastqReader(OUTPUT)) {
+			for (FastqRecord record : reader) {								
+				if(record.equals(r1)) assertEquals(0 , i); // first record are same
+				else if(record.getReadName().equals(r2.getReadName())) {
+					//second record
+					assertEquals(1 , i); 
+					assertEquals(record.getReadString() , "N");  
+                	assertEquals(record.getBaseQualityString(), "!");
+				} else {
+					//third record
+					assertEquals(2 , i); 
+					assertEquals(record.toFastQString() , "@others\nN\n+\n!"); 
+ 				}
+				i ++;				
+			}			
+		}
+ 	}
+}


### PR DESCRIPTION
# Description

A Fastq file may contain an empty sequence after cutAdapter,  Here A base N is set to an empty sequence with 0 base quality value". This tool takes fastq file as input and output, but also can read from stdin and writer to stdout, so it can insert into the pipe on our new WDL script. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

unit tests is added, tested on small real data. It will also run by new WDL

# Are WDL Updates Required?
It is an independent new took, and not yet used by any current WDL pipeline.   Any current WDL pipeline won't be affected.  A new WDL script is created, which implements this tool after cutAdapter, and pass output fastq to BWA mapping, and also creates an uBAM (unmapped BAM).  Thi new WDL script will be tested after its branch is merged into the master.  This new WDL script named fasqTobam.wdl may replace the current mapPairedChunks.wdl.

 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
