### PR TITLE
build(all projects): gradle updates, now works with vscode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,14 @@
-plugins {
-  id("com.github.spotbugs") version "5.2.1"
+buildscript {
+  repositories {
+    maven {
+      url = uri("https://plugins.gradle.org/m2/")
+    }
+  }
+  dependencies {
+    classpath("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.4")
+  }
 }
-
-defaultTasks "build"
+apply plugin: 'base'
 
 ext {
     revision = "git rev-parse --short HEAD".execute().text.trim()
@@ -13,27 +19,18 @@ ext {
     // its better groovy/gradle too
     file('version.txt').withReader { verionId = it.readLine() + "-" + revision }
 }
-allprojects {
-    apply plugin: 'java-library'
-    apply plugin: 'eclipse'
-    apply plugin: 'checkstyle'
-    apply plugin: 'com.github.spotbugs'
-    sourceCompatibility = 21
-
-    //default value is libs according to java plugin
-    libsDirName = "lib" 
-}
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
 
 subprojects {
-    //config spotbugs
+    apply plugin: 'java'
+    apply plugin: 'checkstyle'
+    apply plugin: 'eclipse'
+    apply plugin: "com.github.spotbugs"
+
+    sourceCompatibility = 21
+
     spotbugs {
-	ignoreFailures = true
-	spotbugsTest.enabled = false
+        ignoreFailures = true
+        spotbugsTest.enabled = false
     }
     //output to html, the default is xml
     spotbugsMain {
@@ -46,45 +43,25 @@ subprojects {
         }
     }
 
-    //config checkstyle
+    repositories {
+        mavenCentral()
+        flatDir(dirs:"$projectDir/../lib")
+    }
+
     checkstyle {
-	configFile = file('../config/google_check.xml')
-	toolVersion = '10.12.4'
-	checkstyleTest.enabled=false
+        configFile = file('../config/google_check.xml')
+        toolVersion = '10.12.4'
+        checkstyleTest.enabled=false
     }
     checkstyleMain.onlyIf {project.hasProperty('checkstyle')}
 
-    repositories { 
-	flatDir(dirs:"$projectDir/../lib")
-	mavenCentral()
-    }
-    dependencies {
-	testImplementation 'junit:junit:4.12' 
+     dependencies {
+        testImplementation 'junit:junit:4.13.2'
     }
 
     sourceSets {
-	main { java.srcDirs=['src']; resources.srcDirs=['src'] }
-	test { java.srcDirs=['test']; test.resources.srcDirs=['test'] }
-    }
-
-    jar.doFirst {
-	manifest { 
-	    if(project.hasProperty('mainClassName') && project.getProperty('mainClassName') != null ) {
-		attributes 'Main-Class' : project.mainClassName 
-	    }
-	    attributes  'Implementation-Title': project.name,
-		'Implementation-Version': verionId,
-		'SVN-Version': revision,
-		'Built-By': System.properties['user.name'],
-		'Date': new java.util.Date().toString(),
-		'Class-Path' : project.configurations.runtimeClasspath.collect { it.name }.join(' ')
-	}
-    }
-
-    build.doLast {
-	println "${project}: copy ${configurations.runtimeClasspath.collect { File file -> file.name }} to ${adamalib} and build/flat"
-	copy { from configurations.runtimeClasspath,libsDirectory; into file('build/flat') }
-	copy { from configurations.runtimeClasspath,libsDirectory; into adamalib }
+        main { java.srcDirs=['src']; resources.srcDirs=['src'] }
+        test { java.srcDirs=['test']; test.resources.srcDirs=['test'] }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip

--- a/q3indel/build.gradle
+++ b/q3indel/build.gradle
@@ -1,11 +1,5 @@
-// plugins {
-//   id("com.github.spotbugs") version "6.0.4"
-// }
-
 apply plugin: 'application'
 apply plugin: 'scala'
-// apply plugin: 'spotbugs'
-
 
 mainClassName = 'au.edu.qimr.indel.Main'
 def scriptname = 'q3indel'

--- a/q3indel/build.gradle
+++ b/q3indel/build.gradle
@@ -1,5 +1,11 @@
+// plugins {
+//   id("com.github.spotbugs") version "6.0.4"
+// }
+
 apply plugin: 'application'
 apply plugin: 'scala'
+// apply plugin: 'spotbugs'
+
 
 mainClassName = 'au.edu.qimr.indel.Main'
 def scriptname = 'q3indel'
@@ -7,21 +13,21 @@ def isExecutable = true
 
 //control the ordering of jars, make sure junit before <tool>.jar
 
-// q3indel has some scala classes that require the following task (along with the scalal plugin and api dependency)
+// q3indel has some scala classes that require the following task (along with the scalal plugin and implementation dependency)
 sourceSets {
         main { java.srcDirs=['src']; resources.srcDirs=['src']; scala.srcDirs=['scala/src'] }
         test { java.srcDirs=['test']; test.resources.srcDirs=['test'];scala.srcDirs=['scala/test'] }
     }
 dependencies {
 
-    api project(':qcommon')
-    api project(':qio')
-    api project(':qbamfilter')
-    api project(':qpicard')
+    implementation project(':qcommon')
+    implementation project(':qio')
+    implementation project(':qbamfilter')
+    implementation project(':qpicard')
 
-    api 'org.scala-lang:scala-library:2.12.18'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
+    implementation 'org.scala-lang:scala-library:2.12.18'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
 }
 
 

--- a/q3indel/src/au/edu/qimr/indel/Main.java
+++ b/q3indel/src/au/edu/qimr/indel/Main.java
@@ -2,7 +2,7 @@ package au.edu.qimr.indel;
 
 import au.edu.qimr.indel.pileup.IndelMT;
 import org.qcmg.common.log.QLogger;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 
 public class Main {
 	

--- a/q3panel/build.gradle
+++ b/q3panel/build.gradle
@@ -7,13 +7,13 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qio')
+    implementation project(':qcommon')
+    implementation project(':qio')
 
-    api 'org.apache.commons:commons-lang3:3.4'
-    api 'net.sf.trove4j:core:3.1.0'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api 'com.github.samtools:htsjdk:4.0.2'
+    implementation 'org.apache.commons:commons-lang3:3.4'
+    implementation 'net.sf.trove4j:core:3.1.0'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'com.github.samtools:htsjdk:4.0.2'
 
-    api group: 'com.io7m.xom',name: 'xom', version: '1.2.10'
+    implementation group: 'com.io7m.xom',name: 'xom', version: '1.2.10'
 }

--- a/q3panel/src/au/edu/qimr/panel/Q3ClinVar.java
+++ b/q3panel/src/au/edu/qimr/panel/Q3ClinVar.java
@@ -65,7 +65,7 @@ import org.qcmg.common.model.ChrPositionComparator;
 import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.Pair;
 import org.qcmg.common.util.TabTokenizer;
 

--- a/q3panel/src/au/edu/qimr/panel/Q3Panel.java
+++ b/q3panel/src/au/edu/qimr/panel/Q3Panel.java
@@ -78,7 +78,7 @@ import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
 import org.qcmg.common.util.IndelUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.Pair;
 import org.qcmg.common.util.SnpUtils;
 import org.qcmg.common.util.TabTokenizer;

--- a/q3tiledaligner/build.gradle
+++ b/q3tiledaligner/build.gradle
@@ -6,11 +6,11 @@ def isExecutable = true
 
 
 dependencies {
-    api project(':qcommon')
-    api project(':qio')
+    implementation project(':qcommon')
+    implementation project(':qio')
 
-    api 'com.github.samtools:htsjdk:4.0.2'
-    api 'net.sf.trove4j:core:3.1.0'
-    api 'org.apache.commons:commons-lang3:3.4'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'com.github.samtools:htsjdk:4.0.2'
+    implementation 'net.sf.trove4j:core:3.1.0'
+    implementation 'org.apache.commons:commons-lang3:3.4'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
 }

--- a/q3vcftools/build.gradle
+++ b/q3vcftools/build.gradle
@@ -11,13 +11,13 @@ configurations {
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qio')
+    implementation project(':qcommon')
+    implementation project(':qio')
 
-    api 'com.github.samtools:htsjdk:4.0.2'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api 'net.sf.trove4j:core:3.1.0'
-    api group: 'com.jcraft', name: 'jsch', version: '0.1.54'
-    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
+    implementation 'com.github.samtools:htsjdk:4.0.2'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.trove4j:core:3.1.0'
+    implementation group: 'com.jcraft', name: 'jsch', version: '0.1.54'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
 }
 

--- a/q3vcftools/src/au/edu/qimr/vcftools/AmalAnalyser.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/AmalAnalyser.java
@@ -20,7 +20,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.TabTokenizer;
 
 

--- a/q3vcftools/src/au/edu/qimr/vcftools/Amalgamator.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Amalgamator.java
@@ -22,7 +22,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.TabTokenizer;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;

--- a/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
@@ -29,7 +29,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.TabTokenizer;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;

--- a/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
@@ -24,7 +24,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;

--- a/q3vcftools/src/au/edu/qimr/vcftools/GoldStandardGenerator.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/GoldStandardGenerator.java
@@ -20,7 +20,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;

--- a/q3vcftools/src/au/edu/qimr/vcftools/MergeSameSamples.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/MergeSameSamples.java
@@ -16,7 +16,7 @@ import org.qcmg.common.meta.QExec;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.vcf.ContentType;
 import org.qcmg.common.vcf.VcfFileMeta;
 import org.qcmg.common.vcf.VcfRecord;

--- a/q3vcftools/src/au/edu/qimr/vcftools/Overlap.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Overlap.java
@@ -34,7 +34,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.TabTokenizer;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;

--- a/qannotate/build.gradle
+++ b/qannotate/build.gradle
@@ -3,8 +3,6 @@ mainClassName = 'au.edu.qimr.qannotate.Main'
 def scriptname = 'qannotate'
 def isExecutable = true
 
-configurations { junit }
-
 /*
 * qannotate requires snpEff and the version currently used is 4.0e
 * This version of the snpEff jar file embedds a version of junit that is old,
@@ -25,14 +23,14 @@ dependencies {
     //this junit is required by snpEff-4.0
     junit ('junit:junit:4.10')
 
-    api project(':qcommon')
-    api project(':qio')
-    api project(':qbamfilter')
+    implementation project(':qcommon')
+    implementation project(':qio')
+    implementation project(':qbamfilter')
+    implementation project(':qpicard')
 
-    api 'com.github.samtools:htsjdk:4.0.2'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api name: 'snpEff', version: '4.0e'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation name: 'snpEff', version: '4.0e'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
 }
 //have to specify test classpath for both snpEff and qannotate 
 sourceSets.test.runtimeClasspath = configurations.junit + sourceSets.test.runtimeClasspath

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafIndelTest.java
@@ -31,7 +31,7 @@ import org.qcmg.qio.vcf.VcfFileReader;
 
 import au.edu.qimr.qannotate.utils.MafElement;
 import au.edu.qimr.qannotate.utils.SnpEffMafRecord;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 
 public class Vcf2mafIndelTest {

--- a/qbamannotate/build.gradle
+++ b/qbamannotate/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     // https://mvnrepository.com/artifact/org.eclipse.persistence/org.eclipse.persistence.moxy
     implementation 'org.eclipse.persistence:org.eclipse.persistence.moxy:3.0.3'
 
+
+    testImplementation project(':qpicard')
     testImplementation  project(':qtesting')
+    // testImplementation 'junit:junit:4.13.2'
 }
 

--- a/qbamfilter/build.gradle
+++ b/qbamfilter/build.gradle
@@ -6,10 +6,10 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qpicard')
+    implementation project(':qcommon')
+    implementation project(':qpicard')
 
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api 'org.antlr:antlr:3.2'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'org.antlr:antlr:3.2'
 }
 

--- a/qbamfix/build.gradle
+++ b/qbamfix/build.gradle
@@ -6,8 +6,8 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qpicard')
-    api 'commons-cli:commons-cli:1.2'
+    implementation project(':qcommon')
+    implementation project(':qpicard')
+    implementation 'commons-cli:commons-cli:1.2'
 }
 

--- a/qbamfix/src/org/qcmg/qbamfix/Main.java
+++ b/qbamfix/src/org/qcmg/qbamfix/Main.java
@@ -12,7 +12,7 @@ import htsjdk.samtools.SAMFileHeader;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.picard.HeaderUtils;
 import org.qcmg.picard.SAMFileReaderFactory;
  

--- a/qbamfix/test/org/qcmg/qbamfix/NewOptionsTest.java
+++ b/qbamfix/test/org/qcmg/qbamfix/NewOptionsTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/qbamfix/test/org/qcmg/qbamfix/ReplaceRGTest.java
+++ b/qbamfix/test/org/qcmg/qbamfix/ReplaceRGTest.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/qbammerge/src/org/qcmg/bammerge/Main.java
+++ b/qbammerge/src/org/qcmg/bammerge/Main.java
@@ -8,7 +8,7 @@ package org.qcmg.bammerge;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 
 /**
  * The entry point for the command-line SAM/BAM merging tool.

--- a/qbasepileup/build.gradle
+++ b/qbasepileup/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qbamfilter')
     implementation project(':qpileup')
-    implementation 'com.github.samtools:htsjdk:4.0.2'
+    implementation project(':qpicard')
     implementation 'net.sf.jopt-simple:jopt-simple:4.6'
     testImplementation  'org.easymock:easymock:5.2.0'
 }

--- a/qcnv/build.gradle
+++ b/qcnv/build.gradle
@@ -6,11 +6,11 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qpicard')
-    api project(':qbamfilter')
+    implementation project(':qcommon')
+    implementation project(':qpicard')
+    implementation project(':qbamfilter')
 
-    api 'commons-cli:commons-cli:1.2'	
-    api group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
+    implementation 'commons-cli:commons-cli:1.2'	
+    implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
 }
 

--- a/qcnv/src/org/qcmg/cnv/Main.java
+++ b/qcnv/src/org/qcmg/cnv/Main.java
@@ -8,7 +8,7 @@ package org.qcmg.cnv;
 
 
 import org.qcmg.common.log.QLogger;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 
 
 public class Main {

--- a/qcommon/build.gradle
+++ b/qcommon/build.gradle
@@ -1,4 +1,5 @@
 def isExecutable = true
+apply plugin: 'java-library'
 
 dependencies {
 		
@@ -13,7 +14,7 @@ dependencies {
     
     //jaxb is removed from JDK9+
     //we need below jar in case to run on JDK9 and above
-    //api 'javax.xml.bind:jaxb-api:2.2.12' 
+    //implementation 'javax.xml.bind:jaxb-api:2.2.12' 
     api 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
 }
 

--- a/qcommon/test/org/qcmg/common/dcc/DccConsequenceTest.java
+++ b/qcommon/test/org/qcmg/common/dcc/DccConsequenceTest.java
@@ -2,7 +2,7 @@ package org.qcmg.common.dcc;
 
 
 import static org.junit.Assert.assertEquals;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/qcommon/test/org/qcmg/common/model/CigarStringComparatorTest.java
+++ b/qcommon/test/org/qcmg/common/model/CigarStringComparatorTest.java
@@ -4,7 +4,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.Map.Entry;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.qcmg.common.model.CigarStringComparator;

--- a/qcommon/test/org/qcmg/common/model/PileupElementComparatorTest.java
+++ b/qcommon/test/org/qcmg/common/model/PileupElementComparatorTest.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/qcommon/test/org/qcmg/common/model/ReferenceNameComparatorTest.java
+++ b/qcommon/test/org/qcmg/common/model/ReferenceNameComparatorTest.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/qio/build.gradle
+++ b/qio/build.gradle
@@ -1,5 +1,5 @@
 def isExecutable = true
 
 dependencies {
-    api project(':qcommon')
+    implementation project(':qcommon')
  } 

--- a/qmaftools/build.gradle
+++ b/qmaftools/build.gradle
@@ -6,11 +6,11 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qio')
-    api project(':qpicard')
-    api project(':qbamfilter')
+    implementation project(':qcommon')
+    implementation project(':qio')
+    implementation project(':qpicard')
+    implementation project(':qbamfilter')
 	
-    api 'net.sf.jopt-simple:jopt-simple:4.6'	
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'	
 }
 

--- a/qmaftools/test/org/qcmg/maf/LiftoverTest.java
+++ b/qmaftools/test/org/qcmg/maf/LiftoverTest.java
@@ -2,7 +2,7 @@ package org.qcmg.maf;
 
 import java.io.File;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/qmaftools/test/org/qcmg/maf/MafAddStuffTest.java
+++ b/qmaftools/test/org/qcmg/maf/MafAddStuffTest.java
@@ -2,7 +2,7 @@ package org.qcmg.maf;
 
 import java.io.FileNotFoundException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/qmito/build.gradle
+++ b/qmito/build.gradle
@@ -5,11 +5,11 @@ def isExecutable = true
 
 dependencies {
 	
-    api 'org.apache.commons:commons-math3:3.3'
+    implementation 'org.apache.commons:commons-math3:3.3'
 	
-    api project(':qcommon')
-    api project(':qbamfilter')
+    implementation project(':qcommon')
+    implementation project(':qbamfilter')
+    implementation project(':qpicard')
 
-    api 'com.github.samtools:htsjdk:4.0.2'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
 }

--- a/qmotif/build.gradle
+++ b/qmotif/build.gradle
@@ -8,12 +8,12 @@ def isExecutable = true
 repositories { mavenCentral() }
 
 dependencies {
-    api project(':qcommon')
-    api project(':qio')
-    api project(':qbamfilter')
-    api project(':qpicard')
+    implementation project(':qcommon')
+    implementation project(':qio')
+    implementation project(':qbamfilter')
+    implementation project(':qpicard')
            
-    api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'	
+    implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'	
 }
 

--- a/qmotif/src/org/qcmg/motif/Motif.java
+++ b/qmotif/src/org/qcmg/motif/Motif.java
@@ -30,7 +30,7 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.model.ChrPositionComparator;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.motif.util.MotifConstants;
 import org.qcmg.motif.util.MotifMode;
 import org.qcmg.motif.util.MotifsAndRegexes;

--- a/qmotif/src/org/qcmg/motif/Summariser.java
+++ b/qmotif/src/org/qcmg/motif/Summariser.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.string.StringUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 
 /**
  * 

--- a/qmule/build.gradle
+++ b/qmule/build.gradle
@@ -6,11 +6,11 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qio')
-    api project(':qpicard')
-    api 'com.google.code.findbugs:findbugs:1.3.9'	
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api 'com.github.broadinstitute:picard:3.1.1'
-    api 'org.broadinstitute:barclay:2.0.0'
+    implementation project(':qcommon')
+    implementation project(':qio')
+    implementation project(':qpicard')
+    implementation 'com.google.code.findbugs:findbugs:1.3.9'	
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'com.github.broadinstitute:picard:3.1.1'
+    implementation 'org.broadinstitute:barclay:2.0.0'
 }

--- a/qmule/src/org/qcmg/qmule/IndelDCCHeader.java
+++ b/qmule/src/org/qcmg/qmule/IndelDCCHeader.java
@@ -21,7 +21,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QDccMeta;
 import org.qcmg.common.meta.QLimsMeta;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.picard.util.QDccMetaFactory;
 import org.qcmg.picard.util.QLimsMetaFactory;

--- a/qmule/src/org/qcmg/qmule/MAF2DCC1.java
+++ b/qmule/src/org/qcmg/qmule/MAF2DCC1.java
@@ -17,7 +17,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.tab.TabbedFileReader;
 import org.qcmg.tab.TabbedFileWriter;
 import org.qcmg.tab.TabbedHeader;

--- a/qmule/src/org/qcmg/qmule/TestJarUpdate.java
+++ b/qmule/src/org/qcmg/qmule/TestJarUpdate.java
@@ -19,7 +19,7 @@ import htsjdk.samtools.SAMFileWriter;
 import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.SAMRecord;
 
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.picard.SAMFileReaderFactory;
 
 public class TestJarUpdate {
@@ -27,94 +27,48 @@ public class TestJarUpdate {
 	private SAMFileWriter writer;
 	private SamReader reader;
 	
-	private void doWork() throws Exception{
+	private void doWork() throws Exception {
 		try {
 			
-			LoadReferencedClasses.loadClasses(getClass());
 			
-//			URL className = getClass().getResource(TestJarUpdate.class.getName());
-//			if (null != className) 
-//				System.out.println("url: " + className.getFile());
-//			else 
-//				System.out.println("url: " + null);
-//			
-//			File jarFile = new File(TestJarUpdate.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-//			if (null != jarFile) 
-//				System.out.println("jarFile: " + jarFile.getName());
-//			else 
-//				System.out.println("jarFile: " + null);
-//			
-//			System.out.println("is file type valid jar: " + FileUtils.isFileTypeValid(jarFile, "jar"));
-//			
-//			System.out.println("BEFORE: no of loaded packages: " + Package.getPackages().length);
-//			
-//			if (FileUtils.isFileTypeValid(jarFile, "jar")) {
-//			
-//				// got jar file - load and 
-//				JarFile jf = new JarFile(jarFile);
-//				Attributes att = jf.getManifest().getMainAttributes();
-//				System.out.println("att.size" + att.size());
-//				String classpath = att.getValue("Class-Path");
-//				System.out.println("classpath: " + classpath);
-//				
-//				String [] jars = classpath.split(" ");
-//				for (String jar : jars) {
-//					JarFile internalJarFile = new JarFile(jar);
-//					Enumeration<JarEntry> enums = internalJarFile.entries();
-//					while (enums.hasMoreElements()) {
-//						JarEntry je = enums.nextElement();
-//						if (FileUtils.isFileTypeValid(je.getName(), "class")) {
-//							String blah = je.getName().replace(".class", "");
-//							blah = blah.replaceAll(System.getProperty("file.separator"), ".");
-//							System.out.println("about to load class: " + blah);
-//							this.getClass().getClassLoader().loadClass(blah);
-//						}
-//					}
-//				}
-//				
-//			}
-//			
-//			System.out.println("AFTER: no of loaded packages: " + Package.getPackages().length);
+			// write to bam file
+			// sleep for a few mins to allow the sam jar file to be removed/replaced
+			// close bam file
+			// tinker with class loader
+			File inputFile = File.createTempFile("testJarUpdateInput", ".sam");
+			inputFile.deleteOnExit();
+			File outputFile = File.createTempFile("testJarUpdateOutput", ".bam");
+			
+			createCoverageSam(inputFile);
 			
 			
-		// write to bam file
-		// sleep for a few mins to allow the sam jar file to be removed/replaced
-		// close bam file
-		// tinker with class loader
-		File inputFile = File.createTempFile("testJarUpdateInput", ".sam");
-		inputFile.deleteOnExit();
-		File outputFile = File.createTempFile("testJarUpdateOutput", ".bam");
-//		outputFile.deleteOnExit();
-		
-		createCoverageSam(inputFile);
-		
-		reader = SAMFileReaderFactory.createSAMFileReader(inputFile);
-		
-		SAMFileHeader header = reader.getFileHeader();
-		List<SAMRecord> recs = new ArrayList<SAMRecord>();
-		
-		for( SAMRecord rec : reader) {
-			recs.add(rec);
-		}
-		
-		
-		SAMFileWriterFactory factory = new SAMFileWriterFactory();
-		
-		writer = factory.makeSAMOrBAMWriter(header, true, outputFile);
-		
-//		for (int i = 0 ; i < 100 ; i++)
-			for( SAMRecord rec : recs) {
-				for (int i = 0 ; i < 100 ; i++)
-					writer.addAlignment(rec);
+			reader = SAMFileReaderFactory.createSAMFileReader(inputFile);
+			
+			SAMFileHeader header = reader.getFileHeader();
+			List<SAMRecord> recs = new ArrayList<>();
+			
+			for (SAMRecord rec : reader) {
+				recs.add(rec);
 			}
-		
-		System.out.println("About to sleep!");
-		System.gc();
-		Thread.sleep(60000);
-		System.out.println("Am awake now");
-		
-		close();
-		System.out.println("DONE!!!");
+			
+			
+			SAMFileWriterFactory factory = new SAMFileWriterFactory();
+			
+			writer = factory.makeSAMOrBAMWriter(header, true, outputFile);
+			
+			for (SAMRecord rec : recs) {
+				for (int i = 0 ; i < 100 ; i++) {
+					writer.addAlignment(rec);
+				}
+			}
+			
+			System.out.println("About to sleep!");
+			System.gc();
+			Thread.sleep(60000);
+			System.out.println("Am awake now");
+			
+			close();
+			System.out.println("DONE!!!");
 		} finally {
 			System.out.println("about to run close quietly");
 			closeQuietly();
@@ -135,7 +89,6 @@ public class TestJarUpdate {
 			reader.close();
 		} catch (Exception e) {
 			System.out.println("Exception caught in close(): ");
-//			e.printStackTrace();
 			throw new Exception("CANNOT_CLOSE_FILES");
 		}
 	}
@@ -144,7 +97,6 @@ public class TestJarUpdate {
 		try {
 			close();
 		} catch (Exception e) {
-//			e.printStackTrace();
 		}
 	}
 	

--- a/qmule/src/org/qcmg/qmule/WiggleFromPileupTakeTwo.java
+++ b/qmule/src/org/qcmg/qmule/WiggleFromPileupTakeTwo.java
@@ -19,7 +19,7 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.PositionRange;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.PileupUtils;
 import org.qcmg.common.util.TabTokenizer;
 import org.qcmg.qio.gff3.Gff3FileReader;

--- a/qmule/test/org/qcmg/qmule/DccToMafTest.java
+++ b/qmule/test/org/qcmg/qmule/DccToMafTest.java
@@ -3,7 +3,7 @@ package org.qcmg.qmule;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/qmule/test/org/qcmg/qmule/util/IGVBatchFileGeneratorTest.java
+++ b/qmule/test/org/qcmg/qmule/util/IGVBatchFileGeneratorTest.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/qmule/test/org/qcmg/qmule/util/TabbedDataLoaderTest.java
+++ b/qmule/test/org/qcmg/qmule/util/TabbedDataLoaderTest.java
@@ -1,6 +1,6 @@
 package org.qcmg.qmule.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/qpicard/build.gradle
+++ b/qpicard/build.gradle
@@ -1,8 +1,9 @@
 def isExecutable = false
+apply plugin: 'java-library'
 
 dependencies {
-    api project(':qcommon')
-    api project(':qio')
+    implementation project(':qcommon')
+    implementation project(':qio')
 	  
     api 'com.github.samtools:htsjdk:4.0.2'
 }

--- a/qpicard/test/org/qcmg/picard/util/PileupElementUtilTest.java
+++ b/qpicard/test/org/qcmg/picard/util/PileupElementUtilTest.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import htsjdk.samtools.SAMUtils;
 
 import org.junit.Ignore;

--- a/qpileup/build.gradle
+++ b/qpileup/build.gradle
@@ -16,17 +16,17 @@ test {
 dependencies {
     ant {  untar(src: "../lib/hdf-java-2.8-bin.tar", dest: "build/deps") }
 
-    api project(':qcommon')
-    api project(':qpicard')
-    api project(':qio')
-    api project(':qbamfilter')
+    implementation project(':qcommon')
+    implementation project(':qpicard')
+    implementation project(':qio')
+    implementation project(':qbamfilter')
 	
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
-    api name: 'jhdf'
-    api name: 'jhdf5'
-    api name: 'jhdfobj'  
-    api name: 'jhdf5obj'  
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
+    implementation name: 'jhdf'
+    implementation name: 'jhdf5'
+    implementation name: 'jhdfobj'  
+    implementation name: 'jhdf5obj'  
 
     testImplementation  'org.easymock:easymock:5.2.0'
 }

--- a/qpileup/src/org/qcmg/pileup/QPileup.java
+++ b/qpileup/src/org/qcmg/pileup/QPileup.java
@@ -9,7 +9,7 @@ import ncsa.hdf.hdf5lib.exceptions.HDF5LibraryException;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.pileup.mode.ViewMT;
 
 public final class QPileup {

--- a/qprofiler/build.gradle
+++ b/qprofiler/build.gradle
@@ -6,12 +6,12 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qpicard')
-    api project(':qio')
-    api project(':qvisualise')
+    implementation project(':qcommon')
+    implementation project(':qpicard')
+    implementation project(':qio')
+    implementation project(':qvisualise')
 
-    api 'org.apache.commons:commons-math3:3.3'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'org.apache.commons:commons-math3:3.3'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
 	
 }

--- a/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
+++ b/qprofiler/src/org/qcmg/qprofiler/QProfiler.java
@@ -29,7 +29,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ProfileType;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.qprofiler.bam.BamSummarizer;
 import org.qcmg.qprofiler.bam.BamSummarizerMT;
 import org.qcmg.qprofiler.fa.FaSummarizerMT;

--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -7,10 +7,10 @@ def isExecutable = true
 
 dependencies {
 		
-    api project(':qcommon')
-    api project(':qpicard')
-    api project(':qio')
+    implementation project(':qcommon')
+    implementation project(':qpicard')
+    implementation project(':qio')
 
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
 }
 

--- a/qsignature/build.gradle
+++ b/qsignature/build.gradle
@@ -7,12 +7,12 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qpicard')
-    api project(':qio')
+    implementation project(':qcommon')
+    implementation project(':qpicard')
+    implementation project(':qio')
     
-    api 'org.apache.commons:commons-math3:3.3'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
+    implementation 'org.apache.commons:commons-math3:3.3'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
 	
 }

--- a/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
+++ b/qsignature/src/org/qcmg/sig/CompareGenotypeBespoke.java
@@ -21,7 +21,7 @@ import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.sig.model.Comparison;
 import org.qcmg.sig.model.SigMeta;
 import org.qcmg.sig.util.ComparisonUtil;

--- a/qsnp/build.gradle
+++ b/qsnp/build.gradle
@@ -26,16 +26,16 @@ sourceSets {
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qio')
-    api project(':qbamfilter')
-    api project(':qpicard')
+    implementation project(':qcommon')
+    implementation project(':qio')
+    implementation project(':qbamfilter')
+    implementation project(':qpicard')
     
-    api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
-    api 'net.sf.trove4j:core:3.1.0'
-    api 'org.apache.commons:commons-lang3:3.4'
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
-    api 'org.lz4:lz4-java:1.5.0'
-    api 'org.scala-lang:scala-library:2.12.18'
+    implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
+    implementation 'net.sf.trove4j:core:3.1.0'
+    implementation 'org.apache.commons:commons-lang3:3.4'
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'org.lz4:lz4-java:1.5.0'
+    implementation 'org.scala-lang:scala-library:2.12.18'
 }
 

--- a/qsnp/src/org/qcmg/snp/BuildCommonSnpsVcf.java
+++ b/qsnp/src/org/qcmg/snp/BuildCommonSnpsVcf.java
@@ -29,7 +29,7 @@ import org.qcmg.common.model.ChrRangePosition;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.common.util.TabTokenizer;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;

--- a/qsnp/src/org/qcmg/snp/Main.java
+++ b/qsnp/src/org/qcmg/snp/Main.java
@@ -14,7 +14,7 @@ import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.FileUtils;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 import org.qcmg.snp.util.IniFileUtil;
 
 /**

--- a/qsplit/build.gradle
+++ b/qsplit/build.gradle
@@ -7,10 +7,10 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qcommon')
-    api project(':qpicard')
+    implementation project(':qcommon')
+    implementation project(':qpicard')
     testImplementation  project(':qtesting')
 	
-    api group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
+    implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
 }
 

--- a/qsplit/src/org/qcmg/split/Main.java
+++ b/qsplit/src/org/qcmg/split/Main.java
@@ -8,7 +8,7 @@ import java.net.URISyntaxException;
 
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
-import org.qcmg.common.util.LoadReferencedClasses;
+
 
 public final class Main {
 	private static int exitStatus = 1; // Default to FAILURE

--- a/qsv/build.gradle
+++ b/qsv/build.gradle
@@ -1,4 +1,3 @@
-
 apply plugin: 'application'
 
 mainClassName = 'org.qcmg.qsv.QSV'
@@ -7,11 +6,13 @@ def isExecutable = true
 
 dependencies {
 
-    api project(':qbamfilter')
-    api project(':qpicard')
-    api project(':q3tiledaligner')
-    api group: 'org.ini4j', name: 'ini4j', version: '0.5.2'	
-    api 'net.sf.jopt-simple:jopt-simple:4.6'	
+    implementation project(':qbamfilter')
+    implementation project(':qpicard')
+    implementation project(':q3tiledaligner')
+    implementation project(':qcommon')
+    implementation project(':qio')
+    implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'	
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'	
 		
     testImplementation  'org.easymock:easymock:5.2.0'
     testImplementation  group: 'commons-io', name: 'commons-io', version: '2.6'

--- a/qtesting/build.gradle
+++ b/qtesting/build.gradle
@@ -1,7 +1,7 @@
 def isExecutable = false
 
 dependencies {
-    api project(':qio')
-    api project(':qcommon')	
+    implementation project(':qio')
+    implementation project(':qcommon')	
 }
 

--- a/qvisualise/build.gradle
+++ b/qvisualise/build.gradle
@@ -6,7 +6,7 @@ def isExecutable = true
 
 
 dependencies {
-    api project(':qcommon')
-    api 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation project(':qcommon')
+    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
 }
 

--- a/qvisualise/test/org/qcmg/qvisualise/OptionsTest.java
+++ b/qvisualise/test/org/qcmg/qvisualise/OptionsTest.java
@@ -1,6 +1,6 @@
 package org.qcmg.qvisualise;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/qvisualise/test/org/qcmg/qvisualise/XmlReportReaderTest.java
+++ b/qvisualise/test/org/qcmg/qvisualise/XmlReportReaderTest.java
@@ -5,7 +5,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Ignore;
 import org.qcmg.qvisualise.report.XmlReportReader;

--- a/qvisualise/test/org/qcmg/qvisualise/util/SummaryByCycleTest.java
+++ b/qvisualise/test/org/qcmg/qvisualise/util/SummaryByCycleTest.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.qcmg.qvisualise.util.SummaryByCycle;

--- a/qvisualise/test/org/qcmg/qvisualise/util/SummaryByCycleUtilsTest.java
+++ b/qvisualise/test/org/qcmg/qvisualise/util/SummaryByCycleUtilsTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Ignore;
 import org.junit.Test;


### PR DESCRIPTION
# Description

Small changes to gradle build files that allows users to use vscode.
Use `implementation` rather that `api` in most projects when declaring dependencies.


# How Has This Been Tested?

Existing tests pass, existing build processes work

# Are WDL Updates Required?
no

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
