### PR TITLE
qp2 kmers tweak

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.SequenceUtil;
@@ -340,11 +341,9 @@ public class BamSummaryReport extends SummaryReport {
 	public void parseRecord(final SAMRecord record) {
  		updateRecordsInputed();
  				
-		String readGroup = XmlUtils.UNKNOWN_READGROUP;
-		if (record.getReadGroup() != null && record.getReadGroup().getId() != null) {
-			readGroup = record.getReadGroup().getReadGroupId();								
-		}
-		
+		SAMReadGroupRecord srgr = record.getReadGroup();
+		String readGroup = srgr == null ? XmlUtils.UNKNOWN_READGROUP : srgr.getReadGroupId();
+
 		final int order = (!record.getReadPairedFlag()) ? 0 : 
 			(record.getFirstOfPairFlag()) ? 1 : 2;	
 		

--- a/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/summarise/KmersSummaryTest.java
@@ -40,13 +40,43 @@ public class KmersSummaryTest {
 	}
 
 	@Test
+	public void incrementInt() {
+		assertEquals(1, KmersSummary.incrementInt(0, (byte) 'A', 3));
+		assertEquals(9, KmersSummary.incrementInt(1, (byte) 'A', 3));
+
+		int kmerId = 0;
+		for (byte b : new byte[]{'A','A','A','A','A','A'}) {
+			kmerId = KmersSummary.incrementInt(kmerId, b, 3);
+		}
+		assertEquals(Integer.parseUnsignedInt("001001001001001001", 2), kmerId);
+
+		kmerId = 0;
+		for (byte b : new byte[]{'A','A','T','G','C','A'}) {
+			kmerId = KmersSummary.incrementInt(kmerId, b, 3);
+		}
+		assertEquals(Integer.parseUnsignedInt("001001100011010001", 2), kmerId);
+	}
+
+	@Test
+	public void getBitMaskValue() {
+		assertEquals(262143, KmersSummary.BIT_MASK_VALUE);
+	}
+
+	@Test
+	public void getEntry() {
+		assertEquals(Integer.parseUnsignedInt("001001001001001001", 2), KmersSummary.getEntry(new byte[] {'A','A','A','A','A','A'}));
+//		assertEquals(Integer.parseUnsignedInt("001010011100001001", 2), KmersSummary.getEntry(new byte[] {'A','A','T','G','C','A'}));
+		assertEquals(Integer.parseUnsignedInt("001001100011010001", 2), KmersSummary.getEntry(new byte[] {'A','A','T','G','C','A'}));
+	}
+		 
+	@Test
 	public void producerTest() {
 		assertEquals("A,T,G,C,N", KmersSummary.producer(1,"",true));
 		assertEquals("A,T,G,C", KmersSummary.producer(1,"",false));
-		assertEquals("AA,AT,AG,AC,TA,TT,TG,TC,GA,GT,GG,GC,CA,CT,CG,CC", KmersSummary.producer(2,"",false));		
+		assertEquals("AA,AT,AG,AC,TA,TT,TG,TC,GA,GT,GG,GC,CA,CT,CG,CC", KmersSummary.producer(2,"",false));
 	}
-	
-	@Ignore 
+
+	@Test
 	// speed test should be ignore due to time consuming
 	public void getPossibleKmerStringTest()  {
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
@@ -54,175 +84,177 @@ public class KmersSummaryTest {
 		assertEquals((int)Math.pow(5,6), kmers.length);
 		kmers = summary.getPossibleKmerString(6, false);
 		assertEquals((int)Math.pow(4,6), kmers.length);
-				
+
 		// test speed between split and subString
-		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");  			
-		LocalDateTime now = LocalDateTime.now(); 
-		System.out.println(dtf.format(now)); 
-		
+		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+		LocalDateTime now = LocalDateTime.now();
+		System.out.println(dtf.format(now));
+
 		// calling producer with split 101 times
 		String[] mers1 = summary.getPossibleKmerString(6, false);
 		for (int  i = 0; i < 100; i ++) {
 			mers1 = summary.getPossibleKmerString(6, false);
 		}
-		assertTrue(mers1.length == 4096);
-		System.out.println("the finished producer with split 101 times "); 
-		
-		now = LocalDateTime.now(); 
-		System.out.println(dtf.format(now));		
-		System.out.println("calling producer with subString 101 times "); 
-		
+		assertEquals(4096, mers1.length);
+		System.out.println("the finished producer with split 101 times ");
+
+		now = LocalDateTime.now();
+		System.out.println(dtf.format(now));
+		System.out.println("calling producer with subString 101 times ");
+
 		List<String> mers2 = new ArrayList<>();
 		String str = KmersSummary.producer(6, "", false);
 		while(str.contains(Constants.COMMA_STRING)) {
-			int pos =  str.indexOf(Constants.COMMA_STRING); 
+			int pos =  str.indexOf(Constants.COMMA_STRING);
 			mers2.add(str.substring(0, pos));
-			str = str.substring(pos+1);				
+			str = str.substring(pos+1);
 		}
 		mers2.add(str); // add last mer
 		for (int  i = 0; i < 100; i ++) {
 			str = KmersSummary.producer(6, "", false);
 			mers2 = new ArrayList<>();
 			while(str.contains(Constants.COMMA_STRING)) {
-				int pos =  str.indexOf(Constants.COMMA_STRING); 
+				int pos =  str.indexOf(Constants.COMMA_STRING);
 				mers2.add(str.substring(0, pos));
-				str = str.substring(pos+1);		
+				str = str.substring(pos+1);
 			}
-			mers2.add(str); // add last mer			
+			mers2.add(str); // add last mer
 		}
-		assertTrue(mers2.size() == 4096);
-		now = LocalDateTime.now(); 
+		assertEquals(4096, mers2.size());
+		now = LocalDateTime.now();
 		System.out.println(dtf.format(now));
-		System.out.println("the finished producer with subString 100 times "); 				
+		System.out.println("the finished producer with subString 100 times ");
 	}
-	
+
 	@Test
-	public void bothReversedTest() throws IOException {		
-		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
- 		try(SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);) {
- 			for (SAMRecord record : reader) {
-				final int order = (!record.getReadPairedFlag())? 0: (record.getFirstOfPairFlag())? 1 : 2;	
-				summary.parseKmers(record.getReadBases(), true, order);				
-			} 
+	public void bothReversedTest() throws IOException {
+		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+		try(SamReader reader = SAMFileReaderFactory.createSAMFileReader(input)) {
+			for (SAMRecord record : reader) {
+				final int order = (!record.getReadPairedFlag())? 0: (record.getFirstOfPairFlag())? 1 : 2;
+				summary.parseKmers(record.getReadBases(), true, order);
+//				summary.parseKmers(record.getReadBases(), true, order, false);
+			}
 		}
- 		
+
 		// kmers3
-		//  CAGNG TTAGG <= GTCNCAATCC <= CCTAACNCTG		 first  set to reverse 
- 		String[] bases1 = new String[] {"CAG","AGN","GNG","NGT" ,"GTT"};
- 		//  AGNG TTAGG <= TCNCAATCC  <= CCTAACNCT		 second	 set to reverse
- 		String[] bases2 = new String[] {"AGN","GNG","NGT" ,"GTT"};
- 		for (int i = 0; i < bases2.length; i++) {
- 			assertTrue(summary.getCount(i, bases1[i], 1) == 1);
- 			assertTrue(summary.getCount(i, bases1[i], 2) == 0);
- 			assertTrue(summary.getCount(i, bases2[i], 2) == 1);
- 			assertTrue(summary.getCount(i, bases2[i], 1) == 0); 			
- 		}
- 		assertTrue(summary.getCount(4, bases1[4], 1) == 1);		 
+		//  CAGNG TTAGG <= GTCNCAATCC <= CCTAACNCTG		 first  set to reverse
+		String[] bases1 = new String[] {"CAG","AGN","GNG","NGT" ,"GTT"};
+		//  AGNG TTAGG <= TCNCAATCC  <= CCTAACNCT		 second	 set to reverse
+		String[] bases2 = new String[] {"AGN","GNG","NGT" ,"GTT"};
+		for (int i = 0; i < bases2.length; i++) {
+			assertEquals(1, summary.getCount(i, bases1[i], 1));
+			assertEquals(0, summary.getCount(i, bases1[i], 2));
+			assertEquals(1, summary.getCount(i, bases2[i], 2));
+			assertEquals(0, summary.getCount(i, bases2[i], 1));
+		}
+		assertEquals(1, summary.getCount(4, bases1[4], 1));
 	}
-	
+
 	@Test
 	public void toXmlFastqTest() throws  ParserConfigurationException {
-		
+
 		final String base1 = "CAGNGTTAGGTTTTT";
 		final String base2 = "CCCCGTTAGGTTTTTT";
-		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
-		// prepair data base only no strand and pair info		
+		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+		// prepair data base only no strand and pair info
 		summary.parseKmers(base1.getBytes() , false, 0);
 		summary.parseKmers(base2.getBytes() , false, 0);
-		
+
 		Element root = XmlElementUtils.createRootElement("root", null);
 		summary.toXml(root, 2, true);
-				
+
 		// only one <sequenceMetrics>
 		List<Element> eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS);
 		assertEquals(eles.size(), 1);
 		assertEquals(eles.get(0).getAttribute(XmlUtils.NAME), "2mers");
 		assertEquals(1, eles.get(0).getChildNodes().getLength());
-		
+
 		// check <variableGroup...>
 		Element ele = (Element)eles.get(0).getFirstChild();
 		assertEquals(ele.getAttribute(XmlUtils.NAME), "2mers") ;
-		// base.length -3 
+		// base.length -3
 		// cycle number = base.length - KmersSummary.maxKmers = 16-6 that is [1,11]
 		assertEquals(11, ele.getChildNodes().getLength());
 		for (int i = 0; i < ele.getChildNodes().getLength(); i ++) {
 			Element baseE = XmlElementUtils.getChildElement(ele, XmlUtils.BASE_CYCLE, i);
-			assertEquals(baseE.getAttribute(XmlUtils.CYCLE), (i+1) + "");
-		}	
-		
+			assert baseE != null;
+			assertEquals(baseE.getAttribute(XmlUtils.CYCLE), String.valueOf(i + 1));
+		}
+
 		// test unpaired bam reads
 		root = XmlElementUtils.createRootElement("root", null);
 		summary.toXml(root, 2, false);
-		eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS);		
+		eles = XmlElementUtils.getChildElementByTagName(root, XmlUtils.SEQUENCE_METRICS);
 		// check <variableGroup...>
 		ele = (Element)eles.get(0).getFirstChild();
 		assertEquals(ele.getAttribute(XmlUtils.NAME), "unPaired") ;
-				
+
 	}
 
 	@Test
-	public void toXmlTest() throws ParserConfigurationException, IOException {		
-		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
- 		try(SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);) {
- 			for (SAMRecord record : reader) {		
-				final int order = (!record.getReadPairedFlag())? 0: (record.getFirstOfPairFlag())? 1 : 2;	
-				summary.parseKmers(record.getReadBases(), record.getReadNegativeStrandFlag(), order);				
-			} 
+	public void toXmlTest() throws ParserConfigurationException, IOException {
+		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+		try(SamReader reader = SAMFileReaderFactory.createSAMFileReader(input)) {
+			for (SAMRecord record : reader) {
+				final int order = (!record.getReadPairedFlag())? 0: (record.getFirstOfPairFlag())? 1 : 2;
+				summary.parseKmers(record.getReadBases(), record.getReadNegativeStrandFlag(), order);
+			}
 		}
- 		
+
 		Element root = XmlElementUtils.createRootElement("root", null);
 		summary.toXml(root, 3, false);
-		
+
 		// the popular kmers are based on counts on middle, middle of first half, middle of second half
 		// in this testing case it look at firt cyle, middle cycle and last cycle
-		assertEquals("GTT,CAG", StringUtils.join(summary.getPopularKmerString(16,  3, false, 1), ","));
-		assertEquals("TAA,CCT", StringUtils.join(summary.getPopularKmerString(16,  3, false, 2), ","));
-			 
+		assertEquals("GTT,CAG", StringUtils.join(summary.getPopularKmerString(3, 1), ","));
+		assertEquals("TAA,CCT", StringUtils.join(summary.getPopularKmerString(3, 2), ","));
+
 		List<Element> tallysE = XmlElementUtils.getOffspringElementByTagName(root, XmlUtils.TALLY);
 		assertEquals(4, tallysE.size());
-		
+
 		for (Element tE : tallysE) {
-			assertTrue(tE.getAttribute(XmlUtils.COUNT).equals("1"));
+			assertEquals("1", tE.getAttribute(XmlUtils.COUNT));
 			Element baseCycleEle = (Element) tE.getParentNode();
 			Element groupEle =  (Element) baseCycleEle.getParentNode();
 			Element metricEle = (Element) groupEle.getParentNode();
 			if (tE.getAttribute(XmlUtils.VALUE).equals("GTT")) {
-				assertTrue(baseCycleEle.getAttribute(XmlUtils.CYCLE).equals("5"));
-				assertTrue(metricEle.getAttribute(XmlUtils.NAME).equals("3mers"));
-				assertTrue(groupEle.getAttribute(XmlUtils.NAME).equals("firstReadInPair"));			
+				assertEquals("5", baseCycleEle.getAttribute(XmlUtils.CYCLE));
+				assertEquals("3mers", metricEle.getAttribute(XmlUtils.NAME));
+				assertEquals("firstReadInPair", groupEle.getAttribute(XmlUtils.NAME));
 			} else if (tE.getAttribute(XmlUtils.VALUE).equals("TAA")) {
-				assertTrue(baseCycleEle.getAttribute(XmlUtils.CYCLE).equals("3"));
-				assertTrue(metricEle.getAttribute(XmlUtils.NAME).equals("3mers"));
-				assertTrue(groupEle.getAttribute(XmlUtils.NAME).equals("secondReadInPair"));
+				assertEquals("3", baseCycleEle.getAttribute(XmlUtils.CYCLE));
+				assertEquals("3mers", metricEle.getAttribute(XmlUtils.NAME));
+				assertEquals("secondReadInPair", groupEle.getAttribute(XmlUtils.NAME));
 			} else if (tE.getAttribute(XmlUtils.VALUE).equals("CCT")) {
-				assertTrue(baseCycleEle.getAttribute(XmlUtils.CYCLE).equals("1"));
+				assertEquals("1", baseCycleEle.getAttribute(XmlUtils.CYCLE));
 			} else {
-				assertTrue(tE.getAttribute(XmlUtils.VALUE).equals("CAG"));
+				assertEquals("CAG", tE.getAttribute(XmlUtils.VALUE));
 			}
 		}
-		
+
 		//  kmers3
 		//  CAGNG TTAGG <= GTCNCAATCC <= CCTAACNCTG		 first reversed
- 		String[] bases1 = new String[] {"CAG","AGN","GNG","NGT" ,"GTT"};		
- 		//   CCTAACNCT		 second	forwarded
- 		String[] bases2 = new String[] {"CCT","CTA","TAA" ,"AAC"};  // ,"ACN", "CNC", "NCT"};
- 
- 		for (int i = 0; i < bases2.length; i++) {
- 			assertTrue(summary.getCount(i, bases1[i], 1) == 1);
- 			assertTrue(summary.getCount(i, bases1[i], 2) == 0);
- 			assertTrue(summary.getCount(i, bases2[i], 2) == 1);
- 			assertTrue(summary.getCount(i, bases2[i], 1) == 0);		
- 		}
- 		assertTrue(summary.getCount(4, bases1[4], 1) == 1);
+		String[] bases1 = new String[] {"CAG","AGN","GNG","NGT" ,"GTT"};
+		//   CCTAACNCT		 second	forwarded
+		String[] bases2 = new String[] {"CCT","CTA","TAA" ,"AAC"};  // ,"ACN", "CNC", "NCT"};
+
+		for (int i = 0; i < bases2.length; i++) {
+			assertEquals(1, summary.getCount(i, bases1[i], 1));
+			assertEquals(0, summary.getCount(i, bases1[i], 2));
+			assertEquals(1, summary.getCount(i, bases2[i], 2));
+			assertEquals(0, summary.getCount(i, bases2[i], 1));
+		}
+		assertEquals(1, summary.getCount(4, bases1[4], 1));
 	}
-	
-	
+
+
 	@Test
 	public void bothForwardTest() throws  IOException {
-		
+
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
- 		try(SamReader reader = SAMFileReaderFactory.createSAMFileReader(input);) {
- 			for (SAMRecord record : reader) {
+		try(SamReader reader = SAMFileReaderFactory.createSAMFileReader(input)) {
+			for (SAMRecord record : reader) {
 				final int order = (!record.getReadPairedFlag()) ? 0: (record.getFirstOfPairFlag())? 1 : 2;
 				summary.parseKmers(record.getReadBases(), false, order);
 			}
@@ -235,36 +267,36 @@ public class KmersSummaryTest {
 			for (String base : bases) {
 				// second read
 				if ((cycle == 0 || cycle == 1) && base.equals("C")) {
-			 		assertTrue(summary.getCount(cycle, base, 2) == 1);
+					assertEquals(1, summary.getCount(cycle, base, 2));
 				} else if (cycle == 2 && base.equals("T")) {
-			 		assertTrue(summary.getCount(cycle, base, 2) == 1);
+					assertEquals(1, summary.getCount(cycle, base, 2));
 				} else if (cycle == 3 && base.equals("A")) {
-			 		assertTrue(summary.getCount(cycle, base, 2) == 1);
+					assertEquals(1, summary.getCount(cycle, base, 2));
 				} else {
 					// short mers from second reads are discarded
-					assertTrue(summary.getCount(cycle, base, 2) == 0);
+					assertEquals(0, summary.getCount(cycle, base, 2));
 				}
 			}
 		}
-		 // kmers2
-		 bases = summary.getPossibleKmerString(2, true);
-		 for (int cycle = 0; cycle < 10; cycle ++) {
-			 for (String base : bases) {
-					if (cycle == 0 && base.equals("CC")) {
-						assertTrue(summary.getCount(cycle, base, 1) == 1);
-					} else if (cycle == 1 && base.equals("CT")) {
-						assertTrue(summary.getCount(cycle, base, 1) == 1);
-					} else if (cycle == 2 && base.equals("TA")) {
-						assertTrue(summary.getCount(cycle, base, 1) == 1);
-					} else if (cycle == 3 && base.equals("AA")) {
-						assertTrue(summary.getCount(cycle, base, 1) == 1);
-					} else if (cycle == 4 && base.equals("AC")) {
-						assertTrue(summary.getCount(cycle, base, 1) == 1);
-					} else {
-						assertTrue(summary.getCount(cycle, base,1) == 0);
-					}
+		// kmers2
+		bases = summary.getPossibleKmerString(2, true);
+		for (int cycle = 0; cycle < 10; cycle ++) {
+			for (String base : bases) {
+				if (cycle == 0 && base.equals("CC")) {
+					assertEquals(1, summary.getCount(cycle, base, 1));
+				} else if (cycle == 1 && base.equals("CT")) {
+					assertEquals(1, summary.getCount(cycle, base, 1));
+				} else if (cycle == 2 && base.equals("TA")) {
+					assertEquals(1, summary.getCount(cycle, base, 1));
+				} else if (cycle == 3 && base.equals("AA")) {
+					assertEquals(1, summary.getCount(cycle, base, 1));
+				} else if (cycle == 4 && base.equals("AC")) {
+					assertEquals(1, summary.getCount(cycle, base, 1));
+				} else {
+					assertEquals(0, summary.getCount(cycle, base, 1));
 				}
-		 }
+			}
+		}
 	}
 
 	@Test
@@ -274,41 +306,41 @@ public class KmersSummaryTest {
 	 * @throws ParserConfigurationException
 	 */
 	public void bothFirstTest() {
-						
+
 		final String base1 = "CAGNGTTAGGTTTTT";
 		final String base2 = "CCCCGTTAGGTTTTTT";
 
 		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
 		summary.parseKmers(base1.getBytes() , false, 1);
 		summary.parseKmers(base2.getBytes() , false, 1);
-				
-		/** 		
-		 * int midCycle = cycleNo / 2; 
-		 * int bfMidCycle = (midCycle > 20)? midCycle - 10 : (midCycle < kLength)? 0 : midCycle - kLength; 
-		 * int afMidCycle = (midCycle > 20)? midCycle + 10 : (midCycle < kLength)? cycleNo-1 : midCycle + kLength; 
+
+		/**
+		 * int midCycle = cycleNo / 2;
+		 * int bfMidCycle = (midCycle > 20)? midCycle - 10 : (midCycle < kLength)? 0 : midCycle - kLength;
+		 * int afMidCycle = (midCycle > 20)? midCycle + 10 : (midCycle < kLength)? cycleNo-1 : midCycle + kLength;
 		 * according above code:
-		 * popular kmers string is based on cycle: 
+		 * popular kmers string is based on cycle:
 		 * midCycle 5 = ("base2".length() - 6 + 1)/2
 		 * 2 = 5 - mersNo  since 5>mersNo
 		 * 8 = 5+ mersNo
-		 */		
-		
+		 */
+
 		// CAGNG TTAGG TTTTT
 		// CCCCG TTAGG TTTTT T
 		// the mer with N won't belong to possible mer string
-		assertTrue(summary.getCount(2, "GNG", 1) == 1);
-		assertTrue(summary.getCount(2, "CCG", 1) == 1);
+		assertEquals(1, summary.getCount(2, "GNG", 1));
+		assertEquals(1, summary.getCount(2, "CCG", 1));
 		// two same bases
-		assertTrue(summary.getCount(5, "TTA", 1) == 2);
-		assertTrue(summary.getCount(8, "GGT", 1) == 2);
-		
+		assertEquals(2, summary.getCount(5, "TTA", 1));
+		assertEquals(2, summary.getCount(8, "GGT", 1));
+
 		// mers are not counted that is zero unless "TTA,GGT,CCG"
-		assertEquals("TTA,GGT,CCG", StringUtils.join(summary.getPopularKmerString(16,  3, false, 1), ","));
+		assertEquals("TTA,GGT,CCG", StringUtils.join(summary.getPopularKmerString(3, 1), ","));
 		// nothing on second pair
-		assertEquals("", StringUtils.join(summary.getPopularKmerString(16,  3, false, 2), ","));
-				
+		assertEquals("", StringUtils.join(summary.getPopularKmerString(3, 2), ","));
+
 	}
-	
+
 	/*
 	 * here this method only called once, otherwise exception throw due to file "input.sam" exists
 	 */
@@ -318,57 +350,92 @@ public class KmersSummaryTest {
 		data.add("@RG	ID:1959T	SM:eBeads_20091110_CD	DS:rl=50");
 		data.add("@SQ	SN:chr1	LN:249250621");
 		data.add("@CO	Test SAM file for use by KmersSummaryTest.java");
-		
+
 		// reverse first in pair
-		data.add("642_1887_1862	83	chr1	10167	1	5H10M	=	10176	59	CCTAACNCTG	.(01(\"!\"	RG:Z:1959T");	
- 		// forward second in pair
+		data.add("642_1887_1862	83	chr1	10167	1	5H10M	=	10176	59	CCTAACNCTG	.(01(\"!\"	RG:Z:1959T");
+		// forward second in pair
 		data.add("970_1290_1068	163	chr1	10176	3	9M6H	=	10167	-59	CCTAACNCT	I&&HII%%I	RG:Z:1959T");
-		
+
 		File input = testFolder.newFile("input.sam");
 		try(PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(input)))) {
 			for (String line : data)   out.println(line);
 		} catch (IOException e) {
 			Logger.getLogger("KmersSummaryTest").log(
 					Level.WARNING, "IOException caught whilst attempting to write to SAM test file: " + input.getAbsolutePath(), e);
-		}  
-		
-		return input; 
+		}
+
+		return input;
 	}
-		 
+
 	@Test
-	public void maxLengthTest() {	
+	public void timingTest() {
+		final String bases = "AAACCAGGAGGCTAAGTGGGGTGGAAGGGAGTGAGCTCTCGGACTCCCAGGAGTAAAAGCTTCCAAGTTGGGCTCTCACTTCAGCCCCTCCCACACAGGGAAGCCAGATGGGTTCCCCAGGACCGGGATTCCCCAAGGGGGCTGCTCCCA";
+		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+		for (int i = 0 ; i < 100 ; i++) {
+			summary.parseKmers(bases.getBytes(StandardCharsets.UTF_8), true, 1);
+		}
+	}
+	@Test
+	public void twoMerTest() {
+		final String bases = "AAACCAGGAGGCTAAGTGGGGTGGAAGGGAGTGAGCTCTCGGACTCCCAGGAGTAAAAGCTTCCAAGTTGGGCTCTCACTTCAGCCCCTCCCACACAGGGAAGCCAGATGGGTTCCCCAGGACCGGGATTCCCCAAGGGGGCTGCTCCCA";
+		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+		summary.parseKmers(bases.getBytes(StandardCharsets.UTF_8), false, 1);
+
+		assertEquals(1, summary.getCount(0, "AA", 1));
+		assertEquals(1, summary.getCount(0, "AAA", 1));
+		assertEquals(1, summary.getCount(0, "AAACCA", 1));
+		assertEquals(1, summary.getCount(1, "AA", 1));
+		assertEquals(1, summary.getCount(1, "AAC", 1));
+		assertEquals(1, summary.getCount(1, "AACCAG", 1));
+		assertEquals(1, summary.getCount(144, "CTCCCA", 1));
+		assertEquals(1, summary.getCount(144, "CT", 1));
+		assertEquals(1, summary.getCount(144, "CTC", 1));
+
+		/*
+		and now for a reverse strand read
+		 */
+		summary = new KmersSummary(6);
+		summary.parseKmers(bases.getBytes(StandardCharsets.UTF_8), true, 1);
+
+		assertEquals(1, summary.getCount(0, "TGGGAG", 1));
+		assertEquals(1, summary.getCount(0, "TGG", 1));
+		assertEquals(1, summary.getCount(0, "TG", 1));
+	}
+
+	@Test
+	public void maxLengthTest() {
 		final String bases = "ATGC";
-		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);	
-		
+		KmersSummary summary = new KmersSummary(KmersSummary.maxKmers);
+
 		// due to summary.toXml(). getPopularKmerString(...).getPossibleKmerString(kLength, false)
 		// any seq include 'N' will not be reported, it is better to skip 'N' for testing
 		StringBuilder sb=new StringBuilder();
 		for (int i = 0; i < 200; i ++) sb.append(bases);
 		for (int i = 0; i < 100; i ++) {
-			summary.parseKmers(sb.toString().getBytes(StandardCharsets.UTF_8), false, 1);	
+			summary.parseKmers(sb.toString().getBytes(StandardCharsets.UTF_8), false, 1);
 		}
-		
+
 		// reach maximum 1000 base
 		for (int i = 0; i < (KmersSummary.maxCycleNo/bases.length() -200); i ++) {
-			sb.append(bases);		
+			sb.append(bases);
 		}
-		assertTrue(sb.length() == KmersSummary.maxCycleNo);
-		summary.parseKmers(sb.toString().getBytes(StandardCharsets.UTF_8), false, 1);	
-		
-		assertTrue(summary.getCount(793, "TGCATG", 1) == 101);  // cycle + 1 = 794 to xml
-		assertTrue(summary.getCount(797, "TGCATG", 1) == 1);  // cycle + 1 = 794 to xml
-						
-		// test oversize sequence 
+		assertEquals(KmersSummary.maxCycleNo, sb.length());
+		summary.parseKmers(sb.toString().getBytes(StandardCharsets.UTF_8), false, 1);
+
+		assertEquals(101, summary.getCount(793, "TGCATG", 1));  // cycle + 1 = 794 to xml
+		assertEquals(1, summary.getCount(797, "TGCATG", 1));  // cycle + 1 = 794 to xml
+
+		// test oversize sequence
 		try {
 			sb.append("A");
 			assertTrue(sb.length() > KmersSummary.maxCycleNo);
-			summary.parseKmers(sb.toString().getBytes(StandardCharsets.UTF_8), false, 1);	
+			summary.parseKmers(sb.toString().getBytes(StandardCharsets.UTF_8), false, 1);
 			// must fail if no exception happen
-			assertFalse(true);
+			fail();
 		}catch(IllegalArgumentException e) {
-			// expected exception due to large seq 
+			// expected exception due to large seq
 			assertTrue(true);
-		}				
-	}	
+		}
+	}
 }
 


### PR DESCRIPTION
# Description

When profiling `qp2` running against a BAM, it was observed that the consumer threads were spending a large amount of time in `KmersSummary.parseKmers` method.

This PR contains a change to the way that the kmers information is tallied.
Instead of populating 144 byte arrays of length 6 (for a 150 length read), and then looping through each byte in each array to calculate the position in the array score, this new method walks through the read once, and after each byte updates an int, and uses a bit mask to get the appropriate part of the int to get the position in array score.

The resulting code produces the same output (once you have taken into account `qp2`'s random read names)

A change to `BamSummaryReport` was also made to cut down on the number of calls to `SAMRecord.getReadGroup` as this method performs some work.

# Type of change

 - [X] performance change

# How Has This Been Tested?

New and existing unit tests pass.
Code was run against a WGS BAM file and the output was compared against a run using the current code. Results were the same (apart from non-deterministic parts of `qp2` output)

# Are WDL Updates Required?

No changes to the invocation of `qp2` were made and so no wdl updates required.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
