### PR TITLE
fix(q3tiledaligner): bug in comparator caused IllegalArgumentException

### DIFF
--- a/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TARecordUtilTest.java
+++ b/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TARecordUtilTest.java
@@ -2659,6 +2659,15 @@ public class TARecordUtilTest {
 		assertEquals(false, TARecordUtil.doGenomicPositionsOverlap(1994, 2121, 2011, 2129, 149));
 	}
 	
+	@Test
+	public void compareILPs() {
+		IntLongPair constant = new IntLongPair(2293761, 122046073075177l);
+		IntLongPair ilp1 = new IntLongPair(1507329, 4611878433244640844l);
+		IntLongPair ilp2 = new IntLongPair(1507329, 4611878433244640646l);
+		assertEquals(0, TARecordUtil.compareILPs(ilp1, ilp2, constant));
+		assertEquals(0, TARecordUtil.compareILPs(ilp2, ilp1, constant));
+	}
+	
 	private static long getLong(long position, short sequenceTilePosition, boolean forwardStrand) {
 		long l = NumberUtils.addShortToLong(position, sequenceTilePosition, TARecordUtil.TILE_OFFSET);
 		if ( ! forwardStrand) {

--- a/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TARecordUtilTest.java
+++ b/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TARecordUtilTest.java
@@ -2666,6 +2666,12 @@ public class TARecordUtilTest {
 		IntLongPair ilp2 = new IntLongPair(1507329, 4611878433244640646l);
 		assertEquals(0, TARecordUtil.compareILPs(ilp1, ilp2, constant));
 		assertEquals(0, TARecordUtil.compareILPs(ilp2, ilp1, constant));
+		
+		IntLongPair ilp3 = new IntLongPair(1507329, 4611878433244640946l);
+		assertEquals(-1, TARecordUtil.compareILPs(ilp1, ilp3, constant));
+		assertEquals(1, TARecordUtil.compareILPs(ilp3, ilp1, constant));
+		assertEquals(-1, TARecordUtil.compareILPs(ilp2, ilp3, constant));
+		assertEquals(1, TARecordUtil.compareILPs(ilp3, ilp2, constant));
 	}
 	
 	private static long getLong(long position, short sequenceTilePosition, boolean forwardStrand) {

--- a/qcommon/src/org/qcmg/common/model/BLATRecord.java
+++ b/qcommon/src/org/qcmg/common/model/BLATRecord.java
@@ -10,10 +10,11 @@ package org.qcmg.common.model;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.TabTokenizer;
 
-import com.amazonaws.util.StringUtils;
+//import com.amazonaws.util.StringUtils;
 
 /**
  * Class representing a result returned from BLAT psl file

--- a/qcommon/src/org/qcmg/common/model/BLATRecord.java
+++ b/qcommon/src/org/qcmg/common/model/BLATRecord.java
@@ -641,7 +641,7 @@ public class BLATRecord implements Comparable<BLATRecord> {
 	
 	@Override
 	public int compareTo(BLATRecord o) {
-		int diff = this.qName.compareTo(o.getQName());
+		int diff = (null != this.qName && null != o.getQName()) ? this.qName.compareTo(o.getQName()) : null != this.qName ? -1 : null != o.getQName() ? 1 : 0;
 		if (diff != 0) {
 			return diff;
 		} else {

--- a/qcommon/test/org/qcmg/common/model/BLATRecordTest.java
+++ b/qcommon/test/org/qcmg/common/model/BLATRecordTest.java
@@ -41,6 +41,37 @@ public class BLATRecordTest {
 		assertEquals(true, br.isValid());
 		assertEquals(49, br.getScore());
 	}
+	
+	@Test
+	public void compare() {
+		String b = "57	7	0	0	1	1	0	0	+	name	66	-1	64	GL000219.1	12345	165413	165478	2	43,19	1,46	165414,165459";
+		BLATRecord br1 = new BLATRecord.Builder(b).build();
+		BLATRecord br2 = new BLATRecord.Builder(b).build();
+		
+		assertEquals(0, br1.compareTo(br2));
+		assertEquals(0, br2.compareTo(br1));
+		
+		br2.setQName(null);
+		assertEquals(-1, br1.compareTo(br2));
+		assertEquals(1, br2.compareTo(br1));
+		br1.setQName(null);
+		assertEquals(0, br1.compareTo(br2));
+		assertEquals(0, br2.compareTo(br1));
+		
+		b = "57	7	0	0	1	1	0	0	+	name	66	-1	64	GL000219.1	12345	165413	165478	2	43,19	1,46	165414,165459";
+		String c = "58	7	0	0	1	1	0	0	+	name	66	-1	64	GL000219.1	12345	165413	165478	2	43,19	1,46	165414,165459";
+		br1 = new BLATRecord.Builder(b).build();
+		br2 = new BLATRecord.Builder(c).build();
+		assertEquals(-1, br1.compareTo(br2));
+		assertEquals(1, br2.compareTo(br1));
+		br1.setQName(null);
+		assertEquals(1, br1.compareTo(br2));
+		assertEquals(-1, br2.compareTo(br1));
+		br1.setQName("name");
+		br2.setQName(null);
+		assertEquals(-1, br1.compareTo(br2));
+		assertEquals(1, br2.compareTo(br1));
+	}
 
 	@Test
 	public void getScore() {
@@ -71,6 +102,44 @@ public class BLATRecordTest {
 		recordsList = Arrays.asList(br, br2);
 		recordsList.sort(null);
 		assertEquals(br2, recordsList.get(0));
+	}
+	
+	@Test
+	public void sortingName() {
+		BLATRecord br1 = new BLATRecord.Builder("85	12	0	0	0	0	0	0	+	null	238	94	191	chr2	243199373	33141559	33141656	1	97	94	33141559").build();
+		BLATRecord br2 = new BLATRecord.Builder("77	0	0	3	0	0	5	15	-	null	238	2	94	chr2	243199373	33141310	33141387	6	9,6,4,21,25,12	144,158,167,175,198,224	33141310,33141319,33141325,33141329,33141350,33141375").build();
+		BLATRecord br3 = new BLATRecord.Builder("77	0	0	0	2	4	1	5	-	null	238	156	238	chr16	90354753	56226225	56226306	4	61,3,5,8	0,66,69,74	56226225,56226286,56226291,56226298").build();
+		List<BLATRecord> list = Arrays.asList(br1, br2, br3);
+		list.sort(null);
+		assertEquals(br2, list.get(0));
+		assertEquals(br1, list.get(1));
+		
+		/*
+		 * set names to null and sort - should be same order
+		 */
+		br1.setQName(null);
+		br2.setQName(null);
+		br3.setQName(null);
+		list.sort(null);
+		assertEquals(br2, list.get(0));
+		assertEquals(br1, list.get(1));
+		
+		/*
+		 * if just 1 name is set, that will top the list
+		 */
+		br1.setQName("name");
+		list.sort(null);
+		assertEquals(br1, list.get(0));
+		assertEquals(br2, list.get(1));
+		
+		/*
+		 * another name - this should appear before the other name
+		 */
+		br3.setQName("AAname");
+		list.sort(null);
+		assertEquals(br3, list.get(0));
+		assertEquals(br1, list.get(1));
+		
 	}
 	
 	@Test


### PR DESCRIPTION
# Description

When sorting IntLongPair objects in a list, the comparator was ignoring the case where they could be equal. In certain circumstances this will throw an IllegalArgumentException "Comparison method violates its general contract!"

`TARecordUtil.getBestILPFromList` method had a lambda expression that sorted a list of `IntLongPair` objects.
It would not return 0 (the presumption being that you would never find 2 "equal" `IntLongPair` objects).

This caused the problem when comparing the following 2 objects:

```
IntLongPair ilp1 = new IntLongPair(1507329, 4611878433244640844l);
IntLongPair ilp2 = new IntLongPair(1507329, 4611878433244640646l);
```

`compare(ilp1, ilp2)` returns 1
`compare(ilp2, ilp1) `also returns 1
This violates the general contract.

The fix was to return 0 when 2 `IntLongPair` objects are deemed "equal" (as they are in this case)


Also changed here is the compareTo method in `BLATRecord` which now no longer throws a NPE when comparing records that have a `null` name. Some unit tests accompany this change.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Additional unit test has been added. Updated code runs (without error) against sequence that caused initial `IllegalArgumentException`

# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
