### PR TITLE
feat(qsignature): add gene model information to snp positions vcf file

### DIFF
--- a/qsignature/src/org/qcmg/sig/Messages.java
+++ b/qsignature/src/org/qcmg/sig/Messages.java
@@ -15,6 +15,7 @@ final class Messages {
 	static final String GENERATOR_USAGE = getMessage("GENERATOR_USAGE");
 	static final String POSITIONS_PROFILER_USAGE = getMessage("POSITIONS_PROFILER_USAGE");
 	static final String VCF_PROFILER_USAGE = getMessage("VCF_PROFILER_USAGE");
+	static final String GENE_MODEL_USAGE = getMessage("GENE_MODEL_USAGE");
 
 	static String getMessage(final String identifier) {
 		return messages.getString(identifier);

--- a/qsignature/src/org/qcmg/sig/Options.java
+++ b/qsignature/src/org/qcmg/sig/Options.java
@@ -102,6 +102,8 @@ final class Options {
 			.describedAs("snpPositions");
 		parser.accepts("genePositions", "Gff3 file containing list of gene positions").withRequiredArg().ofType(String.class)
 			.describedAs("genePositions");
+		parser.accepts("geneModel", "GTF file containing gene model information").withRequiredArg().ofType(String.class)
+			.describedAs("geneModel");
 		parser.accepts("reference", "Reference fasta file").withRequiredArg().ofType(String.class)
 			.describedAs("reference");
 		parser.accepts("sequential", SEQUENTIAL_OPTION_DESCRIPTION);
@@ -308,6 +310,9 @@ final class Options {
 
 	public String getExcludeVcfsFile() {
 		return (String) options.valueOf("excludeVcfsFile");
+	}
+	public Optional<String> getGeneModelFile() {
+		return Optional.ofNullable((String) options.valueOf("geneModel"));
 	}
 	
 	public String getValidation() {

--- a/qsignature/src/org/qcmg/sig/VcfAddGeneModel.java
+++ b/qsignature/src/org/qcmg/sig/VcfAddGeneModel.java
@@ -1,0 +1,174 @@
+package org.qcmg.sig;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.qcmg.common.log.QLogger;
+import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.model.ChrPointPosition;
+import org.qcmg.common.model.ChrPosition;
+import org.qcmg.common.util.TabTokenizer;
+import org.qcmg.common.vcf.VcfRecord;
+import org.qcmg.common.vcf.header.VcfHeader;
+import org.qcmg.common.vcf.header.VcfHeaderRecord;
+import org.qcmg.qio.record.RecordWriter;
+import org.qcmg.qio.record.StringFileReader;
+import org.qcmg.qio.vcf.VcfFileReader;
+
+
+/**
+ * This class adds gene model information to the info field of a vcf file.
+ * Only gene model records that have a feature type of exon or five_prime_utr or three_prime_utr will be used.
+ * 
+ * The intended use case is to annotate a snp positions vcf file with gene model information 
+ * and as such it is not anticipated that this class will be often used.
+ * 
+ * @author oliverh
+ *
+ */
+public class VcfAddGeneModel {
+	
+	private static QLogger logger;
+	private int exitStatus;
+	
+	private String logFile;
+	private String outputVcf;
+	private String inputVcf;
+	private String geneModelFile;
+	
+	private Map<ChrPosition, String> geneModelPositionMap = new HashMap<>();
+	
+	private int engage() throws Exception {
+		
+		int geneModelRecordCount = 0;
+		int geneModelExonRecordCount = 0;
+		/*
+		 * load gene model file into memory
+		 */
+		
+		try (StringFileReader reader = new StringFileReader(new File(geneModelFile));) {
+			for (String rec: reader) {
+				geneModelRecordCount++;
+				String [] recArray = TabTokenizer.tokenize(rec);
+				
+				/*
+				 * only proceed if we are an exon, five_prime_utr or three_prime_utr, 
+				 */
+				
+				if (recArray[2].equals("exon") || recArray[2].equals("five_prime_utr") || recArray[2].equals("three_prime_utr")) {
+					geneModelExonRecordCount++;
+					/*
+					 * loop over the positions in this record and create an entry in the map for each one
+					 * This should make the lookup quicker, at the expense of having a larger map
+					 * 
+					 * There will be some overlapping positions - stick with the first one encountered.
+					 */
+					int start = Integer.parseInt(recArray[3]);
+					int stop = Integer.parseInt(recArray[4]);
+					for (int i = start ; i <= stop ; i++) {
+						ChrPosition cp = new ChrPointPosition(recArray[0], i);
+						geneModelPositionMap.putIfAbsent(cp, recArray[8]);
+					}
+				}
+			}
+		}
+		
+		logger.info("Number of entries in geneModelPositionMap: " + geneModelPositionMap.size());
+		logger.info("geneModelRecordCount: " + geneModelRecordCount);
+		logger.info("geneModelExonRecordCount: " + geneModelExonRecordCount);
+		
+		/*
+		 * now go through input vcf and look to see how many matches we get
+		 */
+		
+		int matchingGeneModelAtPosition = 0;
+		int vcfRecordCount = 0;
+		try (VcfFileReader vReader = new VcfFileReader(inputVcf);
+				RecordWriter<VcfRecord> writer = new RecordWriter<>(new File(outputVcf));) {
+			VcfHeader header = vReader.getVcfHeader();
+			for (final VcfHeaderRecord record: header) {
+				writer.addHeader(record.toString());
+			}
+			for (VcfRecord vRec : vReader) {
+				vcfRecordCount++;
+				String info = geneModelPositionMap.get(vRec.getChrPosition());
+				if (null != info) {
+					/*
+					 * perform a little manipulation on the info so that it is valid in the vcf info field
+					 */
+					vRec.setInfo(info.replace("; ", ";").replace(" ", "=").replace("\"", ""));
+					matchingGeneModelAtPosition++;
+				}
+				writer.add(vRec);
+			}
+		}
+		logger.info(matchingGeneModelAtPosition + " positions were found in gene model map from a total of: " + vcfRecordCount);
+		
+		return exitStatus;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		VcfAddGeneModel sp = new VcfAddGeneModel();
+		int exitStatus = 0;
+		try {
+			exitStatus = sp.setup(args);
+		} catch (Exception e) {
+			exitStatus = 2;
+			if (null != logger) {
+				logger.error("Exception caught whilst running VcfAddGeneModel:", e);
+			} else {
+				System.err.println("Exception caught whilst running VcfAddGeneModel: " + e.getMessage());
+				System.err.println(Messages.GENE_MODEL_USAGE);
+			}
+		}
+		
+		if (null != logger) {
+			logger.logFinalExecutionStats(exitStatus);
+		}
+		System.exit(exitStatus);
+	}
+	
+	protected int setup(String [] args) throws Exception {
+		int returnStatus = 1;
+		if (null == args || args.length == 0) {
+			System.err.println(Messages.GENE_MODEL_USAGE);
+			System.exit(1);
+		}
+		Options options = new Options(args);
+
+		if (options.hasHelpOption()) {
+			System.err.println(Messages.GENE_MODEL_USAGE);
+			options.displayHelp();
+			returnStatus = 0;
+		} else if (options.hasVersionOption()) {
+			System.err.println(Messages.getVersionMessage());
+			returnStatus = 0;
+		} else if ( ! options.hasLogOption()) {
+			System.err.println(Messages.GENE_MODEL_USAGE);
+		} else {
+			// configure logging
+			logFile = options.getLog();
+			logger = QLoggerFactory.getLogger(VcfAddGeneModel.class, logFile, options.getLogLevel());
+			
+			
+			String [] cmdLineOutputFiles = options.getOutputFileNames();
+			if (null != cmdLineOutputFiles && cmdLineOutputFiles.length > 0) {
+				outputVcf = cmdLineOutputFiles[0];
+			}
+			
+			options.getGeneModelFile().ifPresent(gm -> geneModelFile = gm);
+			
+			String [] cmdLineInputFiles = options.getInputFileNames();
+			if (null != cmdLineInputFiles && cmdLineInputFiles.length > 0) {
+				inputVcf = cmdLineInputFiles[0];
+			}
+			
+			logger.logInitialExecutionStats("VcfAddGeneModel", VcfAddGeneModel.class.getPackage().getImplementationVersion(), args);
+			
+			return engage();
+		}
+		return returnStatus;
+	}
+
+}

--- a/qsignature/src/org/qcmg/sig/messages.properties
+++ b/qsignature/src/org/qcmg/sig/messages.properties
@@ -3,6 +3,7 @@ COMPARE_USAGE = usage: java -cp qsignature.jar org.qcmg.sig.Compare -log <log_fi
 GENERATOR_USAGE = usage: java -cp qsignature.jar org.qcmg.sig.SignatureGeneratorBespoke -snpPositions <file containing positions of interest> -illuminaArraysDesign <Illumina arrays design document - contains list of snp ids and whether they should be complemented> -input <bam or snp chip file, or folder containing bams or snp chip files> -output <output directory where qsig.xml files will be written to> -log <log_file>
 POSITIONS_PROFILER_USAGE = usage: java -cp qsignature.jar org.qcmg.sig.PositionsProfiler -log <log_file> -snpPositions <snp_positions_vcf_file>
 VCF_PROFILER_USAGE = usage: java -cp qsignature.jar org.qcmg.sig.VcfProfiler -log <log_file> -input <qsignature_generated_vcf_file> -snpPositions <snp_positions_vcf_file> -output <output_file.json>
+GENE_MODEL_USAGE = usage: java -cp qsignature.jar org.qcmg.sig.VcfAddGeneModel -log <log_file> -input <snp positions vcf file> -geneModel <gene model gtf file> -output <snp positions vcf file with gene model information added>
 MISSING_INPUT_OPTIONS = You must specify at least one -i option
 MISSING_DIRECTORY_OPTION = You must specify a -d option indicating the path to be used to find signature files
 INSUFFICIENT_INPUT_FILES = Insufficient input files

--- a/qsignature/test/org/qcmg/sig/VcfAddGeneModelTest.java
+++ b/qsignature/test/org/qcmg/sig/VcfAddGeneModelTest.java
@@ -1,0 +1,102 @@
+package org.qcmg.sig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.vcf.VcfRecord;
+import org.qcmg.qio.vcf.VcfFileReader;
+import org.qcmg.sig.model.SigVcfMeta;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class VcfAddGeneModelTest {
+	
+	@Rule
+	public TemporaryFolder testFolder = new TemporaryFolder();
+	public VcfAddGeneModel vp;
+	
+	@Before
+	public void setup() {
+		vp = new VcfAddGeneModel();
+	}
+	
+	@Test
+    public void runProcess() throws Exception {
+    	final File logFile = testFolder.newFile("runProcess.log");
+    	final File inputVcfFile = testFolder.newFile("runProcess.snps.vcf");
+    	final File geneModelFile = testFolder.newFile("runProcess.gene.model.gtf");
+    	final String outputFileName = inputVcfFile.getAbsolutePath() + ".with.gene.model.vcf";
+		final File outputFile = new File(outputFileName);
+	    	
+	    writeSnpPositionsVcf(inputVcfFile);
+	    writeGeneModelFile(geneModelFile);
+	    	
+    	final int exitStatus = vp.setup(new String[] {"--log" , logFile.getAbsolutePath(), "--geneModel" , geneModelFile.getAbsolutePath(), "--input" , inputVcfFile.getAbsolutePath(), "--output", outputFileName} );
+    	assertEquals(0, exitStatus);
+    	assertTrue(outputFile.exists());
+    	
+    	
+    	/*
+    	 * load in VcfRecords and check to see if gene model info has been added
+    	 */
+    	List<VcfRecord> vcfRecs = new ArrayList<>();
+    	try(VcfFileReader reader = new VcfFileReader(outputFile)) {
+    		for (VcfRecord rec : reader) {
+    			vcfRecs.add(rec);
+    		}
+    	}
+    	
+    	assertEquals(6, vcfRecs.size());
+    	assertEquals(3, vcfRecs.stream().filter(vcf -> ".".equals(vcf.getInfo())).count());
+    	
+    	
+    	for (VcfRecord rec : vcfRecs) {
+    		if (rec.getPosition() == 52651) {
+    			assertEquals(true, rec.getInfo().startsWith("gene_id=123_456;gene_version=15;transcript_id=ENST00000480186;transcript_version=7;"));
+    		} else if (rec.getPosition() == 108826383) {
+    			assertEquals(rec.getInfo(), "gene_id=ENSG00000131686;gene_version=15;transcript_id=ENST00000480186;transcript_version=7;gene_name=CA6;gene_source=ensembl_havana;gene_biotype=protein_coding;transcript_name=CA6-205;transcript_source=ensembl_havana;transcript_biotype=protein_coding;tag=basic;transcript_support_level=2;");
+    		} else if (rec.getPosition() == 159441457) {
+    			assertEquals(true, rec.getInfo().startsWith("gene_id=987_654;gene_version=15;transcript_id=ENST00000480186;transcript_version=7;"));
+    		} else {
+    			assertEquals(true, ".".equals(rec.getInfo()));
+    		}
+    	}
+    }
+	
+	static void writeSnpPositionsVcf(File output) throws IOException {
+    	try (Writer writer = new FileWriter(output);) {
+    		writer.write("##fileformat=VCFv4.2\n");
+    		writer.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n");
+    		writer.write("chr1	52651	.	T	.	.	.	.\n");
+    		writer.write("chr4	75406448	.	T	.	.	.	.\n");
+    		writer.write("chr4	95733906	.	T	.	.	.	.\n");
+    		writer.write("chr4	108826383	.	T	.	.	.	.\n");
+    		writer.write("chr4	159441457	.	T	.	.	.	.\n");
+    		writer.write("chr12	126890980	.	T	.	.	.	.\n");
+    	}
+    }
+	
+	 static void writeGeneModelFile(File output) throws IOException {
+    	try (Writer writer = new FileWriter(output);) {
+    		writer.write("chr1	ensembl_havana	exon	51651	53651	.	+	.	gene_id \"123_456\"; gene_version \"15\"; transcript_id \"ENST00000480186\"; transcript_version \"7\"; exon_number \"3\"; gene_name \"CA6\"; gene_source \"ensembl_havana\"; gene_biotype \"protein_coding\"; transcript_name \"CA6-205\"; transcript_source \"ensembl_havana\"; transcript_biotype \"protein_coding\"; exon_id \"ENSE00001913776\"; exon_version \"2\"; tag \"basic\"; transcript_support_level \"2\";\n");
+			writer.write("chr4	ensembl_havana	CDS	75405448	75407448	.	+	2	gene_id \"ENSG00000131686\"; gene_version \"15\"; transcript_id \"ENST00000480186\"; transcript_version \"7\"; exon_number \"3\"; gene_name \"CA6\"; gene_source \"ensembl_havana\"; gene_biotype \"protein_coding\"; transcript_name \"CA6-205\"; transcript_source \"ensembl_havana\"; transcript_biotype \"protein_coding\"; protein_id \"ENSP00000435280\"; protein_version \"1\"; tag \"basic\"; transcript_support_level \"2\";\n");
+			writer.write("chr4	ensembl_havana	stop_codon	95733806	95733956	.	+	0	gene_id \"ENSG00000131686\"; gene_version \"15\"; transcript_id \"ENST00000480186\"; transcript_version \"7\"; exon_number \"3\"; gene_name \"CA6\"; gene_source \"ensembl_havana\"; gene_biotype \"protein_coding\"; transcript_name \"CA6-205\"; transcript_source \"ensembl_havana\"; transcript_biotype \"protein_coding\"; tag \"basic\"; transcript_support_level \"2\";\n");
+			writer.write("chr4	ensembl_havana	five_prime_utr	108826283	108826483	.	+	.	gene_id \"ENSG00000131686\"; gene_version \"15\"; transcript_id \"ENST00000480186\"; transcript_version \"7\"; gene_name \"CA6\"; gene_source \"ensembl_havana\"; gene_biotype \"protein_coding\"; transcript_name \"CA6-205\"; transcript_source \"ensembl_havana\"; transcript_biotype \"protein_coding\"; tag \"basic\"; transcript_support_level \"2\";\n");
+			writer.write("chr4	ensembl_havana	three_prime_utr	159441357	159441557	.	+	.	gene_id \"987_654\"; gene_version \"15\"; transcript_id \"ENST00000480186\"; transcript_version \"7\"; gene_name \"CA6\"; gene_source \"ensembl_havana\"; gene_biotype \"protein_coding\"; transcript_name \"CA6-205\"; transcript_source \"ensembl_havana\"; transcript_biotype \"protein_coding\"; tag \"basic\"; transcript_support_level \"2\";\n");
+			writer.write("chr12	ensembl_havana	transcript	126890970	126890990	.	+	.	gene_id \"ENSG00000131686\"; gene_version \"15\"; transcript_id \"ENST00000377436\"; transcript_version \"6\"; gene_name \"CA6\"; gene_source \"ensembl_havana\"; gene_biotype \"protein_coding\"; transcript_name \"CA6-201\"; transcript_source \"ensembl_havana\"; transcript_biotype \"protein_coding\"; tag \"CCDS\"; ccds_id \"CCDS57970\"; tag \"basic\"; transcript_support_level \"1\";\n");
+    		
+    	}
+    }
+}


### PR DESCRIPTION
# Description

Added class (`VcfAddGeneModel`) that will populate the info field of a vcf record with the corresponding info from a (supplied) gene model file.
Intended use case is for the rare occasions where a new qsignature snp positions vcf file is being created and gene model annotations are required.


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

A new unit test has been created to verify that the new feature is working as expected.
Existing unit tests pass

# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
