### PR TITLE
fix(qannotate): snpeff records were not being dealt with correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,24 @@ subprojects {
         main { java.srcDirs=['src']; resources.srcDirs=['src'] }
         test { java.srcDirs=['test']; test.resources.srcDirs=['test'] }
     }
+    build.doLast {
+	println "${project}: copy ${configurations.runtimeClasspath.collect { File file -> file.name }} to ${adamalib} and build/flat"
+	copy { from configurations.runtimeClasspath,libsDirectory; into file('build/flat') }
+	copy { from configurations.runtimeClasspath,libsDirectory; into adamalib }
+    }
+    jar.doFirst {
+	manifest { 
+	    if(project.hasProperty('mainClassName') && project.getProperty('mainClassName') != null ) {
+		attributes 'Main-Class' : project.mainClassName 
+	    }
+	    attributes  'Implementation-Title': project.name,
+		'Implementation-Version': verionId,
+		'SVN-Version': revision,
+		'Built-By': System.properties['user.name'],
+		'Date': new java.util.Date().toString(),
+		'Class-Path' : project.configurations.runtimeClasspath.collect { it.name }.join(' ')
+	}
+    }
 }
 
 //create adama/build/lib under root before subprojects build

--- a/q3indel/build.gradle
+++ b/q3indel/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation project(':qpicard')
 
     implementation 'org.scala-lang:scala-library:2.12.18'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
 }
 

--- a/q3panel/build.gradle
+++ b/q3panel/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.4'
     implementation 'net.sf.trove4j:core:3.1.0'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'com.github.samtools:htsjdk:4.0.2'
 
     implementation group: 'com.io7m.xom',name: 'xom', version: '1.2.10'

--- a/q3tiledaligner/build.gradle
+++ b/q3tiledaligner/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation 'com.github.samtools:htsjdk:4.0.2'
     implementation 'net.sf.trove4j:core:3.1.0'
     implementation 'org.apache.commons:commons-lang3:3.4'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }

--- a/q3vcftools/build.gradle
+++ b/q3vcftools/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(':qio')
 
     implementation 'com.github.samtools:htsjdk:4.0.2'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'net.sf.trove4j:core:3.1.0'
     implementation group: 'com.jcraft', name: 'jsch', version: '0.1.54'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'

--- a/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
@@ -153,10 +153,10 @@ public class AmalgamatorGS {
 						gsAndAllOnlyCount++;
 					}
 				}
-				String scoreS = score + "/" + (4 + vcfFiles.length);
+				String scoreS = score + SLASH_STRING + (4 + vcfFiles.length);
 				scoreDist.computeIfAbsent(scoreS, v -> new AtomicInteger()).incrementAndGet();
 				ps.println(cp.getChromosome() + TAB + cp.getStartPosition() + TAB +cp.getRef() + TAB
-						+ cp.getAlt() + TAB + Arrays.stream(p.getLeft()).map(s -> null == s ? "./." : s).collect(Collectors.joining(TAB_STRING))
+						+ cp.getAlt() + TAB + Arrays.stream(p.getLeft()).map(s -> null == s ? MISSING_GT : s).collect(Collectors.joining(TAB_STRING))
 						+ TAB +  Arrays.stream(p.getRight()).map(s -> null == s ? MISSING_DATA_STRING : s).collect(Collectors.joining(TAB_STRING))
 						+ TAB +  Arrays.stream(missingACs).map(s -> null == s ? MISSING_DATA_STRING : s).collect(Collectors.joining(TAB_STRING))
 						+ TAB +  Arrays.stream(missingFTs).map(s -> null == s ? MISSING_DATA_STRING : s).collect(Collectors.joining(TAB_STRING))

--- a/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/AmalgamatorGS.java
@@ -169,7 +169,7 @@ public class AmalgamatorGS {
 				}
 				String scoreS = score + "/" + (4 + vcfFiles.length);
 				scoreDist.computeIfAbsent(scoreS, v -> new AtomicInteger()).incrementAndGet();
-				ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + Constants.TAB +cp.getName() + Constants.TAB 
+				ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + Constants.TAB +cp.getRef() + Constants.TAB
 						+ cp.getAlt() + Constants.TAB + Arrays.stream(p.getLeft()).map(s -> null == s ? "./." : s).collect(Collectors.joining(Constants.TAB_STRING))
 						+ Constants.TAB +  Arrays.stream(p.getRight()).map(s -> null == s ? "." : s).collect(Collectors.joining(Constants.TAB_STRING))
 						+ Constants.TAB +  Arrays.stream(missingACs).map(s -> null == s ? "." : s).collect(Collectors.joining(Constants.TAB_STRING))

--- a/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
@@ -1,417 +1,319 @@
 package au.edu.qimr.vcftools;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-
+import org.qcmg.common.log.QLogger;
+import org.qcmg.common.log.QLoggerFactory;
+import org.qcmg.common.meta.QExec;
 import org.qcmg.common.model.ChrPointPosition;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.model.ChrPositionComparator;
 import org.qcmg.common.model.ChrPositionRefAlt;
 import org.qcmg.common.string.StringUtils;
-import org.qcmg.common.log.QLogger;
-import org.qcmg.common.log.QLoggerFactory;
-import org.qcmg.common.meta.QExec;
+import org.qcmg.common.util.ChrPositionUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.common.util.FileUtils;
-
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 import org.qcmg.qio.vcf.VcfFileReader;
 
+import java.io.*;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static org.qcmg.common.util.Constants.MISSING_DATA_STRING;
+import static org.qcmg.common.util.Constants.TAB;
+
 
 public class Classify {
-	
-	private static QLogger logger;
-	private QExec exec;
-	private String[] vcfFiles;
-	private String outputDirectory;
-	private String version;
-	private String logFile;
-	private String goldStandard;
-	private boolean vcfOutput;
-	private int exitStatus;
-	private boolean somatic;
-	private boolean germline;
-	
-	private final Map<ChrPosition, ChrPositionRefAlt> roguePositions = new HashMap<>(1024 * 64);
-	private final List<VcfRecord> roguePositionsMatches = new ArrayList<>(1024 * 64);
-	
-	protected int engage() throws IOException {
-			
-		logger.info("about to load vcf files");
-		loadVcfs();
-		examineMatches();
+
+    private static QLogger logger;
+    private String[] vcfFiles;
+    private String outputDirectory;
+    private String goldStandard;
+    private boolean vcfOutput;
+    private int exitStatus;
+    private boolean somatic;
+    private boolean germline;
+
+    private final Map<ChrPosition, ChrPositionRefAlt> roguePositions = new HashMap<>(1024 * 64);
+    private final List<VcfRecord> roguePositionsMatches = new ArrayList<>(1024 * 64);
+
+    protected int engage() throws IOException {
+
+        logger.info("about to load vcf files");
+        loadVcfs();
+        examineMatches();
 //		writeOutput();
-		return exitStatus;
-	}
-	
-//	private void outputStats() throws FileNotFoundException {
-//	
-//		/*
-//		 * first of all, the happy positions in all 
-//		 */
-//		final int numberOfInputFiles = vcfFiles.length + (null != goldStandard ? 1 : 0);
-//		/*
-//		 * print summary stats
-//		 */
-//		String[] inputs = new String[numberOfInputFiles];
-//		int i = 0;
-//		for (String s : vcfFiles) {
-//			inputs[i++] = s;
-//		}
-//		if (null != goldStandard) {
-//			inputs[i++] = goldStandard;
-//		}
-//		long centreVenn = positions.entrySet().stream().filter(e -> e.getValue().size() == numberOfInputFiles).count();
-//		logger.info("number of variants in centre of venn: " + centreVenn);
-//		
-//		
-////		Map<String, List<ChrPositionRefAlt>> uniqueVariants = new HashMap<>();
-//		Map<String, List<ChrPositionRefAlt>> partiallyUniqueVariants = new HashMap<>();
-//		
-//		/*
-//		 * get variants unique to one of the inputs
-//		 */
-//		positions.entrySet().stream().filter(e -> e.getValue().size() == 1).forEach(e -> {
-//			partiallyUniqueVariants.computeIfAbsent(e.getValue().get(0), v -> new ArrayList<ChrPositionRefAlt>()).add(e.getKey());
-//		});
-//		
-//		
-//		/*
-//		 * get variants unique to one of the inputs
-//		 */
-//		positions.entrySet().stream().filter(e -> e.getValue().size() > 1 && e.getValue().size() < numberOfInputFiles).forEach(e -> {
-//			partiallyUniqueVariants.computeIfAbsent(e.getValue().stream().collect(Collectors.joining("\t")), v -> new ArrayList<ChrPositionRefAlt>()).add(e.getKey());
-//		});
-//		
-//		
-//		logger.info("number of partially unique variants: " + partiallyUniqueVariants.entrySet().stream().mapToInt(e -> e.getValue().size()).sum());
-//		partiallyUniqueVariants.entrySet().stream().forEach(e -> logger.info("files: " + e.getKey() + " have " + e.getValue().size() + " partially unique variants"));
-//		
-//		
-//		/*
-//		 * assuming we have 3 inputs...
-//		 */
-//		logger.info("123: " + centreVenn);
-//		String oneAndTwoS = inputs[0] + Constants.TAB + inputs[1];
-//		int oneAndTwo =  partiallyUniqueVariants.containsKey(oneAndTwoS) ? partiallyUniqueVariants.get(oneAndTwoS).size() : 0;
-//		logger.info("12: " + oneAndTwo);
-//		int twoAndThree =  partiallyUniqueVariants.containsKey(inputs[1] + Constants.TAB + inputs[2]) ? partiallyUniqueVariants.get(inputs[1] + Constants.TAB + inputs[2]).size() : 0;
-//		logger.info("23: " + twoAndThree);
-//		int oneAndThree =  partiallyUniqueVariants.containsKey(inputs[0] + Constants.TAB + inputs[2]) ? partiallyUniqueVariants.get(inputs[0] + Constants.TAB + inputs[2]).size() : 0;
-//		logger.info("13: " + oneAndThree);
-//		logger.info("1: " + (null != partiallyUniqueVariants.get(inputs[0]) ? partiallyUniqueVariants.get(inputs[0]).size() : 0));
-//		logger.info("2: " + (null != partiallyUniqueVariants.get(inputs[1]) ? partiallyUniqueVariants.get(inputs[1]).size() : 0));
-//		logger.info("3: " + (null != partiallyUniqueVariants.get(inputs[2]) ? partiallyUniqueVariants.get(inputs[2]).size() : 0));
-//		logger.info("file 1: " + inputs[0]);
-//		logger.info("file 2: " + inputs[1]);
-//		logger.info("file 3: " + inputs[2]);
-//		
-//		
-//		/*
-//		 * output all variants NOT found in 1, so that they can be put through the classifier application (yet to be written)
-//		 */
-//		List<ChrPositionRefAlt> notInOne = new ArrayList<>();
-//		partiallyUniqueVariants.forEach((s,l) -> {
-//			if ( ! s.contains(inputs[0])) {
-//				notInOne.addAll(l);
-//			}
-//		});
-//		logger.info("number of variants not in first input file: " + notInOne.size());
-//		writeOutput(notInOne, outputDirectory + "/notInOne.vcf");
-//		
-//	}
-	
-	
-	private void writeOutput(List<ChrPositionRefAlt> recs, String output) throws FileNotFoundException {
-		recs.sort(new ChrPositionComparator());
-		
-		logger.info("writing output");
-		
-		
-		
-		try (PrintStream ps = new PrintStream(new FileOutputStream(new File(output)))) {
-			/*
-			 * put input files along with their positions into the file header
-			 */
-			int j = 1;
-			for (String s : vcfFiles) {
-				ps.println("##" + j++ + ": vcf file: " + s);
-			}
-			if (null != goldStandard) {
-				ps.println("##: gold standard file: " + goldStandard);
-			}
-			
-			
-			String header =  VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE ;
-			if (vcfOutput) {
-				ps.println(VcfHeaderUtils.CURRENT_FILE_FORMAT);
-			}
-			ps.println(header);
-			for (ChrPositionRefAlt cp : recs) {
-//				logger.info("writing out: " + cp.getName());
-				ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + "\t.\t" + cp.getRef() + Constants.TAB + cp.getAlt() + "\t.\t.\t.");
-			}
-		}
-		
-		logger.info("writing output- DONE");
-	}
-	
-	private void examineMatches() {
-		logger.info("Found " + roguePositionsMatches.size() + " in vcf file out of a potential " + roguePositions.size());
-		int germlineCount = 0;
-		int somaticCount = 0;
-		int pass = 0;
-		Map<String, List<VcfRecord>> filterDistSom = new HashMap<>();
-		Map<String, List<VcfRecord>> filterDistGerm = new HashMap<>();
-		for (VcfRecord v : roguePositionsMatches) {
-			if (VcfUtils.isRecordSomatic(v)) {
-				somaticCount++;
-				filterDistSom.computeIfAbsent(getFilter(v), f -> new ArrayList<>()).add(v);
-			} else {
-				germlineCount++;
-				filterDistGerm.computeIfAbsent(getFilter(v), f -> new ArrayList<>()).add(v);
-			}
-			if (VcfUtils.isRecordAPass(v)) {
-				pass++;
-			}
-		}
-		logger.info("pass: " + pass + ", somaticCount: " + somaticCount + ", germlineCount: " + germlineCount);
-		Comparator<Entry<String,  List<VcfRecord>>> comp = Comparator.comparingInt(e -> e.getValue().size());
-		filterDistSom.entrySet().stream().sorted(comp).forEach(e -> logger.info("somatic, filter: " + e.getKey() + ", count: " + e.getValue().size() + ", v: " + e.getValue().get(0).toSimpleString()));
-		filterDistGerm.entrySet().stream().sorted(comp).forEach(e -> logger.info("germline, filter: " + e.getKey() + ", count: " + e.getValue().size() + ", v: " + e.getValue().get(0).toSimpleString()));
-	}
-	
-	public static String getFilter(VcfRecord v) {
-		String filter = v.getFilter();
-		if (StringUtils.isNullOrEmptyOrMissingData(filter)) {
-			/*
-			 * look to see if filter is in the format column
-			 */
-			List<String> formatFields = v.getFormatFields();
-			if (null != formatFields && formatFields.size() > 0) {
-				if (formatFields.get(0).contains(VcfHeaderUtils.FORMAT_FILTER)) {
-					
-					/*
-					 * get filters for all format values
-					 */
-					Map<String, String[]> ffMap = VcfUtils.getFormatFieldsAsMap(formatFields);
-					String [] filterArray = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
-					if (null != filterArray && filterArray.length > 0) {
-						filter = Arrays.stream(filterArray).collect(Collectors.joining(Constants.COMMA_STRING));
-					}
-				}
-			}
-		}
-		return filter;
-	}
-	
-	private void loadVcfs() throws IOException {
-		int i = 0;
-		int index = 0;
-		for (String s : vcfFiles) {
-			if (index == 0) {
-				try (VcfFileReader reader = new VcfFileReader(new File(s))) {
-					for (VcfRecord rec : reader) {
-						if (++ i % 1000000 == 0) {
-							logger.info("hit " + i + " entries");
-						}
-						
-						processVcfRecord(rec, somatic, germline, roguePositions);
-					}
-				}
-				logger.info("input: " + (index+1) + " has " + i + " entries");
-				logger.info("positions size: " + roguePositions.size());
-				i = 0;
-			} else {
-				try (VcfFileReader reader = new VcfFileReader(new File(s))) {
-					for (VcfRecord rec : reader) {
-						if (++ i % 1000000 == 0) {
-							logger.info("hit " + i + " entries");
-						}
-						
-						if (roguePositions.containsKey(rec.getChrPosition())) {
-							roguePositionsMatches.add(rec);
-						}
-					}
-				}
-			}
-			index++;
-		}
-	}
+        return exitStatus;
+    }
+
+    private void writeOutput(List<ChrPositionRefAlt> recs, String output) throws FileNotFoundException {
+        recs.sort(new ChrPositionComparator());
+
+        logger.info("writing output");
 
 
-	/**
-	 * @param rec
-	 */
-	public static void processVcfRecord(VcfRecord rec, boolean somatic, boolean germline, Map<ChrPosition, ChrPositionRefAlt> map) {
-		/*
-		 * we want HC or PASS
-		 */
-//		if (Amalgamator.isRecordHighConfOrPass(rec)) {
-			
-			/*
-			 * only process record if it is of the desired type .eg somatic
-//			 */
-//			boolean recordSomatic = Amalgamator.isRecordSomatic(rec);
-//			if ( (recordSomatic && somatic) || ( ! recordSomatic && germline)) {
-				
-				
-				/*
-				 * only deal with snps and compounds for now
-				 */
-				if (VcfUtils.isRecordASnpOrMnp(rec)) {
-					
-//					String gt = GoldStandardGenerator.getGT(rec, recordSomatic);
-					
-					String ref = rec.getRef();
-					String alt = rec.getAlt();
-					
-					if (ref.length() > 1) {
-						/*
-						 * split cs into constituent snps
-						 */
-						for (int z = 0 ; z < ref.length() ; z++) {
-							addToMap(map, rec.getChrPosition().getChromosome(),  rec.getChrPosition().getStartPosition() + z, rec.getChrPosition().getStartPosition() + z, ref.charAt(z)+"",  alt.charAt(z)+"");
-//							addToMap(map, rec.getChrPosition().getChromosome(),  rec.getChrPosition().getStartPosition() + z, rec.getChrPosition().getStartPosition() + z, ref.charAt(z)+"",  alt.charAt(z) +Constants.TAB_STRING+ gt, input);
-						}
-					} else {
-						addToMap(map, rec.getChrPosition().getChromosome(), rec.getChrPosition().getStartPosition(), rec.getChrPosition().getStartPosition(), ref, alt);
-//						addToMap(map, rec.getChrPosition().getChromosome(), rec.getChrPosition().getStartPosition(), rec.getChrPosition().getStartPosition(), ref, alt+Constants.TAB+gt, input);
-					}
-				}
-//			}
-//		}
-	}
+        try (PrintStream ps = new PrintStream(new FileOutputStream(output))) {
+            /*
+             * put input files along with their positions into the file header
+             */
+            int j = 1;
+            for (String s : vcfFiles) {
+                ps.println("##" + j++ + ": vcf file: " + s);
+            }
+            if (null != goldStandard) {
+                ps.println("##: gold standard file: " + goldStandard);
+            }
 
 
-//	/**
-//	 * @param rec
-//	 * @param recordSomatic
-//	 * @return ./. if rec is null, or if it doesn't have a GT field in the format column
-//	 */
-//	public static String getGT(VcfRecord rec, boolean recordSomatic) {
-//		/*
-//		 * get GT field as this needs to be the same across samples
-//		 */
-//		String gt = "./.";
-//		if (null != rec) {
-//			List<String> ffList = rec.getFormatFields();
-//			if (ffList.size() > 1) {
-//				if (ffList.get(0).startsWith(VcfHeaderUtils.FORMAT_GENOTYPE)) {
-//					int position = ffList.size() == 2 ? 1 : recordSomatic ? 2 : 1;
-//					String stringOfInterest = ffList.get(position);
-//					int colonIndex = stringOfInterest.indexOf(Constants.COLON);
-//					gt = stringOfInterest.substring(0, colonIndex > -1 ? colonIndex : stringOfInterest.length());
-//					int ampIndex = gt.indexOf(Constants.VCF_MERGE_DELIM);
-//					if (ampIndex > -1) {
-//						gt = gt.substring(0, ampIndex);
-//					}
-//				}
-//			}
-//		}
-//		return gt;
-//	}
-	
-	public static void addToMap(Map<ChrPosition, ChrPositionRefAlt> map, String chr, int start, int end, String ref, String alt) {
-		if (null != map && null != chr && start >=0 && end >= start) {
-			ChrPosition cp = new ChrPointPosition(chr, start);
-			ChrPositionRefAlt cpn  = new ChrPositionRefAlt(chr, start, end, ref, alt);
-			map.computeIfAbsent(cp, v -> cpn);
-		}
-	}
-	
-	public static void main(String[] args) throws Exception {
-		
-		Classify qp = new Classify();
-		int exitStatus = qp.setup(args);
-		if (null != logger) {
-			logger.logFinalExecutionStats(exitStatus);
-		} else {
-			System.err.println("Exit status: " + exitStatus);
-		}		
-		System.exit( exitStatus );
-	}
+            String header = VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE;
+            if (vcfOutput) {
+                ps.println(VcfHeaderUtils.CURRENT_FILE_FORMAT);
+            }
+            ps.println(header);
+            for (ChrPositionRefAlt cp : recs) {
+                ps.println(ChrPositionUtils.toVcfString(cp, MISSING_DATA_STRING, null, null, MISSING_DATA_STRING, MISSING_DATA_STRING, MISSING_DATA_STRING));
+//                ps.println(cp.getChromosome() + TAB + cp.getStartPosition() + "\t.\t" + cp.getRef() + TAB + cp.getAlt() + "\t.\t.\t.");
+            }
+        }
 
-	private int setup(String[] args) throws Exception {
-		int returnStatus = 1;
-		Options options = new Options(args);
+        logger.info("writing output- DONE");
+    }
 
-		if (options.hasHelpOption()) {
-			System.err.println(Messages.GOLD_STANDARD_USAGE);
-			options.displayHelp();
-			returnStatus = 0;
-		} else if (options.hasVersionOption()) {
-			System.err.println(Messages.getVersionMessage());
-			returnStatus = 0;
-		} else if (options.getVcfs().length < 1) {
-			System.err.println(Messages.GOLD_STANDARD_USAGE);
-		} else {
-			// configure logging
-			logFile = options.getLog();
-			version = Classify.class.getPackage().getImplementationVersion();
-			if (null == version) {	version = "local"; }
-			logger = QLoggerFactory.getLogger(Classify.class, logFile, options.getLogLevel());
-			exec = logger.logInitialExecutionStats("q3vcftools Overlap", version, args);
-			
-			// get list of file names
-			vcfFiles = options.getVcfs();
-			if (vcfFiles.length < 1) {
-				throw new Exception("INSUFFICIENT_ARGUMENTS");
-			} else {
-				// loop through supplied files - check they can be read
-				for (int i = 0 ; i < vcfFiles.length ; i++ ) {
-					if ( ! FileUtils.canFileBeRead(vcfFiles[i])) {
-						throw new Exception("INPUT_FILE_ERROR: "  +  vcfFiles[i]);
-					}
-				}
-			}
-			vcfOutput = options.hasVcfOutputOption();
-			
-			// set outputfile - if supplied, check that it can be written to
-			if (null != options.getOutputFileName()) {
-				String optionsOutputFile = options.getOutputFileName();
-				if (FileUtils.canFileBeWrittenTo(optionsOutputFile)) {
-					outputDirectory = optionsOutputFile;
-				} else {
-					throw new Exception("OUTPUT_FILE_WRITE_ERROR");
-				}
-				
-			}
-			
-			logger.info("vcf input files: " + Arrays.deepToString(vcfFiles));
-			logger.info("outputDirectory: " + outputDirectory);
-			
-			somatic = options.hasSomaticOption();
-			germline = options.hasGermlineOption();
-			
-			if ( ! somatic && ! germline) {
-				somatic = true; germline = true;
-			}
-			if (somatic)
-				logger.info("Will process somatic records");
-			if (germline)
-				logger.info("Will process germline records");
-			if (vcfOutput)
-				logger.info("Will output gold standard as a vcf file");
-			
-			options.getGoldStandard().ifPresent(s -> goldStandard = s);
-			
-			return engage();
-		}
-		return returnStatus;
-	}
+    private void examineMatches() {
+        logger.info("Found " + roguePositionsMatches.size() + " in vcf file out of a potential " + roguePositions.size());
+        int germlineCount = 0;
+        int somaticCount = 0;
+        int pass = 0;
+        Map<String, List<VcfRecord>> filterDistSom = new HashMap<>();
+        Map<String, List<VcfRecord>> filterDistGerm = new HashMap<>();
+        for (VcfRecord v : roguePositionsMatches) {
+            if (VcfUtils.isRecordSomatic(v)) {
+                somaticCount++;
+                filterDistSom.computeIfAbsent(getFilter(v), f -> new ArrayList<>()).add(v);
+            } else {
+                germlineCount++;
+                filterDistGerm.computeIfAbsent(getFilter(v), f -> new ArrayList<>()).add(v);
+            }
+            if (VcfUtils.isRecordAPass(v)) {
+                pass++;
+            }
+        }
+        logger.info("pass: " + pass + ", somaticCount: " + somaticCount + ", germlineCount: " + germlineCount);
+        Comparator<Entry<String, List<VcfRecord>>> comp = Comparator.comparingInt(e -> e.getValue().size());
+        filterDistSom.entrySet().stream().sorted(comp).forEach(e -> logger.info("somatic, filter: " + e.getKey() + ", count: " + e.getValue().size() + ", v: " + e.getValue().getFirst().toSimpleString()));
+        filterDistGerm.entrySet().stream().sorted(comp).forEach(e -> logger.info("germline, filter: " + e.getKey() + ", count: " + e.getValue().size() + ", v: " + e.getValue().getFirst().toSimpleString()));
+    }
+
+    public static String getFilter(VcfRecord v) {
+        String filter = v.getFilter();
+        if (StringUtils.isNullOrEmptyOrMissingData(filter)) {
+            /*
+             * look to see if filter is in the format column
+             */
+            List<String> formatFields = v.getFormatFields();
+            if (null != formatFields && !formatFields.isEmpty()) {
+                if (formatFields.getFirst().contains(VcfHeaderUtils.FORMAT_FILTER)) {
+
+                    /*
+                     * get filters for all format values
+                     */
+                    Map<String, String[]> ffMap = VcfUtils.getFormatFieldsAsMap(formatFields);
+                    String[] filterArray = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
+                    if (null != filterArray && filterArray.length > 0) {
+                        filter = String.join(Constants.COMMA_STRING, filterArray);
+                    }
+                }
+            }
+        }
+        return filter;
+    }
+
+    /**
+     * Loads the VCF files.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    private void loadVcfs() throws IOException {
+        int i = 0;
+        int index = 0;
+        for (String s : vcfFiles) {
+            if (index == 0) {
+                try (VcfFileReader reader = new VcfFileReader(new File(s))) {
+                    for (VcfRecord rec : reader) {
+                        if (++i % 1000000 == 0) {
+                            logger.info("hit " + i + " entries");
+                        }
+
+                        processVcfRecord(rec, somatic, germline, roguePositions);
+                    }
+                }
+                logger.info("input: " + (index + 1) + " has " + i + " entries");
+                logger.info("positions size: " + roguePositions.size());
+                i = 0;
+            } else {
+                try (VcfFileReader reader = new VcfFileReader(new File(s))) {
+                    for (VcfRecord rec : reader) {
+                        if (++i % 1000000 == 0) {
+                            logger.info("hit " + i + " entries");
+                        }
+
+                        if (roguePositions.containsKey(rec.getChrPosition())) {
+                            roguePositionsMatches.add(rec);
+                        }
+                    }
+                }
+            }
+            index++;
+        }
+    }
+
+
+
+    /**
+     * Processes a VCF record.
+     *
+     * @param rec the VCF record to process
+     * @param somatic whether to process somatic records
+     * @param germline whether to process germline records
+     * @param map the map to add the processed record to
+     */
+    public static void processVcfRecord(VcfRecord rec, boolean somatic, boolean germline, Map<ChrPosition, ChrPositionRefAlt> map) {
+        /*
+         * only deal with snps and compounds for now
+         */
+        if (VcfUtils.isRecordASnpOrMnp(rec)) {
+
+            String ref = rec.getRef();
+            String alt = rec.getAlt();
+
+            if (ref.length() > 1) {
+                /*
+                 * split cs into constituent snps
+                 */
+                for (int z = 0; z < ref.length(); z++) {
+                    addToMap(map, rec.getChrPosition().getChromosome(), rec.getChrPosition().getStartPosition() + z, rec.getChrPosition().getStartPosition() + z, ref.charAt(z) + "", alt.charAt(z) + "");
+                }
+            } else {
+                addToMap(map, rec.getChrPosition().getChromosome(), rec.getChrPosition().getStartPosition(), rec.getChrPosition().getStartPosition(), ref, alt);
+            }
+        }
+    }
+
+
+    /**
+     * Adds a record to the map.
+     *
+     * @param map the map to add the record to
+     * @param chr the chromosome
+     * @param start the start position
+     * @param end the end position
+     * @param ref the reference
+     * @param alt the alt allele
+     */
+    public static void addToMap(Map<ChrPosition, ChrPositionRefAlt> map, String chr, int start, int end, String ref, String alt) {
+        if (null != map && null != chr && start >= 0 && end >= start) {
+            ChrPosition cp = new ChrPointPosition(chr, start);
+            ChrPositionRefAlt cpn = new ChrPositionRefAlt(chr, start, end, ref, alt);
+            map.putIfAbsent(cp, cpn);
+        }
+    }
+
+    /**
+     * The main method.
+     *
+     * @param args the command line arguments
+     * @throws Exception if an error occurs
+     */
+    public static void main(String[] args) throws Exception {
+
+        Classify qp = new Classify();
+        int exitStatus = qp.setup(args);
+        if (null != logger) {
+            logger.logFinalExecutionStats(exitStatus);
+        } else {
+            System.err.println("Exit status: " + exitStatus);
+        }
+        System.exit(exitStatus);
+    }
+
+    /**
+     * Sets up the classification process.
+     *
+     * @param args the command line arguments
+     * @return the exit status
+     * @throws Exception if an error occurs
+     */
+    private int setup(String[] args) throws Exception {
+        int returnStatus = 1;
+        Options options = new Options(args);
+
+        if (options.hasHelpOption()) {
+            System.err.println(Messages.GOLD_STANDARD_USAGE);
+            options.displayHelp();
+            returnStatus = 0;
+        } else if (options.hasVersionOption()) {
+            System.err.println(Messages.getVersionMessage());
+            returnStatus = 0;
+        } else if (options.getVcfs().length < 1) {
+            System.err.println(Messages.GOLD_STANDARD_USAGE);
+        } else {
+            // configure logging
+            String logFile = options.getLog();
+            String version = Classify.class.getPackage().getImplementationVersion();
+            if (null == version) {
+                version = "local";
+            }
+            logger = QLoggerFactory.getLogger(Classify.class, logFile, options.getLogLevel());
+            QExec exec = logger.logInitialExecutionStats("q3vcftools Overlap", version, args);
+
+            // get list of file names
+            vcfFiles = options.getVcfs();
+            if (vcfFiles.length < 1) {
+                throw new Exception("INSUFFICIENT_ARGUMENTS");
+            } else {
+                // loop through supplied files - check they can be read
+                for (String vcfFile : vcfFiles) {
+                    if (!FileUtils.canFileBeRead(vcfFile)) {
+                        throw new Exception("INPUT_FILE_ERROR: " + vcfFile);
+                    }
+                }
+            }
+            vcfOutput = options.hasVcfOutputOption();
+
+            // set output file - if supplied, check that it can be written to
+            if (null != options.getOutputFileName()) {
+                String optionsOutputFile = options.getOutputFileName();
+                if (FileUtils.canFileBeWrittenTo(optionsOutputFile)) {
+                    outputDirectory = optionsOutputFile;
+                } else {
+                    throw new Exception("OUTPUT_FILE_WRITE_ERROR");
+                }
+
+            }
+
+            logger.info("vcf input files: " + Arrays.deepToString(vcfFiles));
+            logger.info("outputDirectory: " + outputDirectory);
+
+            somatic = options.hasSomaticOption();
+            germline = options.hasGermlineOption();
+
+            if (!somatic && !germline) {
+                somatic = true;
+                germline = true;
+            }
+            if (somatic)
+                logger.info("Will process somatic records");
+            if (germline)
+                logger.info("Will process germline records");
+            if (vcfOutput)
+                logger.info("Will output gold standard as a vcf file");
+
+            options.getGoldStandard().ifPresent(s -> goldStandard = s);
+
+            return engage();
+        }
+        return returnStatus;
+    }
 
 }

--- a/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Classify.java
@@ -162,7 +162,7 @@ public class Classify {
 			ps.println(header);
 			for (ChrPositionRefAlt cp : recs) {
 //				logger.info("writing out: " + cp.getName());
-				ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + "\t.\t" + cp.getName() + Constants.TAB + cp.getAlt() + "\t.\t.\t.");
+				ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + "\t.\t" + cp.getRef() + Constants.TAB + cp.getAlt() + "\t.\t.\t.");
 			}
 		}
 		

--- a/q3vcftools/src/au/edu/qimr/vcftools/GoldStandardGenerator.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/GoldStandardGenerator.java
@@ -86,7 +86,7 @@ public class GoldStandardGenerator {
 		 */
 		Map<String, AtomicInteger> mutationCounts = new HashMap<>();
 		recs.forEach(cpra -> {
-			String mutation = cpra.getName() + "->" + cpra.getAlt();
+			String mutation = cpra.getRef() + "->" + cpra.getAlt();
 			mutationCounts.computeIfAbsent(mutation, f -> new AtomicInteger()).incrementAndGet();
 		});
 		mutationCounts.entrySet().stream().sorted(Comparator.comparingInt(e -> e.getValue().get())).forEach(e -> logger.info("mutation: " + e.getKey() + ", counts: " + e.getValue().get()));
@@ -118,7 +118,7 @@ public class GoldStandardGenerator {
 					int tabIndex = cp.getAlt().indexOf(Constants.TAB);
 					String alt = cp.getAlt().substring(0, tabIndex);
 //					String gt = cp.getAlt().substring(tabIndex + 1);
-					ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + "\t.\t" + cp.getName() + Constants.TAB + alt + "\t.\t.\t.");
+					ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + "\t.\t" + cp.getRef() + Constants.TAB + alt + "\t.\t.\t.");
 				} else {
 					ps.println(cp.toTabSeperatedString());
 				}

--- a/q3vcftools/src/au/edu/qimr/vcftools/Overlap.java
+++ b/q3vcftools/src/au/edu/qimr/vcftools/Overlap.java
@@ -23,8 +23,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.qcmg.common.model.ChrPointPosition;
-import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.model.ChrPositionComparator;
 import org.qcmg.common.model.ChrPositionRefAlt;
 import org.qcmg.common.string.StringUtils;
@@ -482,7 +480,7 @@ public class Overlap {
 			ps.println(header);
 			for (ChrPositionRefAlt cp : recs) {
 //				logger.info("writing out: " + cp.getName());
-				ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + "\t.\t" + cp.getName() + Constants.TAB + cp.getAlt() + "\t.\t.\t.");
+				ps.println(cp.getChromosome() + Constants.TAB + cp.getStartPosition() + "\t.\t" + cp.getRef() + Constants.TAB + cp.getAlt() + "\t.\t.\t.");
 			}
 		}
 		

--- a/q3vcftools/test/au/edu/qimr/vcftools/GoldStandardGeneratorTest.java
+++ b/q3vcftools/test/au/edu/qimr/vcftools/GoldStandardGeneratorTest.java
@@ -1,20 +1,5 @@
 package au.edu.qimr.vcftools;
 
-import static org.junit.Assert.*;
-
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,6 +8,20 @@ import org.qcmg.common.commandline.Executor;
 import org.qcmg.common.model.ChrPositionRefAlt;
 import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
 
 public class GoldStandardGeneratorTest {
 	
@@ -36,50 +35,53 @@ public class GoldStandardGeneratorTest {
 		File out = testFolder.newFile();
 		
 		
-	    final List<String> data = new ArrayList<String>(4);
+	    final List<String> data = new ArrayList<>(4);
         data.add("##fileformat=VCFv4.0");
         data.add(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE);
        
         //germ position but not somatic
         data.add("chr1\t100\t.\tG\tA\t.\tPASS\tFS=GTGATATTCCC\tGT:GD:AC:MR:NNS\t0/1:G/A:A0[0],15[36.2],G11[36.82],9[33]\t0/1:G/A:A0[0],33[35.73],G6[30.5],2[34]:15:13"); 
-        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1));) {          
+        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1))) {
             for (final String line : data)   bw.write(line + "\n");                  
          }
-        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2));) {          
+        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2))) {
         	for (final String line : data)   bw.write(line + "\n");                  
         }
         
-        String cmd = " -vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
+        String cmd = "-vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
         Executor exec = execute(cmd);
         assertEquals(0, exec.getErrCode());
         
         /*
          * check for output file
          */
-        List<String> output = Files.lines(Paths.get(out.getAbsolutePath())).collect(Collectors.toList());
-        assertEquals(4, output.size());
+        List<String> output;
+		try (Stream<String> stream = Files.lines(Paths.get(out.getAbsolutePath()))) {
+			output = stream.toList();
+		}
+		assertEquals(4, output.size());
 	}
 	
 	private Executor execute(final String command) throws IOException, InterruptedException {
 		return new Executor(command, "au.edu.qimr.vcftools.GoldStandardGenerator");
 	}
 	
-	/**
-	 * create input vcf file containing 2 dbSNP SNPs and one verified SNP
-	 * @throws IOException
-	 */
-	static void createVcf(File f) throws IOException{
-        List<String> data =Arrays.asList(
-        		"##fileformat=VCFv4.2",
-        		VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE_INCLUDING_FORMAT,
-        		"chr1	95813205	rs11165387	C	T	.	.	FLANK=CTTCGTGTCTT;BaseQRankSum=1.846;ClippingRankSum=-1.363;DP=35;FS=3.217;MQ=60.00;MQRankSum=-1.052;QD=18.76;ReadPosRankSum=-1.432;SOR=0.287;IN=1,2;DB;VAF=0.6175;HOM=0,TCCTTCTTCGtGTCTTTCCTT;EFF=downstream_gene_variant(MODIFIER||3602|||RP11-14O19.1|lincRNA|NON_CODING|ENST00000438093||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/1:17,15:Germline:22:32:T0[]1[]:C1;T8:PASS:.:.:15:C4[36.5]13[38.54];T5[41]10[39.7]:.	0/0:26,0:ReferenceNoVariant:22:26:C1[]1[]:C7:PASS:.:.:.:C8[36.5]18[39.56]:.	0/1:16,18:Germline:21:34:.:.:PASS:99:.:.:.:656.77	./.:.:HomozygousLoss:21:.:.:.:PASS:.:NCIG:.:.:.",
-        		"chr1	60781981	rs5015226	T	G	.	.	FLANK=ACCAAGTGCCT;DP=53;FS=0.000;MQ=60.00;QD=31.16;SOR=0.730;IN=1,2;DB;HOM=0,CGAAAACCAAgTGCCTGCATT;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	1/1:0,46:Germline:34:47:G0[]1[]:G5;T1:PASS:.:.:42:C0[0]1[12];G23[40.04]23[36.83]:.	1/1:0,57:Germline:34:57:G2[]0[]:G3:PASS:.:.:51:G24[39]33[39.18]:.	1/1:0,53:Germline:34:53:.:.:PASS:99:.:.:.:2418.77	1/1:0,60:Germline:34:60:.:.:PASS:99:.:.:.:2749.77"
-        		);
-        
-        try(BufferedWriter out = new BufferedWriter(new FileWriter(f));) {          
-            for (String line : data)   out.write(line + "\n");                  
-         }  
-	}
+//	/**
+//	 * create input vcf file containing 2 dbSNP SNPs and one verified SNP
+//	 * @throws IOException
+//	 */
+//	static void createVcf(File f) throws IOException{
+//        List<String> data =Arrays.asList(
+//        		"##fileformat=VCFv4.2",
+//        		VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE_INCLUDING_FORMAT,
+//        		"chr1	95813205	rs11165387	C	T	.	.	FLANK=CTTCGTGTCTT;BaseQRankSum=1.846;ClippingRankSum=-1.363;DP=35;FS=3.217;MQ=60.00;MQRankSum=-1.052;QD=18.76;ReadPosRankSum=-1.432;SOR=0.287;IN=1,2;DB;VAF=0.6175;HOM=0,TCCTTCTTCGtGTCTTTCCTT;EFF=downstream_gene_variant(MODIFIER||3602|||RP11-14O19.1|lincRNA|NON_CODING|ENST00000438093||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/1:17,15:Germline:22:32:T0[]1[]:C1;T8:PASS:.:.:15:C4[36.5]13[38.54];T5[41]10[39.7]:.	0/0:26,0:ReferenceNoVariant:22:26:C1[]1[]:C7:PASS:.:.:.:C8[36.5]18[39.56]:.	0/1:16,18:Germline:21:34:.:.:PASS:99:.:.:.:656.77	./.:.:HomozygousLoss:21:.:.:.:PASS:.:NCIG:.:.:.",
+//        		"chr1	60781981	rs5015226	T	G	.	.	FLANK=ACCAAGTGCCT;DP=53;FS=0.000;MQ=60.00;QD=31.16;SOR=0.730;IN=1,2;DB;HOM=0,CGAAAACCAAgTGCCTGCATT;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	1/1:0,46:Germline:34:47:G0[]1[]:G5;T1:PASS:.:.:42:C0[0]1[12];G23[40.04]23[36.83]:.	1/1:0,57:Germline:34:57:G2[]0[]:G3:PASS:.:.:51:G24[39]33[39.18]:.	1/1:0,53:Germline:34:53:.:.:PASS:99:.:.:.:2418.77	1/1:0,60:Germline:34:60:.:.:PASS:99:.:.:.:2749.77"
+//        		);
+//
+//        try(BufferedWriter out = new BufferedWriter(new FileWriter(f))) {
+//            for (String line : data)   out.write(line + "\n");
+//         }
+//	}
 	
 	@Test
 	public void getGT() {
@@ -101,12 +103,12 @@ public class GoldStandardGeneratorTest {
 		assertEquals(0, map.size());
 		GoldStandardGenerator.addToMap(map, "1", 0, 0, null, null,0,2);
 		assertEquals(1, map.size());
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][0]);
+        assertTrue(map.values().toArray(new boolean[][]{})[0][0]);
 		
 		GoldStandardGenerator.addToMap(map, "1", 0, 0, null, null,1,2);
 		assertEquals(1, map.size());
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][0]);
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][1]);
+        assertTrue(map.values().toArray(new boolean[][]{})[0][0]);
+        assertTrue(map.values().toArray(new boolean[][]{})[0][1]);
 	}
 	@Test
 	public void addToMapAgain() {
@@ -114,30 +116,30 @@ public class GoldStandardGeneratorTest {
 //		Map<ChrPositionRefAlt, AtomicInteger> map = new HashMap<>(1024 * 64);
 		GoldStandardGenerator.addToMap(map, "chr1", 100, 100, "A", "C	0/1",0,6);
 		assertEquals(1, map.size());
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][0]);
-		assertEquals(false, map.values().toArray(new boolean[][]{})[0][1]);
+        assertTrue(map.values().toArray(new boolean[][]{})[0][0]);
+        assertFalse(map.values().toArray(new boolean[][]{})[0][1]);
 		
 		GoldStandardGenerator.addToMap(map, "chr1", 100, 100, "A", "T	0/1",0,6);
 		assertEquals(2, map.size());
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][0]);
-		assertEquals(false, map.values().toArray(new boolean[][]{})[0][1]);
-		assertEquals(true, map.values().toArray(new boolean[][]{})[1][0]);
-		assertEquals(false, map.values().toArray(new boolean[][]{})[1][1]);
+        assertTrue(map.values().toArray(new boolean[][]{})[0][0]);
+        assertFalse(map.values().toArray(new boolean[][]{})[0][1]);
+        assertTrue(map.values().toArray(new boolean[][]{})[1][0]);
+        assertFalse(map.values().toArray(new boolean[][]{})[1][1]);
 		
 		GoldStandardGenerator.addToMap(map, "chr1", 100, 100, "A", "T	0/1",1,6);
 		assertEquals(2, map.size());
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][0]);
-		assertEquals(true, map.values().toArray(new boolean[][]{})[1][0]);
-		assertEquals(true, map.values().toArray(new boolean[][]{})[1][1]);
-//		
+        assertTrue(map.values().toArray(new boolean[][]{})[0][0]);
+        assertTrue(map.values().toArray(new boolean[][]{})[1][0]);
+        assertTrue(map.values().toArray(new boolean[][]{})[1][1]);
+
 		GoldStandardGenerator.addToMap(map, "chr1", 100, 100, "A", "C	0/1",2,6);
 		assertEquals(2, map.size());
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][0]);
-		assertEquals(false, map.values().toArray(new boolean[][]{})[0][1]);
-		assertEquals(true, map.values().toArray(new boolean[][]{})[0][2]);
-		assertEquals(true, map.values().toArray(new boolean[][]{})[1][0]);
-		assertEquals(true, map.values().toArray(new boolean[][]{})[1][1]);
-//		
+        assertTrue(map.values().toArray(new boolean[][]{})[0][0]);
+        assertFalse(map.values().toArray(new boolean[][]{})[0][1]);
+        assertTrue(map.values().toArray(new boolean[][]{})[0][2]);
+        assertTrue(map.values().toArray(new boolean[][]{})[1][0]);
+        assertTrue(map.values().toArray(new boolean[][]{})[1][1]);
+
 		GoldStandardGenerator.addToMap(map, "chr1", 100, 100, "A", "G	1/1",3,6);
 		assertEquals(3, map.size());
 		GoldStandardGenerator.addToMap(map, "chr1", 100, 100, "A", "G	0/1",4,6);
@@ -153,15 +155,15 @@ public class GoldStandardGeneratorTest {
 		try {
 			Amalgamator.getStringFromArray(array, 1);
 			Assert.fail("should have thrown an exception");
-		} catch (IllegalArgumentException iae) {}
+		} catch (IllegalArgumentException ignored) {}
 		try {
 			Amalgamator.getStringFromArray(array, 10);
 			Assert.fail("should have thrown an exception");
-		} catch (IllegalArgumentException iae) {}
+		} catch (IllegalArgumentException ignored) {}
 		try {
 			Amalgamator.getStringFromArray(array, -1);
 			Assert.fail("should have thrown an exception");
-		} catch (IllegalArgumentException iae) {}
+		} catch (IllegalArgumentException ignored) {}
 		
 		array = new String[]{"hello","there","world"};
 		assertEquals("hello", Amalgamator.getStringFromArray(array, 0));

--- a/q3vcftools/test/au/edu/qimr/vcftools/MergeSameSamplesTest.java
+++ b/q3vcftools/test/au/edu/qimr/vcftools/MergeSameSamplesTest.java
@@ -1,7 +1,12 @@
 package au.edu.qimr.vcftools;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.common.util.Constants;
+import org.qcmg.common.vcf.VcfRecord;
+import org.qcmg.common.vcf.header.VcfHeaderUtils;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -10,18 +15,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.qcmg.common.commandline.Executor;
-import org.qcmg.common.util.Constants;
-import org.qcmg.common.vcf.VcfRecord;
-import org.qcmg.common.vcf.header.VcfHeaderUtils;
+import static org.junit.Assert.*;
 
 public class MergeSameSamplesTest {
 	
@@ -41,10 +39,10 @@ public class MergeSameSamplesTest {
         data.add("##qTestBamUUID=TEST");
         data.add(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL\tTEST");
        
-        data.add(Arrays.stream(new String[]{"chr1","2587689",".","A","C,G",".",".","FLANK=AGCACCCACAC","GT:AD:DP:EOR:FF:FT:INF:NNS:OABS","2/2:3,5,54:62:C1[]1[];G4[]1[]:A6;C26;G58:.:.:47:A2[26.5]1[41];C3[30]2[22];G37[32.59]17[33.06]","1/2:4,10,61:75:A1[]0[];C1[]0[];G0[]2[]:A13;C68;G87;T1:.:SOMATIC:10,50:A2[24.5]2[41];C4[28.25]6[24.33];G35[30.74]26[31.5]"}).collect(Collectors.joining(Constants.TAB_STRING)));
-        data.add(Arrays.stream(new String[]{"chr2","91629178",".","C","A",".",".","FLANK=TCTGTATGTTC","GT:AD:DP:EOR:FF:FT:INF:NNS:OABS","0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]","0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}).collect(Collectors.joining(Constants.TAB_STRING)));
+        data.add(String.join(Constants.TAB_STRING, new String[]{"chr1", "2587689", ".", "A", "C,G", ".", ".", "FLANK=AGCACCCACAC", "GT:AD:DP:EOR:FF:FT:INF:NNS:OABS", "2/2:3,5,54:62:C1[]1[];G4[]1[]:A6;C26;G58:.:.:47:A2[26.5]1[41];C3[30]2[22];G37[32.59]17[33.06]", "1/2:4,10,61:75:A1[]0[];C1[]0[];G0[]2[]:A13;C68;G87;T1:.:SOMATIC:10,50:A2[24.5]2[41];C4[28.25]6[24.33];G35[30.74]26[31.5]"}));
+        data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629178", ".", "C", "A", ".", ".", "FLANK=TCTGTATGTTC", "GT:AD:DP:EOR:FF:FT:INF:NNS:OABS", "0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]", "0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}));
         
-        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1));) {          
+        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1))) {
             for (final String line : data) {
             	bw.write(line + "\n");                  
             }
@@ -53,58 +51,59 @@ public class MergeSameSamplesTest {
         /*
          * remove last 2 entries and add 2 new ones
          */
-        data.remove(data.size() - 1);
-        data.remove(data.size() - 1);
-        data.add(Arrays.stream(new String[]{"chr1","2587689",".","A","G",".",".","DP=60;ExcessHet=3.0103;FS=0.000;MQ=53.08;QD=34.17;SOR=1.919","GT:AD:DP:GQ:QL:FT:INF","1/1:0,56:56:99:1913.77:.:.","1/1:0,91:91:99:2811.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
-        data.add(Arrays.stream(new String[]{"chr2","91629178",".","C","T",".",".","BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846","GT:AD:DP:GQ:QL:FT:INF","0/1:69,22:91:99:664.77:.:.","0/1:147,47:194:99:1551.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
+        data.removeLast();
+        data.removeLast();
+        data.add(String.join(Constants.TAB_STRING, new String[]{"chr1", "2587689", ".", "A", "G", ".", ".", "DP=60;ExcessHet=3.0103;FS=0.000;MQ=53.08;QD=34.17;SOR=1.919", "GT:AD:DP:GQ:QL:FT:INF", "1/1:0,56:56:99:1913.77:.:.", "1/1:0,91:91:99:2811.77:.:."}));
+        data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629178", ".", "C", "T", ".", ".", "BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846", "GT:AD:DP:GQ:QL:FT:INF", "0/1:69,22:91:99:664.77:.:.", "0/1:147,47:194:99:1551.77:.:."}));
         
-        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2));) {          
+        try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2))) {
     		for (final String line : data) {
     			bw.write(line + "\n");                  
     		}
         }
         
-        String cmd = " -vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
+        String cmd = "-vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
         Executor exec = execute(cmd);
         assertEquals(0, exec.getErrCode());
         
         /*
          * check for output file
          */
-        List<String> output = Files.lines(Paths.get(out.getAbsolutePath())).collect(Collectors.toList());
-//        output.forEach(System.out::println);
-        assertEquals(12, output.size());
-        
-        VcfRecord mergedRec = new VcfRecord(output.get(10).split("\t"));
-        assertEquals("chr1", mergedRec.getChromosome());
-        assertEquals(2587689, mergedRec.getPosition());
-        assertEquals("A", mergedRec.getRef());
-        assertEquals("C,G", mergedRec.getAlt());
-        assertEquals(true, mergedRec.getInfo().contains("IN=1,2"));
-        
-        Map<String, String[]> ffs = mergedRec.getFormatFieldsAsMap();
-        assertArrayEquals(new String[]{"2/2","1/2","2/2","2/2"}, ffs.get(VcfHeaderUtils.FORMAT_GENOTYPE));
-        assertArrayEquals(new String[]{"62","75","56","91"}, ffs.get(VcfHeaderUtils.FORMAT_READ_DEPTH));
-        assertArrayEquals(new String[]{"A6;C26;G58","A13;C68;G87;T1",".","."}, ffs.get(VcfHeaderUtils.FORMAT_FF));
-        assertArrayEquals(new String[]{"47","10,50",".","."}, ffs.get(VcfHeaderUtils.FORMAT_NOVEL_STARTS));
-        assertArrayEquals(new String[]{".","SOMATIC",".","."}, ffs.get(VcfHeaderUtils.FORMAT_INFO));
-        assertArrayEquals(new String[]{".",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_FILTER));
-        assertArrayEquals(new String[]{"3,5,54","4,10,61","0,0,56","0,0,91"}, ffs.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS));
-        
-        mergedRec = new VcfRecord(output.get(11).split("\t"));
-        assertEquals("chr2", mergedRec.getChromosome());
-        assertEquals(91629178, mergedRec.getPosition());
-        assertEquals("C", mergedRec.getRef());
-        assertEquals("A,T", mergedRec.getAlt());
-        assertEquals(true, mergedRec.getInfo().contains("IN=1,2"));
-        
-        ffs = mergedRec.getFormatFieldsAsMap();
-        assertArrayEquals(new String[]{"0/1","0/0","0/2","0/2"}, ffs.get(VcfHeaderUtils.FORMAT_GENOTYPE));
-        assertArrayEquals(new String[]{"66","130","91","194"}, ffs.get(VcfHeaderUtils.FORMAT_READ_DEPTH));
-        assertArrayEquals(new String[]{"4",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_NOVEL_STARTS));
-        assertArrayEquals(new String[]{".",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_INFO));
-        assertArrayEquals(new String[]{".",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_FILTER));
-        assertArrayEquals(new String[]{"62,4,0","123,6,1","69,0,22","147,0,47"}, ffs.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS));
+		try (Stream<String> lines = Files.lines(Paths.get(out.getAbsolutePath()))) {
+			List<String> output = lines.toList();
+			assertEquals(12, output.size());
+
+			VcfRecord mergedRec = new VcfRecord(output.get(10).split("\t"));
+			assertEquals("chr1", mergedRec.getChromosome());
+			assertEquals(2587689, mergedRec.getPosition());
+			assertEquals("A", mergedRec.getRef());
+			assertEquals("C,G", mergedRec.getAlt());
+			assertTrue(mergedRec.getInfo().contains("IN=1,2"));
+
+			Map<String, String[]> ffs = mergedRec.getFormatFieldsAsMap();
+			assertArrayEquals(new String[]{"2/2","1/2","2/2","2/2"}, ffs.get(VcfHeaderUtils.FORMAT_GENOTYPE));
+			assertArrayEquals(new String[]{"62","75","56","91"}, ffs.get(VcfHeaderUtils.FORMAT_READ_DEPTH));
+			assertArrayEquals(new String[]{"A6;C26;G58","A13;C68;G87;T1",".","."}, ffs.get(VcfHeaderUtils.FORMAT_FF));
+			assertArrayEquals(new String[]{"47","10,50",".","."}, ffs.get(VcfHeaderUtils.FORMAT_NOVEL_STARTS));
+			assertArrayEquals(new String[]{".","SOMATIC",".","."}, ffs.get(VcfHeaderUtils.FORMAT_INFO));
+			assertArrayEquals(new String[]{".",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_FILTER));
+			assertArrayEquals(new String[]{"3,5,54","4,10,61","0,0,56","0,0,91"}, ffs.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS));
+
+			mergedRec = new VcfRecord(output.get(11).split("\t"));
+			assertEquals("chr2", mergedRec.getChromosome());
+			assertEquals(91629178, mergedRec.getPosition());
+			assertEquals("C", mergedRec.getRef());
+			assertEquals("A,T", mergedRec.getAlt());
+			assertTrue(mergedRec.getInfo().contains("IN=1,2"));
+
+			ffs = mergedRec.getFormatFieldsAsMap();
+			assertArrayEquals(new String[]{"0/1","0/0","0/2","0/2"}, ffs.get(VcfHeaderUtils.FORMAT_GENOTYPE));
+			assertArrayEquals(new String[]{"66","130","91","194"}, ffs.get(VcfHeaderUtils.FORMAT_READ_DEPTH));
+			assertArrayEquals(new String[]{"4",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_NOVEL_STARTS));
+			assertArrayEquals(new String[]{".",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_INFO));
+			assertArrayEquals(new String[]{".",".",".","."}, ffs.get(VcfHeaderUtils.FORMAT_FILTER));
+			assertArrayEquals(new String[]{"62,4,0","123,6,1","69,0,22","147,0,47"}, ffs.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS));
+		}
 	}
 	
 	@Test
@@ -119,11 +118,11 @@ public class MergeSameSamplesTest {
 		data.add("##qTestBamUUID=TEST");
 		data.add(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL\tTEST");
 		
-		data.add(Arrays.stream(new String[]{"chr1","2587689",".","A","C,G",".",".","FLANK=AGCACCCACAC","GT:AD:DP:EOR:FF:FT:INF:NNS:OABS","2/2:3,5,54:62:C1[]1[];G4[]1[]:A6;C26;G58:.:.:47:A2[26.5]1[41];C3[30]2[22];G37[32.59]17[33.06]","1/2:4,10,61:75:A1[]0[];C1[]0[];G0[]2[]:A13;C68;G87;T1:.:SOMATIC:10,50:A2[24.5]2[41];C4[28.25]6[24.33];G35[30.74]26[31.5]"}).collect(Collectors.joining(Constants.TAB_STRING)));
-		data.add(Arrays.stream(new String[]{"chr2","91629178",".","C","A",".",".","FLANK=TCTGTATGTTC","GT:AD:DP:EOR:FF:FT:INF:NNS:OABS","0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]","0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}).collect(Collectors.joining(Constants.TAB_STRING)));
-		data.add(Arrays.stream(new String[]{"chr2","91629179",".","C","A",".",".","FLANK=TCTGTATGTTC","GT:AD:DP:EOR:FF:FT:INF:NNS:OABS","0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]","0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}).collect(Collectors.joining(Constants.TAB_STRING)));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr1", "2587689", ".", "A", "C,G", ".", ".", "FLANK=AGCACCCACAC", "GT:AD:DP:EOR:FF:FT:INF:NNS:OABS", "2/2:3,5,54:62:C1[]1[];G4[]1[]:A6;C26;G58:.:.:47:A2[26.5]1[41];C3[30]2[22];G37[32.59]17[33.06]", "1/2:4,10,61:75:A1[]0[];C1[]0[];G0[]2[]:A13;C68;G87;T1:.:SOMATIC:10,50:A2[24.5]2[41];C4[28.25]6[24.33];G35[30.74]26[31.5]"}));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629178", ".", "C", "A", ".", ".", "FLANK=TCTGTATGTTC", "GT:AD:DP:EOR:FF:FT:INF:NNS:OABS", "0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]", "0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629179", ".", "C", "A", ".", ".", "FLANK=TCTGTATGTTC", "GT:AD:DP:EOR:FF:FT:INF:NNS:OABS", "0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]", "0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}));
 		
-		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1));) {          
+		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1))) {
 			for (final String line : data) {
 				bw.write(line + "\n");                  
 			}
@@ -132,28 +131,30 @@ public class MergeSameSamplesTest {
 		/*
 		 * remove last 3 entries and add 3 new ones
 		 */
-		data.remove(data.size() - 1);
-		data.remove(data.size() - 1);
-		data.remove(data.size() - 1);
-		data.add(Arrays.stream(new String[]{"chr1","2587689",".","A","G",".",".","DP=60;ExcessHet=3.0103;FS=0.000;MQ=53.08;QD=34.17;SOR=1.919","GT:AD:DP:GQ:QL:FT:INF","1/1:0,56:56:99:1913.77:.:.","1/1:0,91:91:99:2811.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
-		data.add(Arrays.stream(new String[]{"chr2","91629178",".","C","T",".",".","BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846","GT:AD:DP:GQ:QL:FT:INF","0/1:69,22:91:99:664.77:.:.","0/1:147,47:194:99:1551.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
-		data.add(Arrays.stream(new String[]{"chr2","91629179",".","C","T",".",".","BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846","GT:AD:DP:GQ:QL:FT:INF","0/1:69,22:91:99:664.77:.:.","0/1:147,47:194:99:1551.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
+		data.removeLast();
+		data.removeLast();
+		data.removeLast();
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr1", "2587689", ".", "A", "G", ".", ".", "DP=60;ExcessHet=3.0103;FS=0.000;MQ=53.08;QD=34.17;SOR=1.919", "GT:AD:DP:GQ:QL:FT:INF", "1/1:0,56:56:99:1913.77:.:.", "1/1:0,91:91:99:2811.77:.:."}));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629178", ".", "C", "T", ".", ".", "BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846", "GT:AD:DP:GQ:QL:FT:INF", "0/1:69,22:91:99:664.77:.:.", "0/1:147,47:194:99:1551.77:.:."}));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629179", ".", "C", "T", ".", ".", "BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846", "GT:AD:DP:GQ:QL:FT:INF", "0/1:69,22:91:99:664.77:.:.", "0/1:147,47:194:99:1551.77:.:."}));
 		
-		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2));) {          
+		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2))) {
 			for (final String line : data) {
 				bw.write(line + "\n");                  
 			}
 		}
 		
-		String cmd = " -vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
+		String cmd = "-vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
 		Executor exec = execute(cmd);
 		assertEquals(0, exec.getErrCode());
 		
 		/*
 		 * check for output file
 		 */
-		List<String> output = Files.lines(Paths.get(out.getAbsolutePath())).collect(Collectors.toList());
-//		output.forEach(System.out::println);
+		List<String> output;
+		try (Stream<String> lines = Files.lines(Paths.get(out.getAbsolutePath()))){
+			output = lines.toList();
+		}
 		assertEquals(13, output.size());
 		
 		assertEquals("chr1	2587689	.	A	C,G	.	.	FLANK=AGCACCCACAC;DP=60;ExcessHet=3.0103;FS=0.000;MQ=53.08;QD=34.17;SOR=1.919;IN=1,2	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	2/2:3,5,54:62:C1[]1[];G4[]1[]:A6;C26;G58:.:.:.:47:A2[26.5]1[41];C3[30]2[22];G37[32.59]17[33.06]:.	1/2:4,10,61:75:A1[]0[];C1[]0[];G0[]2[]:A13;C68;G87;T1:.:.:SOMATIC:10,50:A2[24.5]2[41];C4[28.25]6[24.33];G35[30.74]26[31.5]:.	2/2:0,0,56:56:.:.:.:99:.:.:.:1913.77	2/2:0,0,91:91:.:.:.:99:.:.:.:2811.77", output.get(10));
@@ -163,7 +164,7 @@ public class MergeSameSamplesTest {
 		assertEquals(91629178, mergedRec.getPosition());
 		assertEquals("C", mergedRec.getRef());
 		assertEquals("A,T", mergedRec.getAlt());
-		assertEquals(true, mergedRec.getInfo().contains("IN=1,2"));
+        assertTrue(mergedRec.getInfo().contains("IN=1,2"));
 		
 		Map<String, String[]> ffs = mergedRec.getFormatFieldsAsMap();
 		assertArrayEquals(new String[]{"0/1","0/0","0/2","0/2"}, ffs.get(VcfHeaderUtils.FORMAT_GENOTYPE));
@@ -178,7 +179,7 @@ public class MergeSameSamplesTest {
 		assertEquals(91629179, mergedRec.getPosition());
 		assertEquals("C", mergedRec.getRef());
 		assertEquals("A,T", mergedRec.getAlt());
-		assertEquals(true, mergedRec.getInfo().contains("IN=1,2"));
+        assertTrue(mergedRec.getInfo().contains("IN=1,2"));
 		
 		ffs = mergedRec.getFormatFieldsAsMap();
 		assertArrayEquals(new String[]{"0/1","0/0","0/2","0/2"}, ffs.get(VcfHeaderUtils.FORMAT_GENOTYPE));
@@ -201,10 +202,10 @@ public class MergeSameSamplesTest {
 		data.add("##qTestBamUUID=TEST");
 		data.add(VcfHeaderUtils.STANDARD_FINAL_HEADER_LINE + "\tFORMAT\tCONTROL\tTEST");
 		
-		data.add(Arrays.stream(new String[]{"chr1","2587689",".","A","C,G",".",".","FLANK=AGCACCCACAC","GT:AD:DP:EOR:FF:FT:INF:NNS:OABS","2/2:3,5,54:62:C1[]1[];G4[]1[]:A6;C26;G58:.:.:47:A2[26.5]1[41];C3[30]2[22];G37[32.59]17[33.06]","1/2:4,10,61:75:A1[]0[];C1[]0[];G0[]2[]:A13;C68;G87;T1:.:SOMATIC:10,50:A2[24.5]2[41];C4[28.25]6[24.33];G35[30.74]26[31.5]"}).collect(Collectors.joining(Constants.TAB_STRING)));
-		data.add(Arrays.stream(new String[]{"chr2","91629178",".","CC","AA",".",".","FLANK=TCTGTATGTTC","GT:AD:DP:EOR:FF:FT:INF:NNS:OABS","0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]","0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}).collect(Collectors.joining(Constants.TAB_STRING)));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr1", "2587689", ".", "A", "C,G", ".", ".", "FLANK=AGCACCCACAC", "GT:AD:DP:EOR:FF:FT:INF:NNS:OABS", "2/2:3,5,54:62:C1[]1[];G4[]1[]:A6;C26;G58:.:.:47:A2[26.5]1[41];C3[30]2[22];G37[32.59]17[33.06]", "1/2:4,10,61:75:A1[]0[];C1[]0[];G0[]2[]:A13;C68;G87;T1:.:SOMATIC:10,50:A2[24.5]2[41];C4[28.25]6[24.33];G35[30.74]26[31.5]"}));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629178", ".", "CC", "AA", ".", ".", "FLANK=TCTGTATGTTC", "GT:AD:DP:EOR:FF:FT:INF:NNS:OABS", "0/1:62,4:66:A1[]0[];C1[]6[]:A17;C91;T29:.:.:4:A3[38]1[12];C32[38.06]30[38]", "0/0:123,6:130:A2[]0[];C7[]6[]:A61;C181;G2;T76:.:.:.:A6[38]0[0];C80[40.11]43[37.51];T0[0]1[41]"}));
 		
-		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1));) {          
+		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf1))) {
 			for (final String line : data) {
 				bw.write(line + "\n");                  
 			}
@@ -213,27 +214,29 @@ public class MergeSameSamplesTest {
 		/*
 		 * remove last 2 entries and add 3 new ones
 		 */
-		data.remove(data.size() - 1);
-		data.remove(data.size() - 1);
-		data.add(Arrays.stream(new String[]{"chr1","2587689",".","A","G",".",".","DP=60;ExcessHet=3.0103;FS=0.000;MQ=53.08;QD=34.17;SOR=1.919","GT:AD:DP:GQ:QL:FT:INF","1/1:0,56:56:99:1913.77:.:.","1/1:0,91:91:99:2811.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
-		data.add(Arrays.stream(new String[]{"chr2","91629178",".","C","A",".",".","BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846","GT:AD:DP:GQ:QL:FT:INF","0/1:69,22:91:99:664.77:.:.","0/1:147,47:194:99:1551.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
-		data.add(Arrays.stream(new String[]{"chr2","91629179",".","C","A",".",".","BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846","GT:AD:DP:GQ:QL:FT:INF","0/1:69,22:91:99:664.77:.:.","0/1:147,47:194:99:1551.77:.:."}).collect(Collectors.joining(Constants.TAB_STRING)));
+		data.removeLast();
+		data.removeLast();
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr1", "2587689", ".", "A", "G", ".", ".", "DP=60;ExcessHet=3.0103;FS=0.000;MQ=53.08;QD=34.17;SOR=1.919", "GT:AD:DP:GQ:QL:FT:INF", "1/1:0,56:56:99:1913.77:.:.", "1/1:0,91:91:99:2811.77:.:."}));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629178", ".", "C", "A", ".", ".", "BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846", "GT:AD:DP:GQ:QL:FT:INF", "0/1:69,22:91:99:664.77:.:.", "0/1:147,47:194:99:1551.77:.:."}));
+		data.add(String.join(Constants.TAB_STRING, new String[]{"chr2", "91629179", ".", "C", "A", ".", ".", "BaseQRankSum=-0.281;ClippingRankSum=0.000;DP=92;ExcessHet=3.0103;FS=0.954;MQ=33.50;MQRankSum=-1.018;QD=7.31;ReadPosRankSum=1.395;SOR=0.846", "GT:AD:DP:GQ:QL:FT:INF", "0/1:69,22:91:99:664.77:.:.", "0/1:147,47:194:99:1551.77:.:."}));
 		
-		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2));) {          
+		try(BufferedWriter bw = new BufferedWriter(new FileWriter(vcf2))) {
 			for (final String line : data) {
 				bw.write(line + "\n");                  
 			}
 		}
 		
-		String cmd = " -vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
+		String cmd = "-vcf " + vcf1.getAbsolutePath() + " -vcf " + vcf2.getAbsolutePath() + " -out " + out.getAbsolutePath();
 		Executor exec = execute(cmd);
 		assertEquals(0, exec.getErrCode());
 		
 		/*
 		 * check for output file
 		 */
-		List<String> output = Files.lines(Paths.get(out.getAbsolutePath())).collect(Collectors.toList());
-//		output.forEach(System.out::println);
+		List<String> output;
+		try (Stream<String> lines = Files.lines(Paths.get(out.getAbsolutePath()))){
+			output = lines.toList();
+		}
 		assertEquals(14, output.size());
 		
 		/*
@@ -244,20 +247,20 @@ public class MergeSameSamplesTest {
 		/*
 		 * second snp - regular, only in second caller
 		 */
-		assertEquals(true, output.get(11).startsWith("chr2	91629178	.	C	A	."));
-		assertEquals(true, output.get(11).contains("IN=2"));
+        assertTrue(output.get(11).startsWith("chr2	91629178	.	C	A	."));
+        assertTrue(output.get(11).contains("IN=2"));
 		
 		/*
 		 * third snp - compound, in first caller only
 		 */
-		assertEquals(true, output.get(12).startsWith("chr2	91629178	.	CC	AA	."));
-		assertEquals(true, output.get(12).contains("IN=1"));
+        assertTrue(output.get(12).startsWith("chr2	91629178	.	CC	AA	."));
+        assertTrue(output.get(12).contains("IN=1"));
 		
 		/*
 		 * fourth snp - regular, in second caller only
 		 */
-		assertEquals(true, output.get(13).startsWith("chr2	91629179	.	C	A	."));
-		assertEquals(true, output.get(13).contains("IN=2"));
+        assertTrue(output.get(13).startsWith("chr2	91629179	.	C	A	."));
+        assertTrue(output.get(13).contains("IN=2"));
 	}
 	
 	private Executor execute(final String command) throws IOException, InterruptedException {

--- a/qannotate/build.gradle
+++ b/qannotate/build.gradle
@@ -1,11 +1,36 @@
+plugins {
+  id 'org.hidetake.ssh' version '2.9.0'
+}
+
 apply plugin: 'application'
 mainClassName = 'au.edu.qimr.qannotate.Main'
 def scriptname = 'qannotate'
 def isExecutable = true
 
+remotes {
+  avalon {
+    host = 'hpcpbs01.adqimr.ad.lan'
+    user = 'oliverH'
+    identity = file('../../../../../../.ssh/id_rsa')
+  }
+}
+
+task deploy {
+  doLast {
+    ssh.run {
+      session(remotes.avalon) {
+        put from: "${project.projectDir}/build/flat/qannotate.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
+        put from: "${project.projectDir}/build/flat/qcommon.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
+        put from: "${project.projectDir}/build/flat/qio.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
+        put from: "${project.projectDir}/build/flat/snpEff-5.2a.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
+      }
+    }
+  }
+}
+
 /*
 * qannotate requires snpEff and the version currently used is 4.0e
-* This version of the snpEff jar file embedds a version of junit that is old,
+* This version of the snpEff jar file embeds a version of junit that is old,
 * and qannotate's test classes use some features that the bundled version does not have.
 *
 * This is purely an issue with the ordering of jars on the classpath that is used by the tests
@@ -18,6 +43,7 @@ def isExecutable = true
 */
 
 configurations {  junit }
+configurations {  sshAntTask }
 
 dependencies {
     //this junit is required by snpEff-4.0
@@ -28,7 +54,7 @@ dependencies {
     implementation project(':qbamfilter')
     implementation project(':qpicard')
 
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation name: 'snpEff', version: '4.0e'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
 }

--- a/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/SnpEffMode.java
@@ -47,10 +47,12 @@ public class SnpEffMode extends AbstractMode{
 	    	logger.tool("exit snpEFF: " + ok);
 		
 		//reheader
-        if (ok) { 
-	        	header = new VcfFileReader(tmpFile).getVcfHeader();
-	        	reheader(options.getCommandLine(),options.getInputFileName())	;	
-	        	writeVCF(new File( options.getOutputFileName()) );
+        if (ok) {
+			try (VcfFileReader reader = new VcfFileReader(tmpFile) ){
+				header = reader.getVcfHeader();
+			}
+			reheader(options.getCommandLine(),options.getInputFileName())	;
+			writeVCF(new File( options.getOutputFileName()) );
 			logger.tool("reheader snpEFF output to " +   options.getOutputFileName());
 		} else {
 			logger.info("run SnpEff failed!");

--- a/qannotate/src/au/edu/qimr/qannotate/nanno/AnnotateUtils.java
+++ b/qannotate/src/au/edu/qimr/qannotate/nanno/AnnotateUtils.java
@@ -116,7 +116,7 @@ public class AnnotateUtils {
 		}
 		
 		Set<String> sortedHeaderSet = Arrays.stream(sortedHeader.split(",")).collect(Collectors.toSet());
-		Set<String> fieldsFromAnnotationSourcesSet = Arrays.stream(Arrays.stream(fieldsFromAnnotationSources).collect(Collectors.joining(",")).split(",")).collect(Collectors.toSet());
+		Set<String> fieldsFromAnnotationSourcesSet = Arrays.stream(String.join(",", fieldsFromAnnotationSources).split(",")).collect(Collectors.toSet());
 		
 		for (String s : sortedHeaderSet) {
 			if ( ! fieldsFromAnnotationSourcesSet.contains(s)) {
@@ -149,46 +149,46 @@ public class AnnotateUtils {
 	 * @param hgvsP
 	 * @return
 	 */
-	public static String getSearchTerm(Optional<String> hgvsC, Optional<String> hgvsP) {
+	public static String getSearchTerm(String hgvsC, String hgvsP) {
 		String st = "";
 		
 		/*
 		 * check the optionals - if they are both not present, no need to proceed
 		 */
-		if (( ! hgvsC.isPresent() && ! hgvsP.isPresent())) {
+		if (( hgvsC == null && hgvsP == null)) {
 			return st;
 		}
 		
-		if ( hgvsC.isPresent() && hgvsC.get().length() > 0) {
+		if ( hgvsC != null && ! hgvsC.isEmpty()) {
 			
 			/*
 			 * need to check that the string contains the dot ('.') and the gt sign ('>')
 			 */
-			int dotIndex = hgvsC.get().indexOf('.');
-			int gtIndex = hgvsC.get().indexOf('>');
+			int dotIndex = hgvsC.indexOf('.');
+			int gtIndex = hgvsC.indexOf('>');
 			if (dotIndex > -1 && gtIndex > -1) {
 			
 				/*
 				 * split value into required parts
 				 */
-				String firstPart = hgvsC.get().substring(dotIndex + 1, gtIndex);
-				String secondPart = hgvsC.get().substring(gtIndex + 1);
+				String firstPart = hgvsC.substring(dotIndex + 1, gtIndex);
+				String secondPart = hgvsC.substring(gtIndex + 1);
 				
 				st += Annotate.SEARCH_TERM_VARIETIES.stream().map(s -> "\"" + firstPart + s + secondPart + "\"").collect(Collectors.joining("|"));
 			}
 		}
 		
-		if ( hgvsP.isPresent() && hgvsP.get().length() > 0) {
-			if (st.length() > 0) {
+		if ( hgvsP != null && ! hgvsP.isEmpty()) {
+			if ( ! st.isEmpty()) {
 				/*
 				 * we must have hgvs.c data - so add bar
 				 */
 				st += "|";
 			}
-			st += "\"" + hgvsP.get().substring(hgvsP.get().indexOf('.') + 1) + "\"";
+			st += "\"" + hgvsP.substring(hgvsP.indexOf('.') + 1) + "\"";
 		}
 		
-		if (st.length() > 0) {
+		if ( ! st.isEmpty()) {
 			return "\"GENE\"+(" + st + ")";
 		}
 		return st;
@@ -269,7 +269,7 @@ public class AnnotateUtils {
 			String fieldOrder = ais.getOutputFieldOrder();
 			String [] fieldOrderArray = StringUtils.isNullOrEmpty(fieldOrder) ? new String[]{} : fieldOrder.split(",");
 
-			String header = "#chr\tposition\tref\talt\tGATK_AD\t" + Arrays.stream(fieldOrderArray).collect(Collectors.joining("\t"));
+			String header = "#chr\tposition\tref\talt\toriginal_alt\tGATK_GT\tGATK_AD\t" + Arrays.stream(fieldOrderArray).collect(Collectors.joining("\t"));
 			if (emptyHeadersArray.length > 0) {
 				header += "\t" +  Arrays.stream(emptyHeadersArray).collect(Collectors.joining("\t"));
 			}

--- a/qannotate/src/au/edu/qimr/qannotate/nanno/AnnotationSource.java
+++ b/qannotate/src/au/edu/qimr/qannotate/nanno/AnnotationSource.java
@@ -76,7 +76,7 @@ public abstract class AnnotationSource implements Closeable {
 				String recRef = recArray[refPositionInFile];
 				String recAlt = recArray[altPositionInFile];
 				
-				if (((ChrPositionRefAlt)requestedCp).getName().equals(recRef) && ((ChrPositionRefAlt)requestedCp).getAlt().equals(recAlt)) {
+				if (((ChrPositionRefAlt)requestedCp).getRef().equals(recRef) && ((ChrPositionRefAlt)requestedCp).getAlt().equals(recAlt)) {
 					return annotationToReturn(rec);
 				}
 			}
@@ -99,7 +99,7 @@ public abstract class AnnotationSource implements Closeable {
 					String recRef = recArray[refPositionInFile];
 					String recAlt = recArray[altPositionInFile];
 					
-					if (((ChrPositionRefAlt)requestedCp).getName().equals(recRef) && ((ChrPositionRefAlt)requestedCp).getAlt().equals(recAlt)) {
+					if (((ChrPositionRefAlt)requestedCp).getRef().equals(recRef) && ((ChrPositionRefAlt)requestedCp).getAlt().equals(recAlt)) {
 						return annotationToReturn(rec);
 					}
 				}
@@ -112,7 +112,7 @@ public abstract class AnnotationSource implements Closeable {
 		return annotationToReturn(null);
 	}
 	
-	private void getNextRecord(ChrPosition requestedCp) {
+	void getNextRecord(ChrPosition requestedCp) {
 		currentRecords = new ArrayList<>();
 		
 		/*
@@ -153,12 +153,10 @@ public abstract class AnnotationSource implements Closeable {
 				nextRecords.add(nextRecord);
 				break;
 		    } else {
-				
 				/*
-				 * keep going
+				 * no match yet - keep going
 				 */
 			}
-			
 		}
 	}
 	
@@ -237,9 +235,9 @@ public abstract class AnnotationSource implements Closeable {
 			return -1;
 		}
 		
-		int nameAndStartPosisionMatch = compareChromosomeNameAndStartPositions(cp1.getChromosome(), cp1.getStartPosition(), cp2.getChromosome(), cp2.getStartPosition());
-		if (nameAndStartPosisionMatch != 0) {
-			return nameAndStartPosisionMatch;
+		int nameAndStartPositionMatch = compareChromosomeNameAndStartPositions(cp1.getChromosome(), cp1.getStartPosition(), cp2.getChromosome(), cp2.getStartPosition());
+		if (nameAndStartPositionMatch != 0) {
+			return nameAndStartPositionMatch;
 		}
 		
 		return Integer.compare(cp1.getEndPosition(), cp2.getEndPosition());

--- a/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafRunTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/Vcf2mafRunTest.java
@@ -69,7 +69,7 @@ public class Vcf2mafRunTest {
     }
     
     @Test
-    public void fileNameWithNoSampleidTest() throws IOException{
+    public void fileNameWithNoSampleIdTest() throws IOException{
         String[] str = {"##fileformat=VCFv4.0",            
                 VcfHeaderUtils.STANDARD_DONOR_ID +"=MELA_0264",
                 VcfHeaderUtils.STANDARD_TEST_BAMID +"=TEST_uuid",                
@@ -239,9 +239,9 @@ public class Vcf2mafRunTest {
 	
 	/**
 	 * only used by filenameTest() and bamIdTest()
-	 * @param isDir set output a direcotry or file
+	 * @param isDir set output a directory or file
 	 * @param str is vcf txt 
-	 * @return output file or direcotory from main
+	 * @return output file or directory from main
 	 */
 	private File runMainTest(boolean isDir, String[] str) {
 		

--- a/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotateTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotateTest.java
@@ -31,7 +31,7 @@ public class AnnotateTest {
 	public void jsonInputs() throws IOException {
 		File inputJson = testFolder.newFile("inputs.json");
 		File annotationSource = testFolder.newFile("annotation.vcf");
-		createJsonInputs(inputJson, annotationSource, "blah");
+		createJsonInputs(inputJson, annotationSource, "blah", false, 3, 4);
 		
 		AnnotationInputs ais = AnnotateUtils.getInputs(inputJson.getAbsolutePath());
 		assertEquals(true, ais != null);
@@ -49,7 +49,7 @@ public class AnnotateTest {
 	public void jsonInputsTSVMissingHeader() throws IOException {
 		File inputJson = testFolder.newFile("inputs.json");
 		File annotationSource = testFolder.newFile("annotation.tsv");
-		createJsonInputs(inputJson, annotationSource, "blah");
+		createJsonInputs(inputJson, annotationSource, "blah", false, 3, 4);
 		
 		AnnotationInputs ais = AnnotateUtils.getInputs(inputJson.getAbsolutePath());
 		try {
@@ -81,12 +81,34 @@ public class AnnotateTest {
 			assertEquals(true, iae.getMessage().contains("Could not find requested fields (blah) in header"));
 		}
 	}
-	
+
+	@Test
+	public void jsonInputsShouldHandleValidInputs() throws IOException {
+		// Given valid inputs, the method should process them without throwing exceptions
+		File validInputJson = testFolder.newFile("valid_inputs.json");
+		File validAnnotationSource = testFolder.newFile("valid_annotation.vcf");
+		createJsonInputs(validInputJson, validAnnotationSource, "valid", false, 3, 4);
+
+		// When
+		AnnotationInputs ais = AnnotateUtils.getInputs(validInputJson.getAbsolutePath());
+
+		// Then
+		Assert.assertNotNull(ais);
+		Assert.assertEquals(1, ais.getInputs().size());
+
+		List<AnnotationSource> sources = new ArrayList<>();
+		AnnotateUtils.populateAnnotationSources(ais, sources);
+		Assert.assertEquals(1, sources.size());
+
+		String annotation = sources.get(0).getAnnotation(new ChrPositionRefAlt("chr1", 95813205, 95813205, "C", "T"));
+		Assert.assertEquals("valid=", annotation);
+	}
+
 	@Test
 	public void jsonInputsTSV() throws IOException {
 		File inputJson = testFolder.newFile("inputs.json");
 		File annotationSource = testFolder.newFile("annotation.tsv");
-		createJsonInputs(inputJson, annotationSource, "aaref,HGVSc_VEP,HGVSp_VEP");
+		createJsonInputs(inputJson, annotationSource, "aaref,HGVSc_VEP,HGVSp_VEP", false, 3, 4);
 		createAnnotationFile(annotationSource, true);
 		List<AnnotationSource> sources = new ArrayList<>(2);
 		AnnotationInputs ais = AnnotateUtils.getInputs(inputJson.getAbsolutePath());
@@ -102,6 +124,7 @@ public class AnnotateTest {
 		File annotationSource = testFolder.newFile("annotation.tsv");
 		File inputJson = testFolder.newFile("inputs.json");
 		File outputFile = testFolder.newFile("output.tsv");
+		File logFile = testFolder.newFile("endToEnd.log");
 		
 		/*
 		 * incorrect order and no matching annotations
@@ -116,9 +139,9 @@ public class AnnotateTest {
 		/*
 		 * json inputs - need annotationSource deets
 		 */
-		createJsonInputs(inputJson, annotationSource, "aaref");
+		createJsonInputs(inputJson, annotationSource, "aaref", false, 3, 4);
 		
-		int exitValue = executeTest(inputVcf, inputJson, outputFile);
+		int exitValue = executeTest(inputVcf, inputJson, outputFile, logFile);
 		assertEquals(1, exitValue);
 		
 		/*
@@ -127,8 +150,8 @@ public class AnnotateTest {
 		createVcf(inputVcf, Arrays.asList(
 				"chr1	655652	rs11165387	A	T	.	.	.	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/1:17,15:Germline:22:32:T0[]1[]:C1;T8:PASS:.:.:15:C4[36.5]13[38.54];T5[41]10[39.7]:.	0/0:26,0:ReferenceNoVariant:22:26:C1[]1[]:C7:PASS:.:.:.:C8[36.5]18[39.56]:.",
 				"chr1	655650	rs5015226	A	C	.	.	.	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	1/1:0,46:Germline:34:47:G0[]1[]:G5;T1:PASS:.:.:42:C0[0]1[12];G23[40.04]23[36.83]:.	1/1:0,57:Germline:34:57:G2[]0[]:G3:PASS:.:.:51:G24[39]33[39.18]:."));
-		
-		exitValue = executeTest(inputVcf, inputJson, outputFile);
+
+		exitValue = executeTest(inputVcf, inputJson, outputFile, null);
 		assertEquals(1, exitValue);
 		
 		/*
@@ -137,25 +160,67 @@ public class AnnotateTest {
 		createVcf(inputVcf, Arrays.asList(
 				"chr1	655650	rs11165387	A	C	.	.	.	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/1:17,15:Germline:22:32:T0[]1[]:C1;T8:PASS:.:.:15:C4[36.5]13[38.54];T5[41]10[39.7]:.	0/0:26,0:ReferenceNoVariant:22:26:C1[]1[]:C7:PASS:.:.:.:C8[36.5]18[39.56]:.",
         		"chr1	655652	rs5015226	A	T	.	.	.	GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	1/1:0,46:Germline:34:47:G0[]1[]:G5;T1:PASS:.:.:42:C0[0]1[12];G23[40.04]23[36.83]:.	1/1:0,57:Germline:34:57:G2[]0[]:G3:PASS:.:.:51:G24[39]33[39.18]:."));
-		
-		exitValue = executeTest(inputVcf, inputJson, outputFile);
+
+		exitValue = executeTest(inputVcf, inputJson, outputFile, null);
 		assertEquals(0, exitValue);
 		
 		/*
 		 * check output file
 		 */
 		List<String> lines = Files.readAllLines(Paths.get(outputFile.getAbsolutePath()));
-		assertEquals(true, lines.contains("chr1	655650	A	C	17,15	M				"));
-		assertEquals(true, lines.contains("chr1	655652	A	T	0,46	M				"));
+		assertEquals(true, lines.contains("chr1	655650	A	C	C	0/1	17,15	M				"));
+		assertEquals(true, lines.contains("chr1	655652	A	T	T	1/1	0,46	M				"));
 		
 	}
+
+	@Test
+	public void endToEndSnpEff() throws IOException {
+		File inputVcf = testFolder.newFile("input.vcf");
+		File snpEffAnnotationSource = testFolder.newFile("snpEff_annotation.vcf");
+		File inputJson = testFolder.newFile("inputs.json");
+		File outputFile = testFolder.newFile("output.tsv");
+		File logFile = testFolder.newFile("endToEnd.log");
+
+		createVcf(inputVcf, Arrays.asList(
+				"chr1    94641   .       G       C       229.02  HardFiltered    AC=2;AF=1.00;AN=2;BaseQRankSum=0.00;DP=14;ExcessHet=0.0000;FS=3.358;MLEAC=2;MLEAF=1.00;MQ=37.05;MQRankSum=1.30;QD=17.62;ReadPosRankSum=0.695;SOR=2.093;ANN=C|intergenic_region|MODIFIER|OR4F5-OR4F29|ENSG00000186092.7-ENSG00000284733.2|intergenic_region|ENSG00000186092.7-ENSG00000284733.2|||n.94641G>C||||||       GT:AD:DP:GQ:PL  1/1:6,7:13:21:243,21,0".replaceAll("\\s+", "\t"),
+				"chr1    94819   .       CTTTTCT C       48.60   PASS    AC=1;AF=0.500;AN=2;BaseQRankSum=-1.528e+00;DP=26;ExcessHet=0.0000;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=46.27;MQRankSum=-1.450e+00;QD=2.03;ReadPosRankSum=0.969;SOR=1.071     GT:AD:DP:GQ:PL  0/1:20,4:24:56:56,0,144".replaceAll("\\s+", "\t"),
+				"chr1    94824   .       CT      *,C     67      PASS    AC=1,1;AF=0.500,0.500;AN=2;BaseQRankSum=-9.270e-01;DP=26;ExcessHet=0.0000;FS=7.521;MLEAC=1,1;MLEAF=0.500,0.500;MQ=46.27;MQRankSum=-2.726e+00;QD=3.53;ReadPosRankSum=-1.118e+00;SOR=2.546        GT:AD:DP:GQ:PL  1/2:11,4,4:19:64:118,77,297,64,0,165".replaceAll("\\s+", "\t"),
+				"chr1    889689  .       G       A,C     679.1   PASS    AC=1,1;AF=0.500,0.500;AN=2;BaseQRankSum=-2.586e+00;DP=63;ExcessHet=0.0000;FS=2.623;MLEAC=1,1;MLEAF=0.500,0.500;MQ=52.67;MQRankSum=-1.696e+00;QD=15.43;ReadPosRankSum=-9.520e-01;SOR=0.984;ANN=A|intergenic_region|MODIFIER|OR4F16-SAMD11|ENSG00000284662.2-ENSG00000187634.13|intergenic_region|ENSG00000284662.2-ENSG00000187634.13|||n.889689G>A||||||,C|intergenic_region|MODIFIER|OR4F16-SAMD11|ENSG00000284662.2-ENSG00000187634.13|intergenic_region|ENSG00000284662.2-ENSG00000187634.13|||n.889689G>C||||||     GT:AD:DP:GQ:PL  1/2:22,4,18:44:99:696,580,775,165,0,111".replaceAll("\\s+", "\t"),
+				"chr1    1130186 .       CAAAAAA C,CAAAAAAAAAAAAAA       125.02  HardFiltered    AC=1,1;AF=0.500,0.500;AN=2;DP=17;ExcessHet=0.0000;FS=0.000;MLEAC=1,1;MLEAF=0.500,0.500;MQ=59.72;QD=25.00;SOR=3.611;ANN=C|intergenic_region|MODIFIER|C1orf159-TTLL10|ENSG00000131591.18-ENSG00000162571.14|intergenic_region|ENSG00000131591.18-ENSG00000162571.14|||n.1130187_1130192delAAAAAA||||||,CAAAAAAAAAAAAAA|intergenic_region|MODIFIER|C1orf159-TTLL10|ENSG00000131591.18-ENSG00000162571.14|intergenic_region|ENSG00000131591.18-ENSG00000162571.14|||n.1130192_1130193insAAAAAAAA||||||      GT:AD:DP:GQ:PL  1/2:0,3,2:5:67:142,74,232,72,0,67".replaceAll("\\s+", "\t")));
+		/*
+		 * snp eff annotation file next
+		 */
+		createSnpEFfAnnotationFile(snpEffAnnotationSource, true);
+		/*
+		 * json inputs - need annotationSource deets
+		 */
+		createJsonInputs(inputJson, snpEffAnnotationSource, "gene_name,feature_id,feature_type,effect,cdna_position,cds_position,protein_position,putative_impact,hgvs.c,hgvs.p", true, 4, 5);
+
+		int exitValue = executeTest(inputVcf, inputJson, outputFile, logFile);
+		assertEquals(0, exitValue);
+
+
+		/*
+		 * check output file
+		 */
+		List<String> lines = Files.readAllLines(Paths.get(outputFile.getAbsolutePath()));
+		assertEquals("chr1\t94641\tG\tC\tC\t1/1\t6,7\tOR4F5-OR4F29\tENSG00000186092.7-ENSG00000284733.2\tintergenic_region\tintergenic_region\t\t\t\tMODIFIER\tn.94641G>C\t\t\t\t\t\"GENE\"+(\"94641G>C\"|\"94641G->C\"|\"94641G-->C\"|\"94641G/C\")", lines.get(lines.size() - 7));
+		assertEquals("chr1\t94819\tCTTTTCT\tC\tC\t0/1\t20,4\tOR4F5-OR4F29\tENSG00000186092.7-ENSG00000284733.2\tintergenic_region\tintergenic_region\t\t\t\tMODIFIER\tn.94820_94825delTTTTCT\t\t\t\t\t", lines.get(lines.size() - 6));
+		assertEquals("chr1\t94824\tCT\tC\t*,C\t1/2\t11,4,4\tOR4F5-OR4F29\tENSG00000186092.7-ENSG00000284733.2\tintergenic_region\tintergenic_region\t\t\t\tMODIFIER\tn.94825delT\t\t\t\t\t", lines.get(lines.size() - 5));
+		assertEquals("chr1\t889689\tG\tA\tA,C\t1/2\t22,4,18\tOR4F16-SAMD11\tENSG00000284662.2-ENSG00000187634.13\tintergenic_region\tintergenic_region\t\t\t\tMODIFIER\tn.889689G>A\t\t\t\t\t\"GENE\"+(\"889689G>A\"|\"889689G->A\"|\"889689G-->A\"|\"889689G/A\")", lines.get(lines.size() - 4));
+		assertEquals("chr1\t889689\tG\tC\tA,C\t1/2\t22,4,18\tOR4F16-SAMD11\tENSG00000284662.2-ENSG00000187634.13\tintergenic_region\tintergenic_region\t\t\t\tMODIFIER\tn.889689G>C\t\t\t\t\t\"GENE\"+(\"889689G>C\"|\"889689G->C\"|\"889689G-->C\"|\"889689G/C\")", lines.get(lines.size() - 3));
+		assertEquals("chr1\t1130186\tCAAAAAA\tC\tC,CAAAAAAAAAAAAAA\t1/2\t0,3,2\tC1orf159-TTLL10\tENSG00000131591.18-ENSG00000162571.14\tintergenic_region\tintergenic_region\t\t\t\tMODIFIER\tn.1130187_1130192delAAAAAA\t\t\t\t\t", lines.get(lines.size() - 2));
+		assertEquals("chr1\t1130186\tCAAAAAA\tCAAAAAAAAAAAAAA\tC,CAAAAAAAAAAAAAA\t1/2\t0,3,2\tC1orf159-TTLL10\tENSG00000131591.18-ENSG00000162571.14\tintergenic_region\tintergenic_region\t\t\t\tMODIFIER\tn.1130192_1130193insAAAAAAAA\t\t\t\t\t", lines.get(lines.size() - 1));
+	}
 	
-	private int executeTest(File inputVcf, File inputJson, File outputFile) {
-	      
+	private int executeTest(File inputVcf, File inputJson, File outputFile, File log) throws IOException {
+
+		if (null == log) {
+			log = testFolder.newFile();
+		}
 	    //run vcf2maf
 		try {
-		      File log = testFolder.newFile();
-		      final String command = " au.edu.qimr.qannotate.nanno.Annotate --input " +  inputVcf.getAbsolutePath() + " --loglevel DEBUG  --log " + log.getAbsolutePath() + " -config " + inputJson.getAbsolutePath() 
+		      final String command = "--input " +  inputVcf.getAbsolutePath() + " --loglevel DEBUG --log " + log.getAbsolutePath() + " --config " + inputJson.getAbsolutePath()
 		      	+ " --output " + outputFile.getAbsolutePath();
 		      Executor exec = new Executor(command, "au.edu.qimr.qannotate.nanno.Annotate");
 		      return exec.getErrCode() ;
@@ -164,10 +229,10 @@ public class AnnotateTest {
 			fail("failed during executeTest!");
 		}  
 	      
-	    return 1;	 
+	    return 1;
 	}
 	
-	public static void createJsonInputs(File jsonFile, File annotationFile, String annotationFields) throws IOException {
+	public static void createJsonInputs(File jsonFile, File annotationFile, String annotationFields, boolean snpEffAnnotationFile, int refPos, int altPos) throws IOException {
 		List<String> data = Arrays.asList(
 				"{",
   "\"outputFieldOrder\": \"" + annotationFields + "\",",
@@ -176,10 +241,11 @@ public class AnnotateTest {
   "\"annotationSourceThreadCount\": 1,",
   "\"inputs\": [{",
     "\"file\": \"" + annotationFile.getAbsolutePath() + "\",",
+	"\"snpEffVcf\": " + snpEffAnnotationFile + ",",
     "\"chrIndex\": 1,",
     "\"positionIndex\": 2,",
-    "\"refIndex\": 3,",
-    "\"altIndex\": 4,",
+    "\"refIndex\": " + refPos + ",",
+    "\"altIndex\": " + altPos + ",",
     "\"fields\": \"" + annotationFields + "\"",
   "}]",
 "}"
@@ -265,7 +331,25 @@ public class AnnotateTest {
             }
          }
 	}
-	
+
+	static void createSnpEFfAnnotationFile(File f, boolean addHeader) throws IOException {
+		String header = "#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  78cf87bd-7c1d-4808-911c-70c3f7a98534".replaceAll("\\s+", "\t");
+		List<String> data = Arrays.asList(
+				"chr1    94641   .       G       C       229.02  HardFiltered    AC=2;AF=1.00;AN=2;BaseQRankSum=0.00;DP=14;ExcessHet=0.0000;FS=3.358;MLEAC=2;MLEAF=1.00;MQ=37.05;MQRankSum=1.30;QD=17.62;ReadPosRankSum=0.695;SOR=2.093;ANN=C|intergenic_region|MODIFIER|OR4F5-OR4F29|ENSG00000186092.7-ENSG00000284733.2|intergenic_region|ENSG00000186092.7-ENSG00000284733.2|||n.94641G>C||||||       GT:AD:DP:GQ:PL  1/1:6,7:13:21:243,21,0".replaceAll("\\s+", "\t"),
+				"chr1    94819   .       CTTTTCT C       48.6    PASS    AC=1;AF=0.500;AN=2;BaseQRankSum=-1.528e+00;DP=26;ExcessHet=0.0000;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=46.27;MQRankSum=-1.450e+00;QD=2.03;ReadPosRankSum=0.969;SOR=1.071;ANN=C|intergenic_region|MODIFIER|OR4F5-OR4F29|ENSG00000186092.7-ENSG00000284733.2|intergenic_region|ENSG00000186092.7-ENSG00000284733.2|||n.94820_94825delTTTTCT||||||      GT:AD:DP:GQ:PL  0/1:20,4:24:56:56,0,144".replaceAll("\\s+", "\t"),
+				"chr1    94824   .       CT      *,C     67.0    PASS    AC=1,1;AF=0.500,0.500;AN=2;BaseQRankSum=-9.270e-01;DP=26;ExcessHet=0.0000;FS=7.521;MLEAC=1,1;MLEAF=0.500,0.500;MQ=46.27;MQRankSum=-2.726e+00;QD=3.53;ReadPosRankSum=-1.118e+00;SOR=2.546;ANN=C|intergenic_region|MODIFIER|OR4F5-OR4F29|ENSG00000186092.7-ENSG00000284733.2|intergenic_region|ENSG00000186092.7-ENSG00000284733.2|||n.94825delT||||||    GT:AD:DP:GQ:PL  1/2:11,4,4:19:64:118,77,297,64,0,165".replaceAll("\\s+", "\t"),
+				"chr1    889689  .       G       A,C     679.1   PASS    AC=1,1;AF=0.500,0.500;AN=2;BaseQRankSum=-2.586e+00;DP=63;ExcessHet=0.0000;FS=2.623;MLEAC=1,1;MLEAF=0.500,0.500;MQ=52.67;MQRankSum=-1.696e+00;QD=15.43;ReadPosRankSum=-9.520e-01;SOR=0.984;ANN=A|intergenic_region|MODIFIER|OR4F16-SAMD11|ENSG00000284662.2-ENSG00000187634.13|intergenic_region|ENSG00000284662.2-ENSG00000187634.13|||n.889689G>A||||||,C|intergenic_region|MODIFIER|OR4F16-SAMD11|ENSG00000284662.2-ENSG00000187634.13|intergenic_region|ENSG00000284662.2-ENSG00000187634.13|||n.889689G>C||||||     GT:AD:DP:GQ:PL  1/2:22,4,18:44:99:696,580,775,165,0,111".replaceAll("\\s+", "\t"),
+				"chr1    1130186 .       CAAAAAA C,CAAAAAAAAAAAAAA       125.02  HardFiltered    AC=1,1;AF=0.500,0.500;AN=2;DP=17;ExcessHet=0.0000;FS=0.000;MLEAC=1,1;MLEAF=0.500,0.500;MQ=59.72;QD=25.00;SOR=3.611;ANN=C|intergenic_region|MODIFIER|C1orf159-TTLL10|ENSG00000131591.18-ENSG00000162571.14|intergenic_region|ENSG00000131591.18-ENSG00000162571.14|||n.1130187_1130192delAAAAAA||||||,CAAAAAAAAAAAAAA|intergenic_region|MODIFIER|C1orf159-TTLL10|ENSG00000131591.18-ENSG00000162571.14|intergenic_region|ENSG00000131591.18-ENSG00000162571.14|||n.1130192_1130193insAAAAAAAA||||||      GT:AD:DP:GQ:PL  1/2:0,3,2:5:67:142,74,232,72,0,67".replaceAll("\\s+", "\t"));
+
+		try (BufferedWriter out = new BufferedWriter(new FileWriter(f));) {
+			if (addHeader) {
+				out.write(header + "\n");
+			}
+			for (String line : data) {
+				out.write(line + "\n");
+			}
+		}
+	}
 	/**
 	 * a mini dbSNP vcf file 
 	

--- a/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotateUtilsTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotateUtilsTest.java
@@ -1,7 +1,5 @@
 package au.edu.qimr.qannotate.nanno;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -18,6 +16,8 @@ import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.meta.QExec;
 
+import static org.junit.Assert.*;
+
 public class AnnotateUtilsTest {
 	
 	@Rule
@@ -32,12 +32,12 @@ public class AnnotateUtilsTest {
 		
 		List<String> singleAnnoList = AnnotateUtils.convertAnnotations(annos);
 		assertEquals(6, singleAnnoList.size());
-		assertEquals(true, singleAnnoList.contains("FIELD1=1"));
+        assertTrue(singleAnnoList.contains("FIELD1=1"));
 		
 		annos.add("FIELD7=7\tFIELD8=8\tFIELD9=9\tFIELD10=10");
 		singleAnnoList = AnnotateUtils.convertAnnotations(annos);
 		assertEquals(10, singleAnnoList.size());
-		assertEquals(true, singleAnnoList.contains("FIELD10=10"));
+        assertTrue(singleAnnoList.contains("FIELD10=10"));
 		
 		/*
 		 * look at empty and null lists
@@ -60,14 +60,14 @@ public class AnnotateUtilsTest {
 	
 	@Test
 	public void getSearchTerm() {
-		assertEquals("\"GENE\"+(\"277C>T\"|\"277C->T\"|\"277C-->T\"|\"277C/T\"|\"Arg93Trp\")", AnnotateUtils.getSearchTerm(Optional.of("c.277C>T"), Optional.of("p.Arg93Trp")));
-		assertEquals("\"GENE\"+(\"277T>C\"|\"277T->C\"|\"277T-->C\"|\"277T/C\"|\"Arg93Trp\")", AnnotateUtils.getSearchTerm(Optional.of("c.277T>C"), Optional.of("p.Arg93Trp")));
-		assertEquals("", AnnotateUtils.getSearchTerm(Optional.empty(), Optional.empty()));
-		assertEquals("\"GENE\"+(\"Arg93Trp\")", AnnotateUtils.getSearchTerm(Optional.of("c277TC"), Optional.of("p.Arg93Trp")));
-		assertEquals("\"GENE\"+(\"Arg93Trp\")", AnnotateUtils.getSearchTerm(Optional.of(""), Optional.of("p.Arg93Trp")));
-		assertEquals("\"GENE\"+(\"Arg93Trp\")", AnnotateUtils.getSearchTerm(Optional.empty(), Optional.of("p.Arg93Trp")));
-		assertEquals("", AnnotateUtils.getSearchTerm(Optional.of("c277TC"), Optional.empty()));
-		assertEquals("", AnnotateUtils.getSearchTerm(Optional.of(""), Optional.of("")));
+		assertEquals("\"GENE\"+(\"277C>T\"|\"277C->T\"|\"277C-->T\"|\"277C/T\"|\"Arg93Trp\")", AnnotateUtils.getSearchTerm("c.277C>T", "p.Arg93Trp"));
+		assertEquals("\"GENE\"+(\"277T>C\"|\"277T->C\"|\"277T-->C\"|\"277T/C\"|\"Arg93Trp\")", AnnotateUtils.getSearchTerm("c.277T>C", "p.Arg93Trp"));
+		assertEquals("", AnnotateUtils.getSearchTerm(null, null));
+		assertEquals("\"GENE\"+(\"Arg93Trp\")", AnnotateUtils.getSearchTerm("c277TC", "p.Arg93Trp"));
+		assertEquals("\"GENE\"+(\"Arg93Trp\")", AnnotateUtils.getSearchTerm("", "p.Arg93Trp"));
+		assertEquals("\"GENE\"+(\"Arg93Trp\")", AnnotateUtils.getSearchTerm(null, "p.Arg93Trp"));
+		assertEquals("", AnnotateUtils.getSearchTerm("c277TC", null));
+		assertEquals("", AnnotateUtils.getSearchTerm("", ""));
 	}
 	
 	@Test
@@ -136,13 +136,13 @@ public class AnnotateUtilsTest {
 "}"
 				);
 		
-		try (BufferedWriter out = new BufferedWriter(new FileWriter(inputJson));) {
+		try (BufferedWriter out = new BufferedWriter(new FileWriter(inputJson))) {
 			for (String line : data) {
 				out.write(line + "\n");
 			}
 		}
 		AnnotationInputs ais = AnnotateUtils.getInputs(inputJson.getAbsolutePath());
-		assertEquals(true, ais.isIncludeSearchTerm());
+        assertTrue(ais.isIncludeSearchTerm());
 		assertEquals("test1,test2,test3", ais.getAdditionalEmptyFields());
 		assertEquals(3, ais.getAnnotationSourceThreadCount());
 		assertEquals("field_1,field_2,field_3", ais.getOutputFieldOrder());
@@ -189,7 +189,7 @@ public class AnnotateUtilsTest {
 "}"
 				);
 		
-		try (BufferedWriter out = new BufferedWriter(new FileWriter(inputJson));) {
+		try (BufferedWriter out = new BufferedWriter(new FileWriter(inputJson))) {
 			for (String line : data) {
 				out.write(line + "\n");
 			}
@@ -197,22 +197,22 @@ public class AnnotateUtilsTest {
 		AnnotationInputs ais = AnnotateUtils.getInputs(inputJson.getAbsolutePath());
 		List<String> headers =  AnnotateUtils.generateHeaders(ais, null);
 		assertEquals(4, headers.size());	// 3 inputs plus header line
-		assertEquals(true, headers.contains("##file:fields\t/file_1.tsv:field_1"));
-		assertEquals(true, headers.contains("##file:fields\tfile_2.eff.vcf:field_2"));
-		assertEquals(true, headers.contains("##file:fields\t/file_3.vcf.gz:field_3"));
-		assertEquals("#chr\tposition\tref\talt\tGATK_AD\tfield_1\tfield_2\tfield_3\ttest1\ttest2\ttest3\tsearchTerm", headers.get(headers.size() - 1));
+        assertTrue(headers.contains("##file:fields\t/file_1.tsv:field_1"));
+        assertTrue(headers.contains("##file:fields\tfile_2.eff.vcf:field_2"));
+        assertTrue(headers.contains("##file:fields\t/file_3.vcf.gz:field_3"));
+		assertEquals("#chr\tposition\tref\talt\toriginal_alt\tGATK_GT\tGATK_AD\tfield_1\tfield_2\tfield_3\ttest1\ttest2\ttest3\tsearchTerm", headers.get(headers.size() - 1));
 	}
 	
 	@Test
 	public void isOrderedHeaderListValid() {
-		assertEquals(true, AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h1", "h2", "h3"));
-		assertEquals(false, AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h1", "h2"));
-		assertEquals(false, AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h3", "h2"));
-		assertEquals(false, AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h3", "h1"));
-		assertEquals(false, AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h3", "h1", "h4"));
-		assertEquals(false, AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h2", "h1", "h4"));
-		assertEquals(true, AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h2", "h3", "h1", "h1"));
-		assertEquals(true, AnnotateUtils.isOrderedHeaderListValid("h1,h1,h2,h3", "h2", "h3", "h1", "h1"));
+        assertTrue(AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h1", "h2", "h3"));
+        assertFalse(AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h1", "h2"));
+        assertFalse(AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h3", "h2"));
+        assertFalse(AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h3", "h1"));
+        assertFalse(AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h3", "h1", "h4"));
+        assertFalse(AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h2", "h1", "h4"));
+        assertTrue(AnnotateUtils.isOrderedHeaderListValid("h1,h2,h3", "h2", "h3", "h1", "h1"));
+        assertTrue(AnnotateUtils.isOrderedHeaderListValid("h1,h1,h2,h3", "h2", "h3", "h1", "h1"));
 	}
 	
 	@Test
@@ -220,9 +220,9 @@ public class AnnotateUtilsTest {
 		assertEquals(Optional.empty(), AnnotateUtils.getAnnotationFromList(null, null));
 		assertEquals(Optional.empty(), AnnotateUtils.getAnnotationFromList(new ArrayList<>(), null));
 		assertEquals(Optional.empty(), AnnotateUtils.getAnnotationFromList(new ArrayList<>(), ""));
-		assertEquals(Optional.empty(), AnnotateUtils.getAnnotationFromList(Arrays.asList("ANNO_1=1"), ""));
-		assertEquals(Optional.empty(), AnnotateUtils.getAnnotationFromList(Arrays.asList("ANNO_1=1"), "ANNO_2"));
-		assertEquals(Optional.of("1"), AnnotateUtils.getAnnotationFromList(Arrays.asList("ANNO_1=1"), "ANNO_1"));
+		assertEquals(Optional.empty(), AnnotateUtils.getAnnotationFromList(List.of("ANNO_1=1"), ""));
+		assertEquals(Optional.empty(), AnnotateUtils.getAnnotationFromList(List.of("ANNO_1=1"), "ANNO_2"));
+		assertEquals(Optional.of("1"), AnnotateUtils.getAnnotationFromList(List.of("ANNO_1=1"), "ANNO_1"));
 		assertEquals(Optional.of("2"), AnnotateUtils.getAnnotationFromList(Arrays.asList("ANNO_1=1","ANNO_2=2"), "ANNO_2"));
 		assertEquals(Optional.of("1"), AnnotateUtils.getAnnotationFromList(Arrays.asList("ANNO_1=1","ANNO_2=2"), "ANNO_1"));
 	}

--- a/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotationSourceSnpEffVCFTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotationSourceSnpEffVCFTest.java
@@ -3,6 +3,7 @@ package au.edu.qimr.qannotate.nanno;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -13,22 +14,22 @@ public class AnnotationSourceSnpEffVCFTest {
 	@Test
 	public void extractFieldsFromInfoField() {
 		String info = "AC=2;AF=1.00;AN=2;BaseQRankSum=0.00;DP=46;ExcessHet=0.0000;FS=2.561;MLEAC=2;MLEAF=1.00;MQ=60.00;MQRankSum=0.00;QD=17.47;ReadPosRankSum=0.00;SOR=0.521;ANN=A|3_prime_UTR_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000282670.7|protein_coding|5/5|c.*115G>A|||||115|,A|3_prime_UTR_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000528352.1|nonsense_mediated_decay|7/7|n.*554G>A|||||6971|,A|downstream_gene_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000448074.1|processed_transcript||n.*1991G>A|||||1991|,A|non_coding_transcript_exon_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000528352.1|nonsense_mediated_decay|7/7|n.*554G>A||||||,A|non_coding_transcript_exon_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000489510.1|retained_intron|2/2|n.568G>A||||||";
-		assertEquals("effect=3_prime_UTR_variant", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("effect"), "", "A"));
-		assertEquals("annotation=3_prime_UTR_variant", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("annotation"), "", "A"));
-		assertEquals("cdna_position=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("cdna_position"), "", "A"));
-		assertEquals("cds_position=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("cds_position"), "", "A"));
-		assertEquals("distance_to_feature=115", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("distance_to_feature"), "", "A"));
-		assertEquals("feature_type=transcript", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("feature_type"), "", "A"));
-		assertEquals("rank=5/5", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("rank"), "", "A"));
-		assertEquals("hgvs.c=c.*115G>A", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("hgvs.c"), "", "A"));
+		assertEquals("effect=3_prime_UTR_variant", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("effect"), "", "A"));
+		assertEquals("annotation=3_prime_UTR_variant", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("annotation"), "", "A"));
+		assertEquals("cdna_position=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("cdna_position"), "", "A"));
+		assertEquals("cds_position=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("cds_position"), "", "A"));
+		assertEquals("distance_to_feature=115", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("distance_to_feature"), "", "A"));
+		assertEquals("feature_type=transcript", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("feature_type"), "", "A"));
+		assertEquals("rank=5/5", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("rank"), "", "A"));
+		assertEquals("hgvs.c=c.*115G>A", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("hgvs.c"), "", "A"));
 	}
 	
 	@Test
 	public void extractFieldsFromInfoFieldWrongAlt() {
 		String info = "AC=2;AF=1.00;AN=2;BaseQRankSum=0.00;DP=46;ExcessHet=0.0000;FS=2.561;MLEAC=2;MLEAF=1.00;MQ=60.00;MQRankSum=0.00;QD=17.47;ReadPosRankSum=0.00;SOR=0.521;ANN=A|3_prime_UTR_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000282670.7|protein_coding|5/5|c.*115G>A|||||115|,A|3_prime_UTR_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000528352.1|nonsense_mediated_decay|7/7|n.*554G>A|||||6971|,A|downstream_gene_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000448074.1|processed_transcript||n.*1991G>A|||||1991|,A|non_coding_transcript_exon_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000528352.1|nonsense_mediated_decay|7/7|n.*554G>A||||||,A|non_coding_transcript_exon_variant|MODIFIER|DYNLT5|ENSG00000152760|transcript|ENST00000489510.1|retained_intron|2/2|n.568G>A||||||";
-		assertEquals("", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("effect"), "", "T"));
-		assertEquals("effect=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("effect"), "effect=", "T"));
-		assertEquals("hgvs.c=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("hgvs.c"), "hgvs.c=", "C"));
+		assertEquals("", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("effect"), "", "T"));
+		assertEquals("effect=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("effect"), "effect=", "T"));
+		assertEquals("hgvs.c=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("hgvs.c"), "hgvs.c=", "C"));
 	}
 	
 	@Test
@@ -43,7 +44,7 @@ public class AnnotationSourceSnpEffVCFTest {
 		String info = "AC=2;AF=1.00;AN=2;DP=43;ExcessHet=0.0000;FS=0.000;MLEAC=2;MLEAF=1.00;MQ=60.00;QD=25.36;SOR=0.739;ANN=C|splice_region_variant&intron_variant|LOW|NOC2L|ENSG00000188976|transcript|ENST00000327044.7|protein_coding|8/18|c.888+4C>G||||||,C|splice_region_variant&intron_variant|LOW|NOC2L|ENSG00000188976|transcript|ENST00000477976.5|retained_intron|6/16|n.2335+4C>G||||||,C|downstream_gene_variant|MODIFIER|NOC2L|ENSG00000188976|transcript|ENST00000469563.1|retained_intron||n.*4468C>G|||||4468|,C|downstream_gene_variant|MODIFIER|NOC2L|ENSG00000188976|transcript|ENST00000487214.1|processed_transcript||n.*648C>G|||||648|";
 		String alt = "C";
 		
-		assertEquals("cdna_position=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, Arrays.asList("cdna_position"), ".", alt));
+		assertEquals("cdna_position=", AnnotationSourceSnpEffVCF.extractFieldsFromInfoField(info, List.of("cdna_position"), ".", alt));
 	}
 
 }

--- a/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotationSourceTSVTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotationSourceTSVTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import scala.actors.threadpool.Arrays;
+import java.util.Arrays;
 
 public class AnnotationSourceTSVTest {
 	

--- a/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotationSourceTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/nanno/AnnotationSourceTest.java
@@ -1,9 +1,5 @@
 package au.edu.qimr.qannotate.nanno;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,10 +7,11 @@ import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.model.ChrPosition;
 import org.qcmg.common.util.ChrPositionUtils;
 
-import au.edu.qimr.qannotate.nanno.AnnotationSource;
-import au.edu.qimr.qannotate.nanno.AnnotationSourceTSV;
-import au.edu.qimr.qannotate.nanno.AnnotationSourceVCF;
-import scala.actors.threadpool.Arrays;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 public class AnnotationSourceTest {
 	
@@ -77,12 +74,12 @@ public class AnnotationSourceTest {
 	@Test
 	public void getCPFromStringArray() {
 		try {
-			assertEquals(null, AnnotationSource.getCpFromRecord(null, 0, 0));
-			Assert.fail("SHould have thron IAE");
+            assertNull(AnnotationSource.getCpFromRecord(null, 0, 0));
+			Assert.fail("Should have thrown IAE");
 		} catch (IllegalArgumentException iae) {}
 		try {
-			assertEquals(null, AnnotationSource.getCpFromRecord(new String[]{}, 0, 0));
-			Assert.fail("SHould have thron IAE");
+            assertNull(AnnotationSource.getCpFromRecord(new String[]{}, 0, 0));
+			Assert.fail("Should have thrown IAE");
 		} catch (IllegalArgumentException iae) {}
 		ChrPosition cp = ChrPositionUtils.getChrPosition("1", 1, 1);
 		assertEquals(cp, AnnotationSource.getCpFromRecord(new String[]{"1"}, 0, 0));
@@ -91,23 +88,23 @@ public class AnnotationSourceTest {
 		assertEquals(ChrPositionUtils.getChrPosition("2", 1, 1), AnnotationSource.getCpFromRecord(new String[]{"1", "2"}, 1, 0));
 		try {
 			assertEquals(ChrPositionUtils.getChrPosition("2", 1, 1), AnnotationSource.getCpFromRecord(new String[]{"1", "2"}, 10, 0));
-			Assert.fail("SHould have thron IAE");
+			Assert.fail("Should have thrown IAE");
 		} catch (IllegalArgumentException iae) {}
 	}
 	
 	@Test
 	public void vcfFields() {
 		String info = "";
-		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList(new String[]{"",""}), "EMPTY"));
-		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(".", Arrays.asList(new String[]{"",""}), "EMPTY"));
-		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(".", Arrays.asList(new String[]{""}), "EMPTY"));
+		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList("",""), "EMPTY"));
+		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(".", Arrays.asList("",""), "EMPTY"));
+		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(".", List.of(""), "EMPTY"));
 		info = "ALLELEID=75079;CLNDISDB=MONDO:MONDO:0010075,MedGen:C4017377,OMIM:271640|MONDO:MONDO:0014139,MedGen:C3809210,OMIM:615349,Orphanet:ORPHA536467|MONDO:MONDO:0019675,MedGen:C0432243,OMIM:PS271640,Orphanet:ORPHA93359,SNOMED_CT:254100000|MedGen:CN517202;CLNDN=Spondyloepimetaphyseal_dysplasia_with_joint_laxity,_type_1,_with_or_without_fractures|Ehlers-Danlos_syndrome,_spondylodysplastic_type,_2|Spondyloepimetaphyseal_dysplasia_with_joint_laxity|not_provided;CLNHGVS=NC_000001.11:g.1232279A>G;CLNREVSTAT=criteria_provided,_multiple_submitters,_no_conflicts;CLNSIG=Pathogenic;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;CLNVI=OMIM_Allelic_Variant:615291.0001;GENEINFO=B3GALT6:126792;MC=SO:0001582|initiatior_codon_variant,SO:0001583|missense_variant;ORIGIN=1;RS=786200938";
-		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList(new String[]{""}), "EMPTY"));
-		assertEquals("ALLELEID=75079", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList(new String[]{"ALLELEID"}), "EMPTY"));
-		assertEquals("ALLELEID=75079\tCLNDISDB=MONDO:MONDO:0010075,MedGen:C4017377,OMIM:271640|MONDO:MONDO:0014139,MedGen:C3809210,OMIM:615349,Orphanet:ORPHA536467|MONDO:MONDO:0019675,MedGen:C0432243,OMIM:PS271640,Orphanet:ORPHA93359,SNOMED_CT:254100000|MedGen:CN517202", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList(new String[]{"ALLELEID","CLNDISDB"}), "EMPTY"));
-		assertEquals("CLNDN=Spondyloepimetaphyseal_dysplasia_with_joint_laxity,_type_1,_with_or_without_fractures|Ehlers-Danlos_syndrome,_spondylodysplastic_type,_2|Spondyloepimetaphyseal_dysplasia_with_joint_laxity|not_provided\tMC=SO:0001582|initiatior_codon_variant,SO:0001583|missense_variant", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList(new String[]{"CLNDN","MC"}), "EMPTY"));
+		assertEquals("EMPTY", AnnotationSourceVCF.extractFieldsFromInfoField(info, List.of(""), "EMPTY"));
+		assertEquals("ALLELEID=75079", AnnotationSourceVCF.extractFieldsFromInfoField(info, List.of("ALLELEID"), "EMPTY"));
+		assertEquals("ALLELEID=75079\tCLNDISDB=MONDO:MONDO:0010075,MedGen:C4017377,OMIM:271640|MONDO:MONDO:0014139,MedGen:C3809210,OMIM:615349,Orphanet:ORPHA536467|MONDO:MONDO:0019675,MedGen:C0432243,OMIM:PS271640,Orphanet:ORPHA93359,SNOMED_CT:254100000|MedGen:CN517202", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList("ALLELEID","CLNDISDB"), "EMPTY"));
+		assertEquals("CLNDN=Spondyloepimetaphyseal_dysplasia_with_joint_laxity,_type_1,_with_or_without_fractures|Ehlers-Danlos_syndrome,_spondylodysplastic_type,_2|Spondyloepimetaphyseal_dysplasia_with_joint_laxity|not_provided\tMC=SO:0001582|initiatior_codon_variant,SO:0001583|missense_variant", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList("CLNDN","MC"), "EMPTY"));
 		info = "ALLELEID=1211496;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000001.11:g.19251559C>G;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=EMC1:23065;ORIGIN=1";
-		assertEquals("MC=\tCLNDN=not_provided", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList(new String[]{"MC","CLNDN"}), "EMPTY"));
+		assertEquals("MC=\tCLNDN=not_provided", AnnotationSourceVCF.extractFieldsFromInfoField(info, Arrays.asList("MC","CLNDN"), "EMPTY"));
 	}
 	
 	@Test
@@ -115,15 +112,15 @@ public class AnnotationSourceTest {
 		String header = "#chr	pos(1-based)	ref	alt	aaref	aaalt	rs_dbSNP151	hg19_chr	hg19_pos(1-based)	hg18_chr	hg18_pos(1-based)	aapos	genename	Ensembl_geneid	Ensembl_transcriptid	Ensembl_proteinid	Uniprot_acc	Uniprot_entry	HGVSc_ANNOVAR	HGVSp_ANNOVAR	HGVSc_snpEff	HGVSp_snpEff	HGVSc_VEP	HGVSp_VEP	APPRIS	GENCODE_basic	TSL	VEP_canonical	cds_strand	refcodon	codonpos	codon_degeneracy	Ancestral_allele	AltaiNeandertal	Denisova	VindijiaNeandertal	SIFT_score	SIFT_converted_rankscore	SIFT_pred	SIFT4G_score	SIFT4G_converted_rankscore	SIFT4G_pred	Polyphen2_HDIV_score	Polyphen2_HDIV_rankscore	Polyphen2_HDIV_pred	Polyphen2_HVAR_score	Polyphen2_HVAR_rankscore	Polyphen2_HVAR_pred	LRT_score	LRT_converted_rankscore	LRT_pred	LRT_Omega	MutationTaster_score	MutationTaster_converted_rankscore	MutationTaster_pred	MutationTaster_model	MutationTaster_AAE	MutationAssessor_score	MutationAssessor_rankscore	MutationAssessor_pred	FATHMM_score	FATHMM_converted_rankscore	FATHMM_pred	PROVEAN_score	PROVEAN_converted_rankscore	PROVEAN_pred	VEST4_score	VEST4_rankscore	MetaSVM_score	MetaSVM_rankscore	MetaSVM_pred	MetaLR_score	MetaLR_rankscore	MetaLR_pred	Reliability_index	M-CAP_score	M-CAP_rankscore	M-CAP_pred	REVEL_score	REVEL_rankscore	MutPred_score	MutPred_rankscore	MutPred_protID	MutPred_AAchange	MutPred_Top5features	MVP_score	MVP_rankscore	MPC_score	MPC_rankscore	PrimateAI_score	PrimateAI_rankscore	PrimateAI_pred	DEOGEN2_score	DEOGEN2_rankscore	DEOGEN2_pred	BayesDel_addAF_score	BayesDel_addAF_rankscore	BayesDel_addAF_pred	BayesDel_noAF_score	BayesDel_noAF_rankscore	BayesDel_noAF_pred	ClinPred_score	ClinPred_rankscore	ClinPred_pred	LIST-S2_score	LIST-S2_rankscore	LIST-S2_pred	Aloft_Fraction_transcripts_affected	Aloft_prob_Tolerant	Aloft_prob_Recessive	Aloft_prob_Dominant	Aloft_pred	Aloft_Confidence	CADD_raw	CADD_raw_rankscore	CADD_phred	CADD_raw_hg19	CADD_raw_rankscore_hg19	CADD_phred_hg19	DANN_score	DANN_rankscore	fathmm-MKL_coding_score	fathmm-MKL_coding_rankscore	fathmm-MKL_coding_pred	fathmm-MKL_coding_group	fathmm-XF_coding_score	fathmm-XF_coding_rankscore	fathmm-XF_coding_pred	Eigen-raw_coding	Eigen-raw_coding_rankscore	Eigen-phred_coding	Eigen-PC-raw_coding	Eigen-PC-raw_coding_rankscore	Eigen-PC-phred_coding	GenoCanyon_score	GenoCanyon_rankscore	integrated_fitCons_score	integrated_fitCons_rankscore	integrated_confidence_value	GM12878_fitCons_score	GM12878_fitCons_rankscore	GM12878_confidence_value	H1-hESC_fitCons_score	H1-hESC_fitCons_rankscore	H1-hESC_confidence_value	HUVEC_fitCons_score	HUVEC_fitCons_rankscore	HUVEC_confidence_value	LINSIGHT	LINSIGHT_rankscore	GERP++_NR	GERP++_RS	GERP++_RS_rankscore	phyloP100way_vertebrate	phyloP100way_vertebrate_rankscore	phyloP30way_mammalian	phyloP30way_mammalian_rankscore	phyloP17way_primate	phyloP17way_primate_rankscore	phastCons100way_vertebrate	phastCons100way_vertebrate_rankscore	phastCons30way_mammalian	phastCons30way_mammalian_rankscore	phastCons17way_primatephastCons17way_primate_rankscore	SiPhy_29way_pi	SiPhy_29way_logOdds	SiPhy_29way_logOdds_rankscore	bStatistic	bStatistic_converted_rankscore	1000Gp3_AC	1000Gp3_AF	1000Gp3_AFR_AC	1000Gp3_AFR_AF	1000Gp3_EUR_AC	1000Gp3_EUR_AF	1000Gp3_AMR_AC	1000Gp3_AMR_AF	1000Gp3_EAS_AC	1000Gp3_EAS_AF	1000Gp3_SAS_AC	1000Gp3_SAS_AF	TWINSUK_AC	TWINSUK_AF	ALSPAC_AC	ALSPAC_AF	UK10K_AC	UK10K_AF	ESP6500_AA_AC	ESP6500_AA_AF	ESP6500_EA_AC	ESP6500_EA_AF	ExAC_AC	ExAC_AF	ExAC_Adj_AC	ExAC_Adj_AF	ExAC_AFR_AC	ExAC_AFR_AF	ExAC_AMR_AC	ExAC_AMR_AF	ExAC_EAS_AC	ExAC_EAS_AF	ExAC_FIN_AC	ExAC_FIN_AF	ExAC_NFE_AC	ExAC_NFE_AF	ExAC_SAS_AC	ExAC_SAS_AF	ExAC_nonTCGA_AC	ExAC_nonTCGA_AF	ExAC_nonTCGA_Adj_AC	ExAC_nonTCGA_Adj_AF	ExAC_nonTCGA_AFR_AC	ExAC_nonTCGA_AFR_AF	ExAC_nonTCGA_AMR_AC	ExAC_nonTCGA_AMR_AF	ExAC_nonTCGA_EAS_AC	ExAC_nonTCGA_EAS_AF	ExAC_nonTCGA_FIN_AC	ExAC_nonTCGA_FIN_AF	ExAC_nonTCGA_NFE_AC	ExAC_nonTCGA_NFE_AF	ExAC_nonTCGA_SAS_AC	ExAC_nonTCGA_SAS_AF	ExAC_nonpsych_AC	ExAC_nonpsych_AF	ExAC_nonpsych_Adj_AC	ExAC_nonpsych_Adj_AF	ExAC_nonpsych_AFR_AC	ExAC_nonpsych_AFR_AF	ExAC_nonpsych_AMR_AC	ExAC_nonpsych_AMR_AF	ExAC_nonpsych_EAS_AC	ExAC_nonpsych_EAS_AF	ExAC_nonpsych_FIN_AC	ExAC_nonpsych_FIN_AF	ExAC_nonpsych_NFE_AC	ExAC_nonpsych_NFE_AF	ExAC_nonpsych_SAS_AC	ExAC_nonpsych_SAS_AF	gnomAD_exomes_flag	gnomAD_exomes_AC	gnomAD_exomes_AN	gnomAD_exomes_AF	gnomAD_exomes_nhomalt	gnomAD_exomes_AFR_AC	gnomAD_exomes_AFR_AN	gnomAD_exomes_AFR_AF	gnomAD_exomes_AFR_nhomalt	gnomAD_exomes_AMR_AC	gnomAD_exomes_AMR_AN	gnomAD_exomes_AMR_AF	gnomAD_exomes_AMR_nhomalt	gnomAD_exomes_ASJ_AC	gnomAD_exomes_ASJ_AN	gnomAD_exomes_ASJ_AF	gnomAD_exomes_ASJ_nhomalt	gnomAD_exomes_EAS_AC	gnomAD_exomes_EAS_AN	gnomAD_exomes_EAS_AF	gnomAD_exomes_EAS_nhomalt	gnomAD_exomes_FIN_AC	gnomAD_exomes_FIN_AN	gnomAD_exomes_FIN_AF	gnomAD_exomes_FIN_nhomalt	gnomAD_exomes_NFE_AC	gnomAD_exomes_NFE_AN	gnomAD_exomes_NFE_AF	gnomAD_exomes_NFE_nhomalt	gnomAD_exomes_SAS_AC	gnomAD_exomes_SAS_AN	gnomAD_exomes_SAS_AF	gnomAD_exomes_SAS_nhomalt	gnomAD_exomes_POPMAX_AC	gnomAD_exomes_POPMAX_AN	gnomAD_exomes_POPMAX_AF	gnomAD_exomes_POPMAX_nhomalt	gnomAD_exomes_controls_AC	gnomAD_exomes_controls_AN	gnomAD_exomes_controls_AF	gnomAD_exomes_controls_nhomalt	gnomAD_exomes_controls_AFR_AC	gnomAD_exomes_controls_AFR_AN	gnomAD_exomes_controls_AFR_AF	gnomAD_exomes_controls_AFR_nhomalt	gnomAD_exomes_controls_AMR_AC	gnomAD_exomes_controls_AMR_AN	gnomAD_exomes_controls_AMR_AF	gnomAD_exomes_controls_AMR_nhomalt	gnomAD_exomes_controls_ASJ_AC	gnomAD_exomes_controls_ASJ_AN	gnomAD_exomes_controls_ASJ_AF	gnomAD_exomes_controls_ASJ_nhomalt	gnomAD_exomes_controls_EAS_AC	gnomAD_exomes_controls_EAS_AN	gnomAD_exomes_controls_EAS_AF	gnomAD_exomes_controls_EAS_nhomalt	gnomAD_exomes_controls_FIN_AC	gnomAD_exomes_controls_FIN_AN	gnomAD_exomes_controls_FIN_AF	gnomAD_exomes_controls_FIN_nhomalt	gnomAD_exomes_controls_NFE_AC	gnomAD_exomes_controls_NFE_AN	gnomAD_exomes_controls_NFE_AF	gnomAD_exomes_controls_NFE_nhomalt	gnomAD_exomes_controls_SAS_AC	gnomAD_exomes_controls_SAS_AN	gnomAD_exomes_controls_SAS_AF	gnomAD_exomes_controls_SAS_nhomalt	gnomAD_exomes_controls_POPMAX_AC	gnomAD_exomes_controls_POPMAX_AN	gnomAD_exomes_controls_POPMAX_AF	gnomAD_exomes_controls_POPMAX_nhomalt	gnomAD_genomes_flag	gnomAD_genomes_AC	gnomAD_genomes_AN	gnomAD_genomes_AF	gnomAD_genomes_nhomalt	gnomAD_genomes_AFR_AC	gnomAD_genomes_AFR_AN	gnomAD_genomes_AFR_AF	gnomAD_genomes_AFR_nhomalt	gnomAD_genomes_AMR_AC	gnomAD_genomes_AMR_AN	gnomAD_genomes_AMR_AF	gnomAD_genomes_AMR_nhomalt	gnomAD_genomes_ASJ_AC	gnomAD_genomes_ASJ_AN	gnomAD_genomes_ASJ_AF	gnomAD_genomes_ASJ_nhomalt	gnomAD_genomes_EAS_AC	gnomAD_genomes_EAS_AN	gnomAD_genomes_EAS_AF	gnomAD_genomes_EAS_nhomalt	gnomAD_genomes_FIN_AC	gnomAD_genomes_FIN_AN	gnomAD_genomes_FIN_AF	gnomAD_genomes_FIN_nhomalt	gnomAD_genomes_NFE_AC	gnomAD_genomes_NFE_AN	gnomAD_genomes_NFE_AF	gnomAD_genomes_NFE_nhomalt	gnomAD_genomes_AMI_AC	gnomAD_genomes_AMI_AN	gnomAD_genomes_AMI_AF	gnomAD_genomes_AMI_nhomalt	gnomAD_genomes_SAS_AC	gnomAD_genomes_SAS_AN	gnomAD_genomes_SAS_AF	gnomAD_genomes_SAS_nhomalt	gnomAD_genomes_POPMAX_AC	gnomAD_genomes_POPMAX_AN	gnomAD_genomes_POPMAX_AF	gnomAD_genomes_POPMAX_nhomalt	clinvar_id	clinvar_clnsig	clinvar_trait	clinvar_review	clinvar_hgvs	clinvar_var_source	clinvar_MedGen_id	clinvar_OMIM_id	clinvar_Orphanet_id	Interpro_domain	GTEx_V8_gene	GTEx_V8_tissueGeuvadis_eQTL_target_gene";
 		Map<String, Integer> headerMap = AnnotationSourceTSV.getHeaderNameAndPositions("chr", header);
 		assertEquals(1, headerMap.size());
-		assertEquals(true, headerMap.containsKey("chr"));
-		assertEquals(true, headerMap.containsValue(0));
+        assertTrue(headerMap.containsKey("chr"));
+        assertTrue(headerMap.containsValue(0));
 		
 		headerMap = AnnotationSourceTSV.getHeaderNameAndPositions("chr,genename", header);
 		assertEquals(2, headerMap.size());
-		assertEquals(true, headerMap.containsKey("chr"));
-		assertEquals(true, headerMap.containsValue(0));
-		assertEquals(true, headerMap.containsKey("genename"));
-		assertEquals(new Integer(12), headerMap.get("genename"));
+        assertTrue(headerMap.containsKey("chr"));
+        assertTrue(headerMap.containsValue(0));
+        assertTrue(headerMap.containsKey("genename"));
+		assertEquals(Integer.valueOf(12), headerMap.get("genename"));
 	}
 	 
 	 

--- a/qbamannotate/build.gradle
+++ b/qbamannotate/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(':qio')
     implementation project(':qpicard')
 	
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 
     // https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'

--- a/qbamfilter/build.gradle
+++ b/qbamfilter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qpicard')
 
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'org.antlr:antlr:3.2'
 }
 

--- a/qbammerge/build.gradle
+++ b/qbammerge/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     implementation project(':qcommon')
     implementation project(':qpicard')    
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 	
     testImplementation project(':qtesting')
     testImplementation project(':qsplit')

--- a/qbasepileup/build.gradle
+++ b/qbasepileup/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(':qbamfilter')
     implementation project(':qpileup')
     implementation project(':qpicard')
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     testImplementation  'org.easymock:easymock:5.2.0'
 }
 

--- a/qcnv/build.gradle
+++ b/qcnv/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(':qpicard')
     implementation project(':qbamfilter')
 
-    implementation 'commons-cli:commons-cli:1.2'	
-    implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
+    implementation 'commons-cli:commons-cli:1.2'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }
 

--- a/qcommon/src/org/qcmg/common/commandline/Executor.java
+++ b/qcommon/src/org/qcmg/common/commandline/Executor.java
@@ -8,7 +8,10 @@
 package org.qcmg.common.commandline;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class Executor {
 	
@@ -16,8 +19,8 @@ public class Executor {
 	private final StreamConsumer errorStreamConsumer;
 	private final int errCode;	
 	
-	public Executor(String arguments, String qualifiedMainClassName) throws IOException, InterruptedException {			
-		this("java -classpath \"" + System.getProperty("java.class.path") + "\" " + qualifiedMainClassName + " " + arguments);
+	public Executor(String arguments, String qualifiedMainClassName) throws IOException, InterruptedException {
+		this("java", "-classpath", "\"" + System.getProperty("java.class.path") + "\"", qualifiedMainClassName, arguments);
 	}
 	
 	public Executor(String [] arguments, String qualifiedMainClassName) throws IOException, InterruptedException {				
@@ -28,8 +31,21 @@ public class Executor {
 		this("java -classpath " + System.getProperty("java.class.path") + " " + jvmArgs + " " + qualifiedMainClassName + " " + arguments);
 	}
 
+	// constructor for running a command line
+	public Executor(String cmd1, String cmd2, String cmd3, String cmd4, String cmd5WithSpaces) throws IOException, InterruptedException {
+		List<String> commands = new ArrayList<>(Arrays.asList(cmd1, cmd2, cmd3, cmd4));
+		Collections.addAll(commands, cmd5WithSpaces.split(" "));
+
+		ProcessBuilder processBuilder = new ProcessBuilder(commands);
+		Process process = processBuilder.start();
+		outputStreamConsumer = new StreamConsumer(process.getInputStream());
+		errorStreamConsumer = new StreamConsumer(process.getErrorStream());
+		outputStreamConsumer.run();
+		errorStreamConsumer.run();
+		errCode = process.waitFor();
+	}
+
 	public Executor(String execCommand) throws IOException, InterruptedException {
-//		Process process = new ProcessBuilder(execCommand).start();
 		Process process = Runtime.getRuntime().exec(execCommand);
 		outputStreamConsumer = new StreamConsumer(process.getInputStream());
 		errorStreamConsumer = new StreamConsumer(process.getErrorStream());
@@ -38,8 +54,7 @@ public class Executor {
 		errCode = process.waitFor();
 	}
 
-
-	public StreamConsumer getOutputStreamConsumer() {		
+	public StreamConsumer getOutputStreamConsumer() {
 		return outputStreamConsumer;
 	}
 

--- a/qcommon/src/org/qcmg/common/commandline/Executor.java
+++ b/qcommon/src/org/qcmg/common/commandline/Executor.java
@@ -34,8 +34,9 @@ public class Executor {
 	// constructor for running a command line
 	public Executor(String cmd1, String cmd2, String cmd3, String cmd4, String cmd5WithSpaces) throws IOException, InterruptedException {
 		List<String> commands = new ArrayList<>(Arrays.asList(cmd1, cmd2, cmd3, cmd4));
-		Collections.addAll(commands, cmd5WithSpaces.split(" "));
-
+		if (null != cmd5WithSpaces) {
+			Collections.addAll(commands, cmd5WithSpaces.split(" "));
+		}
 		ProcessBuilder processBuilder = new ProcessBuilder(commands);
 		Process process = processBuilder.start();
 		outputStreamConsumer = new StreamConsumer(process.getInputStream());

--- a/qcommon/src/org/qcmg/common/model/ChrPosition.java
+++ b/qcommon/src/org/qcmg/common/model/ChrPosition.java
@@ -1,35 +1,40 @@
 /**
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
-*/
+ */
 package org.qcmg.common.model;
 
 public interface ChrPosition {
-	
-	String getChromosome();
-	int getStartPosition();
-	
-	/*
-	 * Default methods - don't need to override these unless required
-	 */
-	default int getEndPosition() {
-		return getStartPosition();
-	}
-	default int getLength() {
-		return (getEndPosition() - getStartPosition()) + 1;
-	}
-	default String getName() {
-		return null;
-	}
-	default boolean isPointPosition() {
-		return getStartPosition() == getEndPosition();
-	}
-	default boolean isRangePosition(){
-		return getEndPosition() > getStartPosition();
-	}
-	default String toIGVString() {
-		return getChromosome() + ":" + getStartPosition() + "-" + getEndPosition();
-	}
 
+    String getChromosome();
+
+    int getStartPosition();
+
+    /*
+     * Default methods - don't need to override these unless required
+     */
+    default int getEndPosition() {
+        return getStartPosition();
+    }
+
+    default int getLength() {
+        return (getEndPosition() - getStartPosition()) + 1;
+    }
+
+    default String getName() {
+        return null;
+    }
+
+    default boolean isPointPosition() {
+        return getStartPosition() == getEndPosition();
+    }
+
+    default boolean isRangePosition() {
+        return getEndPosition() > getStartPosition();
+    }
+
+    default String toIGVString() {
+        return getChromosome() + ":" + getStartPosition() + "-" + getEndPosition();
+    }
 }

--- a/qcommon/src/org/qcmg/common/model/ChrPositionRefAlt.java
+++ b/qcommon/src/org/qcmg/common/model/ChrPositionRefAlt.java
@@ -30,7 +30,7 @@ public class ChrPositionRefAlt implements ChrPosition, Comparable<ChrPositionRef
 	public String getAlt() {
 		return alt;
 	}
-	public String getName() {
+	public String getRef() {
 		return cpRef.getName();
 	}
 	

--- a/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
+++ b/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
@@ -1,257 +1,325 @@
 /**
  * © Copyright The University of Queensland 2010-2014.
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
  */
 package org.qcmg.common.util;
 
-import java.util.ArrayList;
+import org.qcmg.common.model.*;
+import org.qcmg.common.string.StringUtils;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.qcmg.common.model.ChrPointPosition;
-import org.qcmg.common.model.ChrPosition;
-import org.qcmg.common.model.ChrPositionName;
-import org.qcmg.common.model.ChrRangePosition;
-import org.qcmg.common.string.StringUtils;
+import static org.qcmg.common.util.Constants.TAB;
 
 public class ChrPositionUtils {
-	
-	public static boolean doChrPositionsOverlap(ChrPosition a, ChrPosition b) {
-		return doChrPositionsOverlap(a,b,0);
-	}
-	
-	public static boolean doChrPositionsOverlap(ChrPosition a, ChrPosition b, int buffer) {
-		
-		// check chromosome first
-		if ( ! a.getChromosome().equals(b.getChromosome())) return false;
-		
-		// now positions
-		if (a.getEndPosition() < b.getStartPosition() - buffer) return false;
-		
-		return  ! (a.getStartPosition() > b.getEndPosition() + buffer);
-	}
-	
-	/**
-	 * All of ChrPosition b must be within ChrPosition a
-	 * @param a
-	 * @param b
-	 * @return
-	 */
-	public static boolean isChrPositionContained(ChrPosition a, ChrPosition b) {
-		
-		if (doChrPositionsOverlap(a, b)) {
-			return a.getStartPosition() <= b.getStartPosition() && a.getEndPosition() >= b.getEndPosition();
-		}
-		return false;
-		
-	}
-	
-	public static Map<ChrRangePosition, Set<ChrRangePosition>> getAmpliconsFromFragments(List<ChrRangePosition> fragments) {
-		
-		Map<ChrRangePosition, Set<ChrRangePosition>> ampliconFragmentMap = fragments.stream()
-			.collect(Collectors.groupingBy(cp -> {
-				return new ChrRangePosition(cp.getChromosome(), cp.getStartPosition(), cp.getEndPosition());
-			}, Collectors.toSet()));
-//		Map<ChrPosition, Set<ChrPosition>> ampliconFragmentMap = fragments.stream()
-//				.collect(Collectors.groupingBy(cp -> {
-//					return new ChrPosition(cp.getChromosome(), cp.getPosition());
-//				}, Collectors.toSet()));
-		
-		
-		return ampliconFragmentMap;
-		
-	}
-	
-	/**
-	 * Returns a ChrPosition object - will be ChrPointPosition if start == end, and ChrRangePosition otherwise
-	 */
-	public static ChrPosition getChrPosition(String chr, int start, int end) {
-		if (start == end) {
-			return ChrPointPosition.valueOf(chr, start);
-		} else {
-			return new ChrRangePosition(chr, start, end);
-		}
-	}
-	
-	/**
-	 * converts coords in the format 9:5073770-5073770 to a ChrPosition object complete with "chr"
-	 * @param cosmicCoords
-	 * @return
-	 */
-	public static ChrPosition createCPFromCosmic(String cosmicCoords) {
-		if (StringUtils.isNullOrEmpty(cosmicCoords)) {
-			return null;
-		} else {
-			int colonIndex = cosmicCoords.indexOf(':');
-			int minusIndex = cosmicCoords.indexOf('-');
-			int start = Integer.parseInt(cosmicCoords.substring(colonIndex + 1, minusIndex));
-			int end = Integer.parseInt(cosmicCoords.substring(minusIndex + 1));
-			return getChrPosition("chr" + cosmicCoords.substring(0, colonIndex), start, end); 
-		}
-	}
-	
-	public static boolean arePositionsWithinDelta(ChrPosition a, ChrPosition b, int delta) {
-		// check chromosome first
-		if ( ! a.getChromosome().equals(b.getChromosome())) return false;
-		
-		int diff = Math.abs(a.getStartPosition() - b.getStartPosition());
-		if (diff > delta) {
-			return false;
-		}
-		
-		diff += Math.abs(a.getEndPosition() - b.getEndPosition());
-		return diff <= delta;
-	}
-	
-	public static boolean doChrPositionsOverlapPositionOnly(ChrPosition a, ChrPosition b) {
-		// positions
-		if (a.getStartPosition() > b.getEndPosition()) return false;
-		
-		return ! (a.getEndPosition() < b.getStartPosition());
-	}
-	
 
-	public static ChrPosition cloneWithNewChromosomeName(ChrPosition cp, String newChr) {
-		if (cp instanceof ChrPointPosition) {
-			return ChrPointPosition.valueOf(newChr, cp.getStartPosition());
-		} else if  (cp instanceof ChrRangePosition) {
-			return new ChrRangePosition(newChr, cp.getStartPosition(), cp.getEndPosition());
-		} else {
-			throw new UnsupportedOperationException("cloneWithNewName not yet implemented for any types other than ChrPointPosition and ChrRangePosition!!!");
-		}
-	}
-	
-	/**
-	 * ASsumes that String is in the IGV notation.
-	 * eg. chr1:123456-2345678
-	 * 
-	 * @param position
-	 * @return
-	 */
-	public static ChrRangePosition getChrPositionFromString(String position) {
-		if (StringUtils.isNullOrEmpty(position)) 
-			throw new IllegalArgumentException("Null or empty string passed to getChrPositionFromString()");
-		
-		int colonPos = position.indexOf(':');
-		int minusPos = position.indexOf('-');
-		
-		if (colonPos == -1 || minusPos == -1) {
-			throw new IllegalArgumentException("invalid string passed to getChrPositionFromString() - must be in chr1:12345-23456 format: " + position);
-		}
-		
-		String chr = position.substring(0, colonPos);
-		int start = Integer.parseInt(position.substring(colonPos + 1, minusPos));
-		int end = Integer.parseInt(position.substring(minusPos + 1));
-		
-		return new ChrRangePosition(chr, start, end);
-	}
-	public static ChrPositionName getChrPositionNameFromString(String position, String name) {
-		if (StringUtils.isNullOrEmpty(position)) 
-			throw new IllegalArgumentException("Null or empty string passed to getChrPositionNameFromString()");
-		
-		int colonPos = position.indexOf(':');
-		int minusPos = position.indexOf('-');
-		
-		if (colonPos == -1 || minusPos == -1) {
-			throw new IllegalArgumentException("invalid string passed to getChrPositionNameFromString() - must be in chr1:12345-23456 format: " + position);
-		}
-		
-		String chr = position.substring(0, colonPos);
-		int start = Integer.parseInt(position.substring(colonPos + 1, minusPos));
-		int end = Integer.parseInt(position.substring(minusPos + 1));
-		
-		return new ChrPositionName(chr, start, end, name);
-	}
-	
-	public static ChrPointPosition getChrPointPositionFromString(String position) {
-		if (StringUtils.isNullOrEmpty(position)) 
-			throw new IllegalArgumentException("Null or empty string passed to getChrPositionFromString()");
-		
-		int colonPos = position.indexOf(':');
-		int minusPos = position.indexOf('-');
-		
-		if (colonPos == -1 || minusPos == -1) {
-			throw new IllegalArgumentException("invalid string passed to getChrPositionFromString() - must be in chr1:12345-23456 format: " + position);
-		}
-		
-		String chr = position.substring(0, colonPos);
-		int start = Integer.parseInt(position.substring(colonPos + 1, minusPos));
-		int end = Integer.parseInt(position.substring(minusPos + 1));
-		if (start != end) {
-			throw new IllegalArgumentException("Start and end position in getChrPointPositionFromString are not the same. Start: " + start + ", end: " + end + ", from string: " + position);
-		}
-		
-		return ChrPointPosition.valueOf(chr, start);
-	}
-	
-	public static ChrPosition getPrecedingChrPosition(ChrPosition cp) {
-		return new ChrRangePosition(cp.getChromosome(), cp.getStartPosition() - 1, cp.getEndPosition() - 1);
-	}
-	
-	/**
-	 * Returns a list of ChrPosition objects based on the contents of the supplied String array
-	 *  
-	 * @param positions
-	 * @return
-	 */
-	public static List<ChrPosition> getChrPositionsFromStrings(String[] positions) {
-		
-		if (null == positions || positions.length == 0) 
-			throw new IllegalArgumentException("null or empty string array passed to getChrPositionsFromStrings");
-		
-		List<ChrPosition> chrPositions = new ArrayList<>();
-		for (String s : positions) {
-			chrPositions.add(getChrPositionFromString(s));
-		}
-		return chrPositions;
-	}
-	
-	/**
-	 * Returns a map of ChrPointPosition objects based on the contents of the supplied String array
-	 *  
-	 * @param positions
-	 * @return
-	 */
-	public static Map<ChrPosition, ChrPosition>  getChrPointPositionsFromStrings(String[] positions) {
-		
-		if (null == positions || positions.length == 0) 
-			throw new IllegalArgumentException("null or empty string array passed to getChrPositionsFromStrings");
-		
-		Map<ChrPosition, ChrPosition> chrPositions = new HashMap<>();
-		for (String s : positions) {
-			ChrPosition cpp = getChrPointPositionFromString(s);
-			chrPositions.put(cpp, cpp);
-		}
-		return chrPositions;
-	}
-	
-	/**
-	 * Returns true if the two supplied chrpos objects are on the same chromosome and are adjacent
-	 * that is, the end position of 1 is next to the start position of the other
-	 * 
-	 * if they overlap, return false
-	 * 
-	 * @param cp1
-	 * @param cp2
-	 * @return
-	 */
-	public static boolean areAdjacent(ChrPosition cp1, ChrPosition cp2) {
-		// need to be on the same chromosome
-		if (cp1.getChromosome().equals(cp2.getChromosome())) {
-			
-			if (cp1.getStartPosition() == cp2.getEndPosition() + 1) {
-				return true;
-			}
-			if (cp1.getEndPosition() == cp2.getStartPosition() - 1) {
-				return true;
-			}
-		}
-		return false;
-	}
-	
+    /**
+     * Checks if two ChrPosition objects overlap.
+     *
+     * @param a the first ChrPosition
+     * @param b the second ChrPosition
+     * @return true if the ChrPositions overlap, false otherwise
+     */
+    public static boolean doChrPositionsOverlap(ChrPosition a, ChrPosition b) {
+        return doChrPositionsOverlap(a, b, 0);
+    }
+
+    /**
+     * Checks if two ChrPosition objects overlap with a buffer.
+     *
+     * @param a the first ChrPosition
+     * @param b the second ChrPosition
+     * @param buffer the buffer to consider for overlap
+     * @return true if the ChrPositions overlap considering the buffer, false otherwise
+     */
+    public static boolean doChrPositionsOverlap(ChrPosition a, ChrPosition b, int buffer) {
+
+        // check chromosome first
+        if (!a.getChromosome().equals(b.getChromosome())) return false;
+
+        // now positions
+        if (a.getEndPosition() < b.getStartPosition() - buffer) return false;
+
+        return !(a.getStartPosition() > b.getEndPosition() + buffer);
+    }
+
+    /**
+     * Checks if a ChrPosition is contained within another ChrPosition.
+     *
+     * @param a the first ChrPosition
+     * @param b the second ChrPosition
+     * @return true if b is contained within a, false otherwise
+     */
+    public static boolean isChrPositionContained(ChrPosition a, ChrPosition b) {
+
+        if (doChrPositionsOverlap(a, b)) {
+            return a.getStartPosition() <= b.getStartPosition() && a.getEndPosition() >= b.getEndPosition();
+        }
+        return false;
+
+    }
+
+    /**
+     * Returns a map of ChrRangePosition objects grouped by their start and end positions.
+     *
+     * @param fragments the list of ChrRangePosition objects
+     * @return a map of ChrRangePosition objects grouped by their start and end positions
+     */
+    public static Map<ChrRangePosition, Set<ChrRangePosition>> getAmpliconsFromFragments(List<ChrRangePosition> fragments) {
+
+        return fragments.stream()
+                .collect(Collectors.groupingBy(cp -> new ChrRangePosition(cp.getChromosome(), cp.getStartPosition(), cp.getEndPosition()), Collectors.toSet()));
+    }
+
+    /**
+     * Returns a ChrPosition object - will be ChrPointPosition if start == end, and ChrRangePosition otherwise
+     */
+    public static ChrPosition getChrPosition(String chr, int start, int end) {
+        if (start == end) {
+            return ChrPointPosition.valueOf(chr, start);
+        } else {
+            return new ChrRangePosition(chr, start, end);
+        }
+    }
+
+    /**
+     * Converts a string in the COSMIC format to a ChrPosition object.
+     * The COSMIC format is "9:5073770-5073770", where the chromosome number is followed by the start and end positions separated by a colon and a dash.
+     * The resulting ChrPosition object will have "chr" prepended to the chromosome number.
+     *
+     * @param cosmicCoords the string in COSMIC format
+     * @return the corresponding ChrPosition object
+     * @throws IllegalArgumentException if the string is null or empty
+     */
+    public static ChrPosition createCPFromCosmic(String cosmicCoords) {
+        if (StringUtils.isNullOrEmpty(cosmicCoords)) {
+            return null;
+        } else {
+            int colonIndex = cosmicCoords.indexOf(':');
+            int minusIndex = cosmicCoords.indexOf('-');
+            int start = Integer.parseInt(cosmicCoords.substring(colonIndex + 1, minusIndex));
+            int end = Integer.parseInt(cosmicCoords.substring(minusIndex + 1));
+            return getChrPosition("chr" + cosmicCoords.substring(0, colonIndex), start, end);
+        }
+    }
+
+    /**
+     * Checks if the start and end positions of two ChrPosition objects are within a specified delta.
+     * The method first checks if the two ChrPosition objects are on the same chromosome.
+     * Then, it calculates the absolute difference between the start positions and the end positions of the two ChrPosition objects.
+     * If the total difference is less than or equal to the specified delta, the method returns true.
+     *
+     * @param a the first ChrPosition
+     * @param b the second ChrPosition
+     * @param delta the maximum allowed difference between the start and end positions of the two ChrPosition objects
+     * @return true if the start and end positions of the two ChrPosition objects are within the specified delta, false otherwise
+     */
+    public static boolean arePositionsWithinDelta(ChrPosition a, ChrPosition b, int delta) {
+        // check chromosome first
+        if (!a.getChromosome().equals(b.getChromosome())) return false;
+
+        int diff = Math.abs(a.getStartPosition() - b.getStartPosition());
+        if (diff > delta) {
+            return false;
+        }
+
+        diff += Math.abs(a.getEndPosition() - b.getEndPosition());
+        return diff <= delta;
+    }
+
+    /**
+     * Checks if two ChrPosition objects overlap considering only their positions.
+     *
+     * @param a the first ChrPosition
+     * @param b the second ChrPosition
+     * @return true if the positions of the ChrPositions overlap, false otherwise
+     */
+    public static boolean doChrPositionsOverlapPositionOnly(ChrPosition a, ChrPosition b) {
+        // positions
+        if (a.getStartPosition() > b.getEndPosition()) return false;
+
+        return !(a.getEndPosition() < b.getStartPosition());
+    }
+
+
+    /**
+     * Returns a new ChrPosition object with a new chromosome name.
+     *
+     * @param cp the ChrPosition to clone
+     * @param newChr the new chromosome name
+     * @return a new ChrPosition object with the new chromosome name
+     */
+    public static ChrPosition cloneWithNewChromosomeName(ChrPosition cp, String newChr) {
+        if (cp instanceof ChrPointPosition) {
+            return ChrPointPosition.valueOf(newChr, cp.getStartPosition());
+        } else if (cp instanceof ChrRangePosition) {
+            return new ChrRangePosition(newChr, cp.getStartPosition(), cp.getEndPosition());
+        } else {
+            throw new UnsupportedOperationException("cloneWithNewName not yet implemented for any types other than ChrPointPosition and ChrRangePosition!!!");
+        }
+    }
+
+    /**
+     * Converts a string in the format "chr1:12345-12345" to a ChrRangePosition object.
+     * The string must represent a range on the chromosome (start position does not equal end position).
+     *
+     * @param position the string to convert
+     * @return the corresponding ChrRangePosition object
+     * @throws IllegalArgumentException if the string is null, empty, not in the correct format, or represents a single point rather than a range
+     */
+    public static ChrRangePosition getChrPositionFromString(String position) {
+        if (StringUtils.isNullOrEmpty(position))
+            throw new IllegalArgumentException("Null or empty string passed to getChrPositionFromString()");
+
+        int colonPos = position.indexOf(':');
+        int minusPos = position.indexOf('-');
+
+        if (colonPos == -1 || minusPos == -1) {
+            throw new IllegalArgumentException("invalid string passed to getChrPositionFromString() - must be in chr1:12345-23456 format: " + position);
+        }
+
+        String chr = position.substring(0, colonPos);
+        int start = Integer.parseInt(position.substring(colonPos + 1, minusPos));
+        int end = Integer.parseInt(position.substring(minusPos + 1));
+
+        return new ChrRangePosition(chr, start, end);
+    }
+
+    /**
+     * Converts a string in the format "chr1:12345-12345" and a name to a ChrPositionName object.
+     * The string must represent a single point on the chromosome (start position equals end position).
+     *
+     * @param position the string to convert
+     * @param name the name to assign to the ChrPositionName object
+     * @return the corresponding ChrPositionName object
+     * @throws IllegalArgumentException if the string is null, empty, not in the correct format, or represents a range rather than a single point
+     */
+    public static ChrPositionName getChrPositionNameFromString(String position, String name) {
+        if (StringUtils.isNullOrEmpty(position))
+            throw new IllegalArgumentException("Null or empty string passed to getChrPositionNameFromString()");
+
+        int colonPos = position.indexOf(':');
+        int minusPos = position.indexOf('-');
+
+        if (colonPos == -1 || minusPos == -1) {
+            throw new IllegalArgumentException("invalid string passed to getChrPositionNameFromString() - must be in chr1:12345-23456 format: " + position);
+        }
+
+        String chr = position.substring(0, colonPos);
+        int start = Integer.parseInt(position.substring(colonPos + 1, minusPos));
+        int end = Integer.parseInt(position.substring(minusPos + 1));
+
+        return new ChrPositionName(chr, start, end, name);
+    }
+
+    /**
+     * Converts a string in the format "chr1:12345-12345" to a ChrPointPosition object.
+     * The string must represent a single point on the chromosome (start position equals end position).
+     *
+     * @param position the string to convert
+     * @return the corresponding ChrPointPosition object
+     * @throws IllegalArgumentException if the string is null, empty, not in the correct format, or represents a range rather than a single point
+     */
+    public static ChrPointPosition getChrPointPositionFromString(String position) {
+        if (StringUtils.isNullOrEmpty(position))
+            throw new IllegalArgumentException("Null or empty string passed to getChrPositionFromString()");
+
+        int colonPos = position.indexOf(':');
+        int minusPos = position.indexOf('-');
+
+        if (colonPos == -1 || minusPos == -1) {
+            throw new IllegalArgumentException("invalid string passed to getChrPositionFromString() - must be in chr1:12345-23456 format: " + position);
+        }
+
+        String chr = position.substring(0, colonPos);
+        int start = Integer.parseInt(position.substring(colonPos + 1, minusPos));
+        int end = Integer.parseInt(position.substring(minusPos + 1));
+        if (start != end) {
+            throw new IllegalArgumentException("Start and end position in getChrPointPositionFromString are not the same. Start: " + start + ", end: " + end + ", from string: " + position);
+        }
+
+        return ChrPointPosition.valueOf(chr, start);
+    }
+
+    /**
+     * Returns a new ChrPosition object that precedes the given ChrPosition.
+     * The start and end positions of the new ChrPosition are each one less than the corresponding positions of the given ChrPosition.
+     *
+     * @param cp the ChrPosition to get the preceding position of
+     * @return a new ChrPosition that precedes the given ChrPosition
+     */
+    public static ChrPosition getPrecedingChrPosition(ChrPosition cp) {
+        return new ChrRangePosition(cp.getChromosome(), cp.getStartPosition() - 1, cp.getEndPosition() - 1);
+    }
+
+    /**
+     * Returns a map of ChrPointPosition objects based on the contents of the supplied String array
+     *
+     * @param positions
+     * @return
+     */
+    public static Map<ChrPosition, ChrPosition> getChrPointPositionsFromStrings(String[] positions) {
+
+        if (null == positions || positions.length == 0)
+            throw new IllegalArgumentException("null or empty string array passed to getChrPositionsFromStrings");
+
+        Map<ChrPosition, ChrPosition> chrPositions = new HashMap<>();
+        for (String s : positions) {
+            ChrPosition cpp = getChrPointPositionFromString(s);
+            chrPositions.put(cpp, cpp);
+        }
+        return chrPositions;
+    }
+
+    /**
+     * Converts a ChrPosition and additional data to a VCF string.
+     *
+     * @param cp the ChrPosition
+     * @param id the ID
+     * @param ref the reference
+     * @param alt the alternative
+     * @param qual the quality
+     * @param filter the filter
+     * @param info the info
+     * @return the VCF string
+     */
+    public static String toVcfString(ChrPosition cp, String id, String ref, String alt, String qual, String filter, String info) {
+        switch (cp) {
+            case ChrPositionRefAlt cpra -> {
+                return cpra.getChromosome() + TAB + cpra.getStartPosition() + TAB + id + TAB + cpra.getRef() + TAB + cpra.getAlt() + TAB + qual + TAB + filter + TAB + info;
+            }
+            case ChrPosition cpp -> {
+                return cpp.getChromosome() + TAB + cpp.getStartPosition() + TAB + id + TAB + ref + TAB + alt + TAB + qual + TAB + filter + TAB + info;
+            }
+        }
+    }
+
+    /**
+     * Returns true if the two supplied ChrPosition objects are on the same chromosome and are adjacent
+     * that is, the end position of 1 is next to the start position of the other
+     *
+     * if they overlap, return false
+     *
+     * @param cp1 the first ChrPosition
+     * @param cp2 the second ChrPosition
+     * @return true if the ChrPositions are adjacent, false otherwise
+     */
+    public static boolean areAdjacent(ChrPosition cp1, ChrPosition cp2) {
+        // need to be on the same chromosome
+        if (cp1.getChromosome().equals(cp2.getChromosome())) {
+
+            if (cp1.getStartPosition() == cp2.getEndPosition() + 1) {
+                return true;
+            }
+            return cp1.getEndPosition() == cp2.getStartPosition() - 1;
+        }
+        return false;
+    }
+
 }

--- a/qcommon/src/org/qcmg/common/util/Constants.java
+++ b/qcommon/src/org/qcmg/common/util/Constants.java
@@ -5,14 +5,16 @@
 */
 package org.qcmg.common.util;
 
+import java.nio.file.FileSystems;
+
 public class Constants {
 	public  static final char TAB = '\t';
 	public  static final String TAB_STRING = "\t";
 	public static final char SC = ';';
 	public static final char BAR = '|';
 	public static final char SLASH = '/';
-	public static final String NEW_LINE = System.getProperty("line.separator");
-	public static final String FILE_SEPARATOR = System.getProperty("file.separator");
+	public static final String NEW_LINE = System.lineSeparator();
+	public static final String FILE_SEPARATOR = FileSystems.getDefault().getSeparator();
 	
 	public static final char NL = '\n';
 	public static final char MISSING_DATA = '.';

--- a/qcommon/test/org/qcmg/common/model/ChrPositionRefAltTest.java
+++ b/qcommon/test/org/qcmg/common/model/ChrPositionRefAltTest.java
@@ -36,7 +36,7 @@ public class ChrPositionRefAltTest {
 	@Test
 	public void getRef() {
 		ChrPositionRefAlt cp1 = new ChrPositionRefAlt("1", 1,1, "ref","alt");
-		assertEquals("ref", cp1.getName());
+		assertEquals("ref", cp1.getRef());
 		assertEquals("alt", cp1.getAlt());
 	}
 	

--- a/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
@@ -1,6 +1,7 @@
 package org.qcmg.common.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.qcmg.common.util.Constants.MISSING_DATA_STRING;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,6 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcmg.common.model.ChrPointPosition;
 import org.qcmg.common.model.ChrPosition;
+import org.qcmg.common.model.ChrPositionRefAlt;
 import org.qcmg.common.model.ChrRangePosition;
 
 public class ChrPositionUtilsTest {
@@ -33,6 +35,24 @@ public class ChrPositionUtilsTest {
 		cp2 = new ChrRangePosition("1", 98, 202);
 		assertEquals(true, ChrPositionUtils.arePositionsWithinDelta(cp1, cp2, 4));
 	}
+
+	@Test
+	public void toVcfStringShouldReturnCorrectFormat() {
+		ChrPosition cp = new ChrRangePosition("chr1", 1000, 2000);
+		String id = "id";
+		String ref = "A";
+		String alt = "T";
+		String qual = "30";
+		String filter = "PASS";
+		String info = "DP=100";
+
+		String expected = "chr1\t1000\tid\tA\tT\t30\tPASS\tDP=100";
+		String actual = ChrPositionUtils.toVcfString(cp, id, ref, alt, qual, filter, info);
+		assertEquals(expected, actual);
+
+		ChrPosition cp1 = new ChrPositionRefAlt("chr1", 1000, 1001, "C", "G");
+		assertEquals("chr1\t1000\t.\tC\tG\t.\t.\t.", ChrPositionUtils.toVcfString(cp1, MISSING_DATA_STRING, null, null, MISSING_DATA_STRING, MISSING_DATA_STRING, MISSING_DATA_STRING));
+	}
 	
 	@Test
 	public void cloneWithNewName() {
@@ -41,7 +61,6 @@ public class ChrPositionUtilsTest {
 		assertEquals("chrXY", ChrPositionUtils.cloneWithNewChromosomeName(cp, "chrXY").getChromosome());
 		assertEquals("myCP", ChrPositionUtils.cloneWithNewChromosomeName(cp, "myCP").getChromosome());
 		assertEquals("1", ChrPositionUtils.cloneWithNewChromosomeName(cp, "1").getChromosome());
-		
 	}
 	
 	@Test

--- a/qcoverage/build.gradle
+++ b/qcoverage/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(':qio')
     implementation project(':qbamfilter')
     implementation project(':qpicard')
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     // https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
     // https://mvnrepository.com/artifact/org.eclipse.persistence/org.eclipse.persistence.moxy

--- a/qcoverage/test/org/qcmg/coverage/CoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/CoverageTest.java
@@ -1,7 +1,6 @@
 package org.qcmg.coverage;
 
 import htsjdk.samtools.SAMFileHeader.SortOrder;
-import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
@@ -13,7 +12,6 @@ import org.qcmg.common.commandline.Executor;
 import org.qcmg.qio.gff3.Gff3Record;
 import org.qcmg.qio.record.RecordWriter;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -64,7 +62,7 @@ public class CoverageTest {
 	public final void defaultTest() throws Exception {
 		
  	 	
-		String cmd = "--log " + log + " --type phys  --input-gff3 " + inputGff3 + " --input-bam " + inputBam + 
+		String cmd = "--log " + log + " --type phys --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
 				" --input-bai " + inputBai +  " --output " + fname ;
 
 		//default value txt output only
@@ -77,7 +75,7 @@ public class CoverageTest {
 	
 	@Test
 	public final void xmlTest() throws Exception {
-		String cmd = "--log " + log + " --type phys  --input-gff3 " + inputGff3 + " --input-bam " + inputBam + 
+		String cmd = "--log " + log + " --type phys --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
 				" --input-bai " + inputBai +  " --output " +fname  + " --output-format xml";
 
 		//xml output only
@@ -121,7 +119,7 @@ public class CoverageTest {
 	}
 
 	@Test
-	public void writeXmlOutput() throws IOException, ParserConfigurationException, jakarta.xml.bind.JAXBException {
+	public void writeXmlOutput() throws IOException, jakarta.xml.bind.JAXBException {
 		QCoverageStats qcs = new QCoverageStats();
 		CoverageReport cr = new CoverageReport();
 		for (int i = 0 ; i < 10 ; i++) {
@@ -139,7 +137,7 @@ public class CoverageTest {
 	
 	@Test
 	public final void vcfTest() throws Exception {
-		String cmd = "--log " + log + " --type phys  --input-gff3 " + inputGff3 + " --input-bam " + inputBam + 
+		String cmd = "--log " + log + " --type phys --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
 				" --input-bai " + inputBai +  " --output " +fname  + " --output-format vcf";
 
 		//run fail for vcf without per-feature
@@ -156,7 +154,7 @@ public class CoverageTest {
 	
 	@Test
 	public final void vcfFeatureTest() throws Exception {
-		String cmd = "--log " + log + " --type phys  --input-gff3 " + inputGff3 + " --input-bam " + inputBam + 
+		String cmd = "--log " + log + " --type phys --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
 				" --input-bai " + inputBai +  " --output " +fname  + " --per-feature --output-format vcf";
 	
 		//vcf output only
@@ -174,9 +172,9 @@ public class CoverageTest {
 	
 	@Test
 	public final void allTest() throws Exception {
-		String cmd = "--log " + log + " --type phys  --input-gff3 " + inputGff3 + " --input-bam " + inputBam + 
+		String cmd = "--log " + log + " --type phys --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
 				" --input-bai " + inputBai +  " --output " +fname  + 
-				" --output-format xml  --output-format txt";
+				" --output-format xml --output-format txt";
 
 		//two types output
 		Executor exec = execute(cmd);
@@ -190,9 +188,9 @@ public class CoverageTest {
 		assertFalse(fOutput.exists());
 		
 		//run fail for vcf without per-feature
-		cmd = "--log " + log + " --type phys  --input-gff3 " + inputGff3 + " --input-bam " + inputBam + 
+		cmd = "--log " + log + " --type phys --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
 				" --input-bai " + inputBai +  " --output " +fname  + 
-				" --output-format vcf  --output-format xml  --output-format txt";
+				" --output-format vcf --output-format xml --output-format txt";
 		exec = execute(cmd);
 		assertEquals(1, exec.getErrCode());
 		
@@ -202,9 +200,9 @@ public class CoverageTest {
 	@Test
 	public final void allFeatureTest() throws Exception {
 		String foutput = fname + ".xml";
-		String cmd = "--log " + log + " --type phys  --input-gff3 " + inputGff3 + " --input-bam " + inputBam + 
+		String cmd = "--log " + log + " --type phys --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
 				" --input-bai " + inputBai +  " --output " + foutput + 
-				" --per-feature --output-format vcf  --output-format xml  --output-format txt";
+				" --per-feature --output-format vcf --output-format xml --output-format txt";
 
 		//three types output
 		Executor exec = execute(cmd);

--- a/qcoverage/test/org/qcmg/coverage/MultiBamPhysicalCoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/MultiBamPhysicalCoverageTest.java
@@ -1,7 +1,10 @@
 package org.qcmg.coverage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import htsjdk.samtools.SAMFileHeader.SortOrder;
+import org.junit.*;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.qio.gff3.Gff3Record;
+import org.qcmg.qio.record.RecordWriter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -10,20 +13,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import htsjdk.samtools.SAMFileHeader.SortOrder;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.qcmg.common.commandline.Executor;
-import org.qcmg.qio.record.RecordWriter;
-import org.qcmg.qio.gff3.Gff3Record;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MultiBamPhysicalCoverageTest {
 	
@@ -35,9 +27,6 @@ public class MultiBamPhysicalCoverageTest {
 	private File fOutput;
 	private String fname;
 	static Gff3Record record;
-	
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 	
 	@BeforeClass
 	 public static void setup() throws IOException {
@@ -74,10 +63,10 @@ public class MultiBamPhysicalCoverageTest {
 		}
 		
 		private String getCmd(int start, int stop) {
-			return "--log " + tmpDir + "/logfile --type  phys --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --input-bam " + inputBam2 + " --input-bai " + inputBai2 + " --output " +fname;
+			return "--log " + tmpDir + "/logfile --type phys --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --input-bam " + inputBam2 + " --input-bai " + inputBai2 + " --output " +fname;
 		}
 
-		private File createGFF3File(final int start, final int end) throws IOException {
+		private void createGFF3File(final int start, final int end) throws IOException {
 			record.setStart(start);
 			record.setEnd(end);
 
@@ -85,7 +74,6 @@ public class MultiBamPhysicalCoverageTest {
 			try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
 				writer.add(record);
 			}
-			return file;
 		}
 
 	private Executor execute(final String command) throws IOException, InterruptedException {
@@ -97,15 +85,14 @@ public class MultiBamPhysicalCoverageTest {
 	public final void leftDisjointRead() throws IOException, InterruptedException {
 		createGFF3File(54000, 54025);
 		
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54025));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -116,15 +103,14 @@ public class MultiBamPhysicalCoverageTest {
 	public final void rightDisjointRead() throws IOException, InterruptedException {
 		createGFF3File(54077, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54077, 54120));
- 
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -135,15 +121,14 @@ public class MultiBamPhysicalCoverageTest {
 	public final void leftOnEndRead() throws IOException, InterruptedException {
 		createGFF3File(54000, 54026);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54026));
 
-		assertTrue(0 == exec.getErrCode());
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 	 	List<String> fileContents;
 	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
+	    		fileContents = r.lines().toList();
 	    	}
 	    	
 	    	assertEquals(3, fileContents.size());
@@ -155,15 +140,14 @@ public class MultiBamPhysicalCoverageTest {
   	public final void rightOnEndRead() throws Exception {
       	createGFF3File(54076, 54120);
 
-  		ExpectedException.none();
   		Executor exec = execute(getCmd(54076, 54120));
-  		
-  		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
   		assertTrue(fOutput.exists());
   		
   		List<String> fileContents;
   		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-  			fileContents = r.lines().collect(Collectors.toList());
+  			fileContents = r.lines().toList();
   		}
   		
   		assertEquals(2, fileContents.size());
@@ -174,15 +158,14 @@ public class MultiBamPhysicalCoverageTest {
 	public final void leftOverlapRead() throws IOException, InterruptedException {
     	createGFF3File(54000, 54036);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54036));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -192,17 +175,16 @@ public class MultiBamPhysicalCoverageTest {
 
     @Test
 	public final void rightOverlapRead() throws IOException, InterruptedException {
-    		createGFF3File(54050, 54120);
+		createGFF3File(54050, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54050, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -215,26 +197,17 @@ public class MultiBamPhysicalCoverageTest {
 	public final void subsetRead() throws IOException, InterruptedException {
     	createGFF3File(54030, 54070);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54030, 54070));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
 		assertEquals("physical	exon	41	2x", fileContents.get(1));
 	}
-    
-    @Test
-	public final void xu() throws IOException, InterruptedException {
-    	
-    	String str = getCmd(54030, 54070);
-    	
-    	System.out.println("xu test getCmd: " + str);
-    }
 }

--- a/qcoverage/test/org/qcmg/coverage/PerFeaturePhysicalCoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/PerFeaturePhysicalCoverageTest.java
@@ -1,7 +1,10 @@
 package org.qcmg.coverage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import htsjdk.samtools.SAMFileHeader.SortOrder;
+import org.junit.*;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.qio.gff3.Gff3Record;
+import org.qcmg.qio.record.RecordWriter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -10,20 +13,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import htsjdk.samtools.SAMFileHeader.SortOrder;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.qcmg.common.commandline.Executor;
-import org.qcmg.qio.gff3.Gff3Record;
-import org.qcmg.qio.record.RecordWriter;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PerFeaturePhysicalCoverageTest {
  
@@ -34,11 +26,7 @@ public class PerFeaturePhysicalCoverageTest {
 	private String fname;
 	static Gff3Record record;
 
-	
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-	
-	
+
 	@BeforeClass
 	 public static void setup() throws IOException {
 		 tmpDir = Files.createTempDirectory(null);
@@ -72,10 +60,10 @@ public class PerFeaturePhysicalCoverageTest {
 	}
 	
 	private String getCmd(int start, int stop) {
-		return "--log " + tmpDir + "/logfile --type phys --per-feature --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai  " + inputBai + " --output " +fname;
+		return "--log " + tmpDir + "/logfile --type phys --per-feature --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --output " +fname;
 	}
 
-	private File createGFF3File(final int start, final int end) throws IOException {
+	private void createGFF3File(final int start, final int end) throws IOException {
 		record.setStart(start);
 		record.setEnd(end);
 
@@ -83,28 +71,25 @@ public class PerFeaturePhysicalCoverageTest {
 		try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
 			writer.add(record);
 		}
-		return file;
 	}
 
 	private Executor execute(final String command) throws Exception {
-		//return new Executor(command, "org.qcmg.coverage.Main");
 		return new Executor(command, "org.qcmg.coverage.Coverage");
 
 	}
 	
     @Test
 	public final void leftDisjointRead() throws Exception {
-    		createGFF3File(54000, 54025);
+		createGFF3File(54000, 54025);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54025));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -116,15 +101,14 @@ public class PerFeaturePhysicalCoverageTest {
 	public final void rightDisjointRead() throws Exception {
     	createGFF3File(54077, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54077, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -135,17 +119,16 @@ public class PerFeaturePhysicalCoverageTest {
    
     @Test
 	public final void leftOnEndRead() throws Exception {
-    		createGFF3File(54000, 54026);
+		createGFF3File(54000, 54026);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54026));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(4, fileContents.size());
@@ -158,15 +141,14 @@ public class PerFeaturePhysicalCoverageTest {
 	public final void rightOnEndRead() throws Exception {
     	createGFF3File(54076, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54076, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -178,42 +160,40 @@ public class PerFeaturePhysicalCoverageTest {
 	public final void leftOverlapRead() throws Exception {
      	createGFF3File(54000, 54036);
 
-    		ExpectedException.none();
-    		Executor exec = execute(getCmd(54000, 54036));
-    		
-    		assertTrue(0 == exec.getErrCode());
-    		assertTrue(fOutput.exists());
-    		
-    		List<String> fileContents;
-    		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-    			fileContents = r.lines().collect(Collectors.toList());
-    		}
-    		
-    		assertEquals(4, fileContents.size());
-    		assertEquals("#chr1	.	exon	54000	54036	.	+	null	", fileContents.get(1));
-    		assertEquals("physical	26	0x", fileContents.get(2));
-    		assertEquals("physical	11	1x", fileContents.get(3));
+		Executor exec = execute(getCmd(54000, 54036));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(4, fileContents.size());
+		assertEquals("#chr1	.	exon	54000	54036	.	+	null	", fileContents.get(1));
+		assertEquals("physical	26	0x", fileContents.get(2));
+		assertEquals("physical	11	1x", fileContents.get(3));
 	}
 
     @Test
 	public final void rightOverlapRead() throws Exception {
      	createGFF3File(54050, 54120);
 
-    		ExpectedException.none();
-    		Executor exec = execute(getCmd(54050, 54120));
-    		
-    		assertTrue(0 == exec.getErrCode());
-    		assertTrue(fOutput.exists());
-    		
-    		List<String> fileContents;
-    		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-    			fileContents = r.lines().collect(Collectors.toList());
-    		}
-    		
-    		assertEquals(4, fileContents.size());
-    		assertEquals("#chr1	.	exon	54050	54120	.	+	null	", fileContents.get(1));
-    		assertEquals("physical	50	0x", fileContents.get(2));
-    		assertEquals("physical	21	1x", fileContents.get(3));
+		Executor exec = execute(getCmd(54050, 54120));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(4, fileContents.size());
+		assertEquals("#chr1	.	exon	54050	54120	.	+	null	", fileContents.get(1));
+		assertEquals("physical	50	0x", fileContents.get(2));
+		assertEquals("physical	21	1x", fileContents.get(3));
 	}
 
     
@@ -221,19 +201,18 @@ public class PerFeaturePhysicalCoverageTest {
 	public final void subsetRead() throws Exception {
       	createGFF3File(54030, 54070);
 
-    		ExpectedException.none();
-    		Executor exec = execute(getCmd(54030, 54070));
-    		
-    		assertTrue(0 == exec.getErrCode());
-    		assertTrue(fOutput.exists());
-    		
-    		List<String> fileContents;
-    		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-    			fileContents = r.lines().collect(Collectors.toList());
-    		}
-    		
-    		assertEquals(3, fileContents.size());
-    		assertEquals("#chr1	.	exon	54030	54070	.	+	null	", fileContents.get(1));
-    		assertEquals("physical	41	1x", fileContents.get(2));
+		Executor exec = execute(getCmd(54030, 54070));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(3, fileContents.size());
+		assertEquals("#chr1	.	exon	54030	54070	.	+	null	", fileContents.get(1));
+		assertEquals("physical	41	1x", fileContents.get(2));
 	}
 }

--- a/qcoverage/test/org/qcmg/coverage/PerFeatureSequenceCoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/PerFeatureSequenceCoverageTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import htsjdk.samtools.SAMFileHeader.SortOrder;
 
@@ -18,9 +17,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.qcmg.common.commandline.Executor;
 import org.qcmg.qio.gff3.Gff3Record;
 import org.qcmg.qio.record.RecordWriter;
@@ -31,9 +28,6 @@ public class PerFeatureSequenceCoverageTest {
 	static Path tmpDir;
 	private File fOutput;
 	private String fname;
-	
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 	
 	@BeforeClass
 	 public static void setup() throws IOException {
@@ -62,10 +56,10 @@ public class PerFeatureSequenceCoverageTest {
 	}
 	
 	private String getCmd(int start, int stop) {
-		return "--log " + tmpDir + "/logfile --type seq --per-feature --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai  " + inputBai + " --output " +fname;
+		return "--log " + tmpDir + "/logfile --type seq --per-feature --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --output " +fname;
 	}
 
-	private File createGFF3File(final int start, final int end) throws IOException {
+	private void createGFF3File(final int start, final int end) throws IOException {
 		Gff3Record record = new Gff3Record();
 		record.setSeqId("chr1");
 		record.setType("exon");
@@ -79,29 +73,24 @@ public class PerFeatureSequenceCoverageTest {
 		try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
 			writer.add(record);
 		}
-		
-		return file;
 	}
 
 	private Executor execute(final String command) throws Exception {
-		//return new Executor(command, "org.qcmg.coverage.Main");
 		return new Executor(command, "org.qcmg.coverage.Coverage");
-
 	}
 	
 	@Test
 	public final void leftDisjointReadSeqCov() throws Exception {
 		createGFF3File(54000, 54025);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54025));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -114,15 +103,14 @@ public class PerFeatureSequenceCoverageTest {
 	public final void rightDisjointRead() throws Exception {
     	createGFF3File(54077, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54077, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -132,17 +120,16 @@ public class PerFeatureSequenceCoverageTest {
 
     @Test
 	public final void rightOnEndRead() throws Exception {
-    		createGFF3File(54076, 54120);
+		createGFF3File(54076, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54076, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -154,15 +141,14 @@ public class PerFeatureSequenceCoverageTest {
 	public final void leftOverlapRead() throws Exception {
     	createGFF3File(54000, 54036);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54036));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(4, fileContents.size());
@@ -175,15 +161,14 @@ public class PerFeatureSequenceCoverageTest {
 	public final void rightOverlapRead() throws Exception {
     	createGFF3File(54050, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54050, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(4, fileContents.size());
@@ -197,15 +182,14 @@ public class PerFeatureSequenceCoverageTest {
 	public final void subsetRead() throws Exception {
     	createGFF3File(54030, 54070);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54030, 54070));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());

--- a/qcoverage/test/org/qcmg/coverage/PhysicalCoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/PhysicalCoverageTest.java
@@ -1,7 +1,10 @@
 package org.qcmg.coverage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import htsjdk.samtools.SAMFileHeader.SortOrder;
+import org.junit.*;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.qio.gff3.Gff3Record;
+import org.qcmg.qio.record.RecordWriter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -10,20 +13,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import htsjdk.samtools.SAMFileHeader.SortOrder;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.qcmg.common.commandline.Executor;
-import org.qcmg.qio.gff3.Gff3Record;
-import org.qcmg.qio.record.RecordWriter;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PhysicalCoverageTest {
 	static String inputBam;
@@ -31,9 +23,6 @@ public class PhysicalCoverageTest {
 	static Path tmpDir;
 	private File fOutput;
 	private String fname;
-	
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 	
 	 @BeforeClass
 	 public static void setup() throws Exception {
@@ -61,10 +50,10 @@ public class PhysicalCoverageTest {
 	}
 	
 	private String getCmd(int start, int stop) {
-		return "--log " + tmpDir + "/logfile --type phys --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai  " + inputBai + " --output " +fname;
+		return "--log " + tmpDir + "/logfile --type phys --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --output " +fname;
 	}
 
-	private File createGFF3File(final int start, final int end) throws IOException {
+	private void createGFF3File(final int start, final int end) throws IOException {
 		Gff3Record record = new Gff3Record();
 		record.setSeqId("chr1");
 		record.setType("exon");
@@ -78,8 +67,7 @@ public class PhysicalCoverageTest {
 		try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
 			writer.add(record);
 		}
-		
-		return file;
+
 	}
 
 	private Executor execute(final String command) throws IOException, InterruptedException {
@@ -92,15 +80,14 @@ public class PhysicalCoverageTest {
 	public  void leftDisjointRead() throws IOException, InterruptedException {
 		createGFF3File(54000, 54025);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54025));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -111,15 +98,14 @@ public class PhysicalCoverageTest {
 	public  void rightDisjointRead() throws IOException, InterruptedException {
 		createGFF3File(54077, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54077, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -131,15 +117,14 @@ public class PhysicalCoverageTest {
 	public  void leftOnEndRead() throws IOException, InterruptedException {
 		createGFF3File(54000, 54026);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54026));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -152,15 +137,14 @@ public class PhysicalCoverageTest {
 	public  void rightOnEndRead() throws IOException, InterruptedException {
 		createGFF3File(54076, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54076, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -171,15 +155,14 @@ public class PhysicalCoverageTest {
 	public  void leftOverlapRead() throws IOException, InterruptedException {
 		createGFF3File(54000, 54036);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54036));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -192,15 +175,14 @@ public class PhysicalCoverageTest {
 	public  void rightOverlapRead() throws IOException, InterruptedException {
 		createGFF3File(54050, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54050, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -212,15 +194,14 @@ public class PhysicalCoverageTest {
 	public  void subsetRead() throws IOException, InterruptedException {
 		createGFF3File(54030, 54070);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54030, 54070));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());

--- a/qcoverage/test/org/qcmg/coverage/QueryPhysicalCoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/QueryPhysicalCoverageTest.java
@@ -1,8 +1,11 @@
 package org.qcmg.coverage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.qio.gff3.Gff3Record;
+import org.qcmg.qio.record.RecordWriter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -11,354 +14,325 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.qcmg.common.commandline.Executor;
-import org.qcmg.qio.gff3.Gff3Record;
-import org.qcmg.qio.record.RecordWriter;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class QueryPhysicalCoverageTest {
-	static String inputBam;
-	static String inputBai;
-	static Path tmpDir;
-	private File fOutput;
-	private String fname;
-	static Gff3Record record;
+    static String inputBam;
+    static String inputBai;
+    static Path tmpDir;
+    private File fOutput;
+    private String fname;
+    static Gff3Record record;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-	
-	 @BeforeClass
-	 public static void setup() throws Exception {
-		 tmpDir = Files.createTempDirectory(null);
-		 inputBam = Files.createTempFile(tmpDir, null, ".bam").toString();
-		 inputBai = inputBam.replace("bam", "bai");
-		 SequenceCoverageTest.createCoverageBam(inputBam, SequenceCoverageTest.getAACSAMRecords(SortOrder.coordinate), SequenceCoverageTest.createSamHeaderObject(SortOrder.coordinate));
-		 
-		 record = new Gff3Record();
-		 record.setSeqId("chr1");
-		 record.setType("exon");
-		 record.setScore(".");
-		 record.setSource(".");
-		 record.setStrand("+");
-	 }
-	 
-	 @AfterClass
-	 public static void tearDown() {
-		tmpDir.toFile().delete();
-	 }
 
-	@Before
-	public final void before() {
-	 	fname = tmpDir.toString() + "/output";
-		fOutput = new File(fname + ".txt");
+    @BeforeClass
+    public static void setup() throws Exception {
+        tmpDir = Files.createTempDirectory(null);
+        inputBam = Files.createTempFile(tmpDir, null, ".bam").toString();
+        inputBai = inputBam.replace("bam", "bai");
+        SequenceCoverageTest.createCoverageBam(inputBam, SequenceCoverageTest.getAACSAMRecords(SortOrder.coordinate), SequenceCoverageTest.createSamHeaderObject(SortOrder.coordinate));
 
-	}
+        record = new Gff3Record();
+        record.setSeqId("chr1");
+        record.setType("exon");
+        record.setScore(".");
+        record.setSource(".");
+        record.setStrand("+");
+    }
 
-	@After
-	public final void after() {
-		fOutput.delete();
-	}
-	
-	private String getCmd(int start, int stop) {
-		return "--log " + tmpDir + "/logfile --type phys --query ISIZE<50 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai  " + inputBai + " --output " +fname;
-	}
-	private String getExCmd(int start, int stop) {
-		return "--log " + tmpDir + "/logfile --type phys --query ISIZE>50 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai  " + inputBai + " --output " +fname;
-	}
+    @AfterClass
+    public static void tearDown() {
+        tmpDir.toFile().delete();
+    }
 
-	private File createGFF3File(final int start, final int end) throws IOException {
-		record.setStart(start);
-		record.setEnd(end);
+    @Before
+    public final void before() {
+        fname = tmpDir.toString() + "/output";
+        fOutput = new File(fname + ".txt");
 
-		File file = new File(tmpDir + "/test" + start +"-" + end + ".gff3");
-		try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
-			writer.add(record);
-		}
-		return file;
-	}
+    }
 
-	private Executor execute(final String command) throws IOException, InterruptedException {
-		//return new Executor(command, "org.qcmg.coverage.Main");
-		return new Executor(command, "org.qcmg.coverage.Coverage");
+    @After
+    public final void after() {
+        fOutput.delete();
+    }
 
-	}
-	
+    private String getCmd(int start, int stop) {
+        return "--log " + tmpDir + "/logfile --type phys --query ISIZE<50 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --output " + fname;
+    }
+
+    private String getExCmd(int start, int stop) {
+        return "--log " + tmpDir + "/logfile --type phys --query ISIZE>50 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --output " + fname;
+    }
+
+    private void createGFF3File(final int start, final int end) throws IOException {
+        record.setStart(start);
+        record.setEnd(end);
+
+        File file = new File(tmpDir + "/test" + start + "-" + end + ".gff3");
+        try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
+            writer.add(record);
+        }
+    }
+
+    private Executor execute(final String command) throws IOException, InterruptedException {
+        return new Executor(command, "org.qcmg.coverage.Coverage");
+    }
+
     @Test
     public final void leftDisjointRead() throws IOException, InterruptedException {
-    		createGFF3File(54000, 54025);
+        createGFF3File(54000, 54025);
+        Executor exec = execute(getCmd(54000, 54025));
 
-		ExpectedException.none();
-		Executor exec = execute(getCmd(54000, 54025));
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("physical	exon	26	0x", fileContents.get(1));
-	}
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	26	0x", fileContents.get(1));
+    }
+
     @Test
     public final void leftDisjointReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54000, 54025);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54000, 54025));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("physical	exon	26	0x", fileContents.get(1));
-    	
+        createGFF3File(54000, 54025);
+        Executor exec = execute(getExCmd(54000, 54025));
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	26	0x", fileContents.get(1));
+
     }
 
     @Test
-	public final void rightDisjointRead() throws IOException, InterruptedException {
-    		createGFF3File(54077, 54120);
+    public final void rightDisjointRead() throws IOException, InterruptedException {
+        createGFF3File(54077, 54120);
 
-		ExpectedException.none();
-		Executor exec = execute(getCmd(54077, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("physical	exon	44	0x", fileContents.get(1));
-		
-	}
-    
+        Executor exec = execute(getCmd(54077, 54120));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	44	0x", fileContents.get(1));
+
+    }
+
     @Test
     public final void rightDisjointReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54077, 54120);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54077, 54120));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("physical	exon	44	0x", fileContents.get(1));
-    }
-   
-    @Test
-	public final void leftOnEndRead() throws IOException, InterruptedException {
-    		createGFF3File(54000, 54026);
+        createGFF3File(54077, 54120);
 
-		ExpectedException.none();
-		Executor exec = execute(getCmd(54000, 54026));
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(3, fileContents.size());
-		assertEquals("physical	exon	26	0x", fileContents.get(1));
-		assertEquals("physical	exon	1	1x", fileContents.get(2));
-	}
-    
+        Executor exec = execute(getExCmd(54077, 54120));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	44	0x", fileContents.get(1));
+    }
+
+    @Test
+    public final void leftOnEndRead() throws IOException, InterruptedException {
+        createGFF3File(54000, 54026);
+
+        Executor exec = execute(getCmd(54000, 54026));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(3, fileContents.size());
+        assertEquals("physical	exon	26	0x", fileContents.get(1));
+        assertEquals("physical	exon	1	1x", fileContents.get(2));
+    }
+
     @Test
     public final void leftOnEndReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54000, 54026);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54000, 54026));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("physical	exon	27	0x", fileContents.get(1));
+        createGFF3File(54000, 54026);
+
+        Executor exec = execute(getExCmd(54000, 54026));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	27	0x", fileContents.get(1));
     }
 
     @Test
-	public final void rightOnEndRead() throws IOException, InterruptedException {
-    		createGFF3File(54076, 54120);
+    public final void rightOnEndRead() throws IOException, InterruptedException {
+        createGFF3File(54076, 54120);
 
-		ExpectedException.none();
-		Executor exec = execute(getCmd(54076, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("physical	exon	45	0x", fileContents.get(1));
-	}
-    
+        Executor exec = execute(getCmd(54076, 54120));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	45	0x", fileContents.get(1));
+    }
+
     @Test
     public final void rightOnEndReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54076, 54120);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54076, 54120));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("physical	exon	45	0x", fileContents.get(1));
+        createGFF3File(54076, 54120);
+
+        Executor exec = execute(getExCmd(54076, 54120));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	45	0x", fileContents.get(1));
     }
 
     @Test
-	public final void leftOverlapRead() throws IOException, InterruptedException {
-    	createGFF3File(54000, 54036);
+    public final void leftOverlapRead() throws IOException, InterruptedException {
+        createGFF3File(54000, 54036);
 
-		ExpectedException.none();
-		Executor exec = execute(getCmd(54000, 54036));
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(3, fileContents.size());
-		assertEquals("physical	exon	26	0x", fileContents.get(1));
-		assertEquals("physical	exon	11	1x", fileContents.get(2));
-	}
-    
+        Executor exec = execute(getCmd(54000, 54036));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(3, fileContents.size());
+        assertEquals("physical	exon	26	0x", fileContents.get(1));
+        assertEquals("physical	exon	11	1x", fileContents.get(2));
+    }
+
     @Test
     public final void leftOverlapReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54000, 54036);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54000, 54036));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("physical	exon	37	0x", fileContents.get(1));
+        createGFF3File(54000, 54036);
+
+        Executor exec = execute(getExCmd(54000, 54036));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	37	0x", fileContents.get(1));
     }
 
     @Test
-	public final void rightOverlapRead() throws Exception {
-    		createGFF3File(54050, 54120);
+    public final void rightOverlapRead() throws Exception {
+        createGFF3File(54050, 54120);
 
-		ExpectedException.none();
-		Executor exec = execute(getCmd(54050, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(3, fileContents.size());
-		assertEquals("physical	exon	50	0x", fileContents.get(1));
-		assertEquals("physical	exon	21	1x", fileContents.get(2));
-	}
-    
+        Executor exec = execute(getCmd(54050, 54120));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(3, fileContents.size());
+        assertEquals("physical	exon	50	0x", fileContents.get(1));
+        assertEquals("physical	exon	21	1x", fileContents.get(2));
+    }
+
     @Test
     public final void rightOverlapReadEx() throws Exception {
-	    	createGFF3File(54050, 54120);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54050, 54120));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("physical	exon	71	0x", fileContents.get(1));
+        createGFF3File(54050, 54120);
+
+        Executor exec = execute(getExCmd(54050, 54120));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	71	0x", fileContents.get(1));
     }
 
     @Test
-	public final void subsetRead() throws IOException, InterruptedException {
-   		createGFF3File(54030, 54070);
+    public final void subsetRead() throws IOException, InterruptedException {
+        createGFF3File(54030, 54070);
 
-		ExpectedException.none();
-		Executor exec = execute(getCmd(54030, 54070));
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("physical	exon	41	1x", fileContents.get(1));
-	}
-    
+        Executor exec = execute(getCmd(54030, 54070));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	41	1x", fileContents.get(1));
+    }
+
     @Test
     public final void subsetReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54030, 54070);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54030, 54070));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("physical	exon	41	0x", fileContents.get(1));
+        createGFF3File(54030, 54070);
+
+        Executor exec = execute(getExCmd(54030, 54070));
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("physical	exon	41	0x", fileContents.get(1));
     }
 
 }

--- a/qcoverage/test/org/qcmg/coverage/QuerySequenceCoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/QuerySequenceCoverageTest.java
@@ -1,7 +1,10 @@
 package org.qcmg.coverage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import htsjdk.samtools.SAMFileHeader.SortOrder;
+import org.junit.*;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.qio.gff3.Gff3Record;
+import org.qcmg.qio.record.RecordWriter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -10,20 +13,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import htsjdk.samtools.SAMFileHeader.SortOrder;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.qcmg.common.commandline.Executor;
-import org.qcmg.qio.gff3.Gff3Record;
-import org.qcmg.qio.record.RecordWriter;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class QuerySequenceCoverageTest {
  	
@@ -34,9 +26,7 @@ public class QuerySequenceCoverageTest {
 	private String fname;
 	static Gff3Record record;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-	
+
 	 @BeforeClass
 	 public static void setup() throws Exception {
 		 tmpDir = Files.createTempDirectory(null);
@@ -70,13 +60,13 @@ public class QuerySequenceCoverageTest {
 	}
 	
 	private String getCmd(int start, int stop) {
-		return "--log " + tmpDir + "/logfile --type seq --query Cigar_M>35 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai  " + inputBai + " --output " +fname;
+		return "--log " + tmpDir + "/logfile --type seq --query Cigar_M>35 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --output " +fname;
 	}
 	private String getExCmd(int start, int stop) {
-		return "--log " + tmpDir + "/logfile --type seq --query Cigar_M>45 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai  " + inputBai + " --output " +fname;
+		return "--log " + tmpDir + "/logfile --type seq --query Cigar_M>45 --input-gff3 " + tmpDir + "/test" + start + "-" + stop + ".gff3 --input-bam " + inputBam + " --input-bai " + inputBai + " --output " +fname;
 	}
 
-	private File createGFF3File(final int start, final int end) throws IOException {
+	private void createGFF3File(final int start, final int end) throws IOException {
 		record.setStart(start);
 		record.setEnd(end);
 
@@ -84,7 +74,6 @@ public class QuerySequenceCoverageTest {
 		try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
 			writer.add(record);
 		}
-		return file;
 	}
 
 	private Executor execute(final String command) throws IOException, InterruptedException {
@@ -97,15 +86,14 @@ public class QuerySequenceCoverageTest {
 	public final void leftDisjointReadSeqCov() throws Exception {
 		createGFF3File(54000, 54025);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54025));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -116,15 +104,14 @@ public class QuerySequenceCoverageTest {
 	public final void leftDisjointReadSeqCovEx() throws IOException, InterruptedException {
 		createGFF3File(54000, 54025);
 		
-		ExpectedException.none();
 		Executor exec = execute(getExCmd(54000, 54025));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -133,17 +120,16 @@ public class QuerySequenceCoverageTest {
 
 	@Test
 	public final void rightDisjointRead() throws IOException, InterruptedException {
-    		createGFF3File(54077, 54120);
+		createGFF3File(54077, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54077, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -153,36 +139,34 @@ public class QuerySequenceCoverageTest {
     
     @Test
     public final void rightDisjointReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54077, 54120);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54077, 54120));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("sequence	exon	44	0x", fileContents.get(1));
+		createGFF3File(54077, 54120);
+
+		Executor exec = execute(getExCmd(54077, 54120));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(2, fileContents.size());
+		assertEquals("sequence	exon	44	0x", fileContents.get(1));
     }
    
     @Test
 	public final void leftOnEndRead() throws IOException, InterruptedException {
-    		createGFF3File(54000, 54026);
+		createGFF3File(54000, 54026);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54026));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -192,36 +176,34 @@ public class QuerySequenceCoverageTest {
     
     @Test
     public final void leftOnEndReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54000, 54026);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54000, 54026));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("sequence	exon	27	0x", fileContents.get(1));
+		createGFF3File(54000, 54026);
+
+		Executor exec = execute(getExCmd(54000, 54026));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(2, fileContents.size());
+		assertEquals("sequence	exon	27	0x", fileContents.get(1));
     }
 
     @Test
 	public final void rightOnEndRead() throws IOException, InterruptedException {
-    		createGFF3File(54076, 54120);
+		createGFF3File(54076, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54076, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -230,36 +212,34 @@ public class QuerySequenceCoverageTest {
     
     @Test
     public final void rightOnEndReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54076, 54120);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54076, 54120));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("sequence	exon	45	0x", fileContents.get(1));
+		createGFF3File(54076, 54120);
+
+		Executor exec = execute(getExCmd(54076, 54120));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(2, fileContents.size());
+		assertEquals("sequence	exon	45	0x", fileContents.get(1));
     }
 
     @Test
 	public final void leftOverlapRead() throws IOException, InterruptedException {
     	createGFF3File(54000, 54036);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54000, 54036));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -269,36 +249,34 @@ public class QuerySequenceCoverageTest {
     
     @Test
     public final void leftOverlapReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54000, 54036);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54000, 54036));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("sequence	exon	37	0x", fileContents.get(1));
+		createGFF3File(54000, 54036);
+
+		Executor exec = execute(getExCmd(54000, 54036));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(2, fileContents.size());
+		assertEquals("sequence	exon	37	0x", fileContents.get(1));
     }
 
     @Test
 	public final void rightOverlapRead() throws Exception {
-    		createGFF3File(54050, 54120);
+		createGFF3File(54050, 54120);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54050, 54120));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(3, fileContents.size());
@@ -308,36 +286,34 @@ public class QuerySequenceCoverageTest {
     
     @Test
     public final void rightOverlapReadEx() throws Exception {
-	    	createGFF3File(54050, 54120);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54050, 54120));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("sequence	exon	71	0x", fileContents.get(1));
+		createGFF3File(54050, 54120);
+
+		Executor exec = execute(getExCmd(54050, 54120));
+
+        assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(2, fileContents.size());
+		assertEquals("sequence	exon	71	0x", fileContents.get(1));
     }
 
     @Test
 	public final void subsetRead() throws IOException, InterruptedException {
    		createGFF3File(54030, 54070);
 
-		ExpectedException.none();
 		Executor exec = execute(getCmd(54030, 54070));
-		
-		assertTrue(0 == exec.getErrCode());
+
+        assertEquals(0, exec.getErrCode());
 		assertTrue(fOutput.exists());
 		
 		List<String> fileContents;
 		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
+			fileContents = r.lines().toList();
 		}
 		
 		assertEquals(2, fileContents.size());
@@ -346,21 +322,20 @@ public class QuerySequenceCoverageTest {
     
     @Test
     public final void subsetReadEx() throws IOException, InterruptedException {
-	    	createGFF3File(54030, 54070);
-	    	
-	    	ExpectedException.none();
-	    	Executor exec = execute(getExCmd(54030, 54070));
-	    	
-	    	assertTrue(0 == exec.getErrCode());
-	    	assertTrue(fOutput.exists());
-	    	
-	    	List<String> fileContents;
-	    	try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-	    		fileContents = r.lines().collect(Collectors.toList());
-	    	}
-	    	
-	    	assertEquals(2, fileContents.size());
-	    	assertEquals("sequence	exon	41	0x", fileContents.get(1));
+		createGFF3File(54030, 54070);
+
+		Executor exec = execute(getExCmd(54030, 54070));
+
+		 assertEquals(0, exec.getErrCode());
+		assertTrue(fOutput.exists());
+
+		List<String> fileContents;
+		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
+			fileContents = r.lines().toList();
+		}
+
+		assertEquals(2, fileContents.size());
+		assertEquals("sequence	exon	41	0x", fileContents.get(1));
     }	
 
 }

--- a/qcoverage/test/org/qcmg/coverage/SequenceCoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/SequenceCoverageTest.java
@@ -1,354 +1,328 @@
 package org.qcmg.coverage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMFileWriter;
-import htsjdk.samtools.SAMFileWriterFactory;
-import htsjdk.samtools.SAMReadGroupRecord;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.*;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.commandline.Executor;
 import org.qcmg.qio.gff3.Gff3Record;
 import org.qcmg.qio.record.RecordWriter;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class SequenceCoverageTest {
-	
-	String bam;
-	String bai;
-	String gff54000To54025;
-	String gff54030To54070;
-	String gff54077To54120;
-	String gff54000To54026;
-	String gff54076To54120;
-	String gff54000To54036;
-	String gff54050To54120;
-	final String inputSam1 = "coverage.sam";
-	final String inputBam1 = "coverage.bam";
-	final String inputIndex1 = "coverage.bai";
 
-	final String gff3 = "test.gff3";
-//	final String cmd =  String.format("--log ./logfile --per-feature -t phys --gff3 %s --input-bam%s --input-bai %s -o %s",
-//			gff3, inputBam1, inputIndex1,output);
+    String bam;
+    String bai;
+    String gff54000To54025;
+    String gff54030To54070;
+    String gff54077To54120;
+    String gff54000To54026;
+    String gff54076To54120;
+    String gff54000To54036;
+    String gff54050To54120;
 
-	 @Rule
-	 public TemporaryFolder testFolder = new TemporaryFolder();
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
 
-	@Before
-	public final void before() throws Exception {
-		if (null == bam) {
-			bam = testFolder.newFile("coverage.bam").getAbsolutePath();
-			createCoverageBam(bam, getAACSAMRecords(SortOrder.coordinate), createSamHeaderObject(SortOrder.coordinate));
-			bai = bam.replace("bam", "bai");
-		}
-		if (null == gff54000To54025) {
-			File f = testFolder.newFile("gff1");
-			gff54000To54025 = f.getAbsolutePath();
-			createGFF3File(54000, 54025, f);
-			
-			File f2 = testFolder.newFile("gff2");
-			gff54030To54070 = f2.getAbsolutePath();
-			createGFF3File(54030, 54070, f2);
-			
-			File f3 = testFolder.newFile("gff3");
-			gff54077To54120 = f3.getAbsolutePath();
-			createGFF3File(54077, 54120, f3);
-			
-			File f4 = testFolder.newFile("gff4");
-			gff54000To54026 = f4.getAbsolutePath();
-			createGFF3File(54000, 54026, f4);
-			
-			File f5 = testFolder.newFile("gff5");
-			gff54076To54120 = f5.getAbsolutePath();
-			createGFF3File(54076, 54120, f5);
-			
-			File f6 = testFolder.newFile("gff6");
-			gff54000To54036 = f6.getAbsolutePath();
-			createGFF3File(54000, 54036, f6);
-			
-			File f7 = testFolder.newFile("gff7");
-			gff54050To54120 = f7.getAbsolutePath();
-			createGFF3File(54050, 54120, f7);
-		}
-	}
 
-	private void createGFF3File(final int start, final int end, File file) throws IOException {
-		Gff3Record record = new Gff3Record();
-		record.setSeqId("chr1");
-		record.setType("exon");
-		record.setStart(start);
-		record.setEnd(end);
-		record.setScore(".");
-		record.setSource(".");
-		record.setStrand("+");
+    @Before
+    public final void before() throws Exception {
+        if (null == bam) {
+            bam = testFolder.newFile("coverage.bam").getAbsolutePath();
+            createCoverageBam(bam, getAACSAMRecords(SortOrder.coordinate), createSamHeaderObject(SortOrder.coordinate));
+            bai = bam.replace("bam", "bai");
+        }
+        if (null == gff54000To54025) {
+            File f = testFolder.newFile("gff1");
+            gff54000To54025 = f.getAbsolutePath();
+            createGFF3File(54000, 54025, f);
 
-		try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
-			writer.add(record);
-		}
-	}
+            File f2 = testFolder.newFile("gff2");
+            gff54030To54070 = f2.getAbsolutePath();
+            createGFF3File(54030, 54070, f2);
 
-	private Executor execute(final String command) throws Exception {
-		//return new Executor(command, "org.qcmg.coverage.Main");
-		return new Executor(command, "org.qcmg.coverage.Coverage");
+            File f3 = testFolder.newFile("gff3");
+            gff54077To54120 = f3.getAbsolutePath();
+            createGFF3File(54077, 54120, f3);
 
-	}
-	
-	@Test
-	public void beforeReadsStart() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
-		ExpectedException.none();
-		Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54000To54025 + " --input-bam " + bam + " --input-bai " + bai + " --output " +fname);
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("sequence	exon	26	0x", fileContents.get(1));
-		
-		fOutput.delete();
-	
-	}
-	@Test
-	public void overlapReadsStart() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
+            File f4 = testFolder.newFile("gff4");
+            gff54000To54026 = f4.getAbsolutePath();
+            createGFF3File(54000, 54026, f4);
 
-		ExpectedException.none();
-		Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54030To54070 + " --input-bam " + bam + " --input-bai " + bai + " --output " +fname);
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("sequence	exon	41	1x", fileContents.get(1));
-		
-		fOutput.delete();
-	}
+            File f5 = testFolder.newFile("gff5");
+            gff54076To54120 = f5.getAbsolutePath();
+            createGFF3File(54076, 54120, f5);
+
+            File f6 = testFolder.newFile("gff6");
+            gff54000To54036 = f6.getAbsolutePath();
+            createGFF3File(54000, 54036, f6);
+
+            File f7 = testFolder.newFile("gff7");
+            gff54050To54120 = f7.getAbsolutePath();
+            createGFF3File(54050, 54120, f7);
+        }
+    }
+
+    private void createGFF3File(final int start, final int end, File file) throws IOException {
+        Gff3Record record = new Gff3Record();
+        record.setSeqId("chr1");
+        record.setType("exon");
+        record.setStart(start);
+        record.setEnd(end);
+        record.setScore(".");
+        record.setSource(".");
+        record.setStrand("+");
+
+        try (RecordWriter<Gff3Record> writer = new RecordWriter<>(file)) {
+            writer.add(record);
+        }
+    }
+
+    private Executor execute(final String command) throws Exception {
+        return new Executor(command, "org.qcmg.coverage.Coverage");
+    }
+
+    @Test
+    public void beforeReadsStart() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54000To54025 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("sequence	exon	26	0x", fileContents.get(1));
+
+        fOutput.delete();
+
+    }
+
+    @Test
+    public void overlapReadsStart() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
+
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54030To54070 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("sequence	exon	41	1x", fileContents.get(1));
+
+        fOutput.delete();
+    }
 
 
     @Test
-	public final void afterRead() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
+    public final void afterRead() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
 
 
-		ExpectedException.none();
-		Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54077To54120 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
-		assertTrue(0 == exec.getErrCode());
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54077To54120 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
+        assertEquals(0, exec.getErrCode());
 
-		assertTrue(fOutput.exists());
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("sequence	exon	44	0x", fileContents.get(1));
+        assertTrue(fOutput.exists());
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
 
-		fOutput.delete();
-	}
+        assertEquals(2, fileContents.size());
+        assertEquals("sequence	exon	44	0x", fileContents.get(1));
 
-   
-    @Test
-	public final void overlapBeginningOfRead() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
+        fOutput.delete();
+    }
 
-
-		ExpectedException.none();
-		Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54000To54026 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
-		assertTrue(0 == exec.getErrCode());
-
-		assertTrue(fOutput.exists());
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(3, fileContents.size());
-		assertEquals("sequence	exon	26	0x", fileContents.get(1));
-		assertEquals("sequence	exon	1	1x", fileContents.get(2));
-
-		fOutput.delete();
-	}
 
     @Test
-	public final void rightOnEndRead() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
+    public final void overlapBeginningOfRead() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
 
-		ExpectedException.none();
-		Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54076To54120 + " --input-bam " + bam + " --input-bai " + bai +   " --output " + fname);
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("sequence	exon	45	0x", fileContents.get(1));
 
-		fOutput.delete();
-	}
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54000To54026 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
+        assertEquals(0, exec.getErrCode());
 
-    @Test
-	public final void leftOverlapRead() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
+        assertTrue(fOutput.exists());
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
 
-		ExpectedException.none();
-		Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54000To54036 + " --input-bam " + bam + " --input-bai " + bai +  " --output " + fname);
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(3, fileContents.size());
-		assertEquals("sequence	exon	26	0x", fileContents.get(1));
-		assertEquals("sequence	exon	11	1x", fileContents.get(2));
+        assertEquals(3, fileContents.size());
+        assertEquals("sequence	exon	26	0x", fileContents.get(1));
+        assertEquals("sequence	exon	1	1x", fileContents.get(2));
 
-		fOutput.delete();
-	}
+        fOutput.delete();
+    }
 
     @Test
-	public final void rightOverlapRead() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
+    public final void rightOnEndRead() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
 
-		ExpectedException.none();
-		Executor exec = execute(" --log ./logfile --type seq --input-gff3 " + gff54050To54120 + " --input-bam " + bam + " --input-bai " + bai +  " --output " + fname);
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(3, fileContents.size());
-		assertEquals("sequence	exon	50	0x", fileContents.get(1));
-		assertEquals("sequence	exon	21	1x", fileContents.get(2));
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54076To54120 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
 
-		fOutput.delete();
-	}
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("sequence	exon	45	0x", fileContents.get(1));
+
+        fOutput.delete();
+    }
 
     @Test
-	public final void subsetRead() throws Exception {
-		String fname = testFolder.getRoot().getAbsolutePath()+"/output";
-		File fOutput = new File(fname + ".txt");
+    public final void leftOverlapRead() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
 
-		ExpectedException.none();
-		Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54030To54070 + " --input-bam " + bam + " --input-bai " + bai +" --output " + fname);
-		
-		assertTrue(0 == exec.getErrCode());
-		assertTrue(fOutput.exists());
-		
-		List<String> fileContents;
-		try (BufferedReader r= new BufferedReader( new FileReader(fOutput))) {
-			fileContents = r.lines().collect(Collectors.toList());
-		}
-		
-		assertEquals(2, fileContents.size());
-		assertEquals("sequence	exon	41	1x", fileContents.get(1));
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54000To54036 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
 
-		fOutput.delete();
-	}
-    
-	public static final void createCoverageBam(String outputFileName,List<SAMRecord> recs, SAMFileHeader h) {
-		File outputFile = new File(outputFileName);
-		SAMFileWriterFactory.setDefaultCreateIndexWhileWriting(true);
-		try (SAMFileWriter outputWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(h, true, outputFile)) {
-			for (SAMRecord read : recs) {
-				outputWriter.addAlignment(read);
-			}
-		}
-	}
-	
-	 public static SAMFileHeader createSamHeaderObject(SortOrder sort) {
-		 SAMSequenceDictionary dict = new SAMSequenceDictionary(
-				 Arrays.asList(new SAMSequenceRecord("chr1",100000),
-						 new SAMSequenceRecord("chr2",100000),
-						 new SAMSequenceRecord("chr3",100000)));
-		 
-		 SAMFileHeader h = new SAMFileHeader();
-		 h.setSequenceDictionary(dict);
-		 h.setSortOrder(sort);
-		 
-		 SAMReadGroupRecord rg1 = new SAMReadGroupRecord("ZZ");
-		 rg1.setPlatform("SOLiD");
-		 rg1.setLibrary("Library_20100702_A	PI:1355	DS:RUNTYPE{50x50MP}");
-		 SAMReadGroupRecord rg2 = new SAMReadGroupRecord("ZZZ");
-		 rg2.setPlatform("SOLiD");
-		 rg2.setLibrary("Library_20100702_A	PI:1355	DS:RUNTYPE{50x50MP}");
-		 
-		 h.setReadGroups(Arrays.asList(rg1, rg2));
-		 return h;
-	 }
-	
-	
-	public static List<SAMRecord> getAACSAMRecords(SortOrder so) {
-		SAMFileHeader h = createSamHeaderObject(so); 
-		
-		SAMRecord s1 = getSAM(h, "1290_738_1025",	0	,"chr1",	54026,	255,	"45M5H",	"*",	0,	0,	"AACATTCCAAAAGTCAACCATCCAAGTTTATTCTAAATAGATGTG","!DDDDDDDDDDDDDDDD''DDDDDD9DDDDDDDDD:<3B''DDD!","ZZ");
-		SAMRecord s2 = getSAM(h, "2333_755_492",	16	,"chr2",	10103,	255,	"10H40M",	"*",	0,	0,	"CACACCACACCCACACACCACACACCACACCCACACCCAC","!=DD?%+DD<)=DDD<@9)9C:DA.:DD>%%,<?('-,4!","ZZ");
-		SAMRecord s3 = getSAM(h, "1879_282_595",	0	,"chr3",	60775,	255,	"40M10H",	"*",	0,	0,	"TCTAAATTTGTTTGATCACATACTCCTTTTCTGGCTAACA","!DD,*@DDD''DD>5:DD>;DDDD=CDD8%%DA9-DDC0!","ZZ");
-		
-		return Arrays.asList(s1, s2, s3);
-	}
-	
-	private static SAMRecord getSAM(SAMFileHeader h, String readName,int flags, String chr, int pos, int mapQ, String cigar, String mRef, int mPos, int iSize, String bases, String quals, String md) {
-		SAMRecord s1 = new SAMRecord(h);
-		s1.setAlignmentStart(pos);
-		s1.setCigarString(cigar);
-		s1.setBaseQualityString(quals);
-		s1.setFlags(flags);
-		s1.setMappingQuality(mapQ);
-		s1.setInferredInsertSize(iSize);
-		s1.setReadName(readName);
-		s1.setReferenceName(chr);
-		s1.setReadString(bases);
-		s1.setAttribute("MD", md);
-		s1.setMateReferenceName(mRef);
-		s1.setMateAlignmentStart(mPos);
-		return s1;
-	}
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(3, fileContents.size());
+        assertEquals("sequence	exon	26	0x", fileContents.get(1));
+        assertEquals("sequence	exon	11	1x", fileContents.get(2));
+
+        fOutput.delete();
+    }
+
+    @Test
+    public final void rightOverlapRead() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
+
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54050To54120 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(3, fileContents.size());
+        assertEquals("sequence	exon	50	0x", fileContents.get(1));
+        assertEquals("sequence	exon	21	1x", fileContents.get(2));
+
+        fOutput.delete();
+    }
+
+    @Test
+    public final void subsetRead() throws Exception {
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
+        File fOutput = new File(fname + ".txt");
+
+        Executor exec = execute("--log ./logfile --type seq --input-gff3 " + gff54030To54070 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname);
+
+        assertEquals(0, exec.getErrCode());
+        assertTrue(fOutput.exists());
+
+        List<String> fileContents;
+        try (BufferedReader r = new BufferedReader(new FileReader(fOutput))) {
+            fileContents = r.lines().toList();
+        }
+
+        assertEquals(2, fileContents.size());
+        assertEquals("sequence	exon	41	1x", fileContents.get(1));
+
+        fOutput.delete();
+    }
+
+    public static void createCoverageBam(String outputFileName, List<SAMRecord> recs, SAMFileHeader h) {
+        File outputFile = new File(outputFileName);
+        SAMFileWriterFactory.setDefaultCreateIndexWhileWriting(true);
+        try (SAMFileWriter outputWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(h, true, outputFile)) {
+            for (SAMRecord read : recs) {
+                outputWriter.addAlignment(read);
+            }
+        }
+    }
+
+    public static SAMFileHeader createSamHeaderObject(SortOrder sort) {
+        SAMSequenceDictionary dict = new SAMSequenceDictionary(
+                Arrays.asList(new SAMSequenceRecord("chr1", 100000),
+                        new SAMSequenceRecord("chr2", 100000),
+                        new SAMSequenceRecord("chr3", 100000)));
+
+        SAMFileHeader h = new SAMFileHeader();
+        h.setSequenceDictionary(dict);
+        h.setSortOrder(sort);
+
+        SAMReadGroupRecord rg1 = new SAMReadGroupRecord("ZZ");
+        rg1.setPlatform("SOLiD");
+        rg1.setLibrary("Library_20100702_A	PI:1355	DS:RUNTYPE{50x50MP}");
+        SAMReadGroupRecord rg2 = new SAMReadGroupRecord("ZZZ");
+        rg2.setPlatform("SOLiD");
+        rg2.setLibrary("Library_20100702_A	PI:1355	DS:RUNTYPE{50x50MP}");
+
+        h.setReadGroups(Arrays.asList(rg1, rg2));
+        return h;
+    }
+
+
+    public static List<SAMRecord> getAACSAMRecords(SortOrder so) {
+        SAMFileHeader h = createSamHeaderObject(so);
+
+        SAMRecord s1 = getSAM(h, "1290_738_1025", 0, "chr1", 54026, 255, "45M5H", "*", 0, 0, "AACATTCCAAAAGTCAACCATCCAAGTTTATTCTAAATAGATGTG", "!DDDDDDDDDDDDDDDD''DDDDDD9DDDDDDDDD:<3B''DDD!", "ZZ");
+        SAMRecord s2 = getSAM(h, "2333_755_492", 16, "chr2", 10103, 255, "10H40M", "*", 0, 0, "CACACCACACCCACACACCACACACCACACCCACACCCAC", "!=DD?%+DD<)=DDD<@9)9C:DA.:DD>%%,<?('-,4!", "ZZ");
+        SAMRecord s3 = getSAM(h, "1879_282_595", 0, "chr3", 60775, 255, "40M10H", "*", 0, 0, "TCTAAATTTGTTTGATCACATACTCCTTTTCTGGCTAACA", "!DD,*@DDD''DD>5:DD>;DDDD=CDD8%%DA9-DDC0!", "ZZ");
+
+        return Arrays.asList(s1, s2, s3);
+    }
+
+    private static SAMRecord getSAM(SAMFileHeader h, String readName, int flags, String chr, int pos, int mapQ, String cigar, String mRef, int mPos, int iSize, String bases, String quals, String md) {
+        SAMRecord s1 = new SAMRecord(h);
+        s1.setAlignmentStart(pos);
+        s1.setCigarString(cigar);
+        s1.setBaseQualityString(quals);
+        s1.setFlags(flags);
+        s1.setMappingQuality(mapQ);
+        s1.setInferredInsertSize(iSize);
+        s1.setReadName(readName);
+        s1.setReferenceName(chr);
+        s1.setReadString(bases);
+        s1.setAttribute("MD", md);
+        s1.setMateReferenceName(mRef);
+        s1.setMateAlignmentStart(mPos);
+        return s1;
+    }
 
 }

--- a/qmaftools/build.gradle
+++ b/qmaftools/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation project(':qpicard')
     implementation project(':qbamfilter')
 	
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'	
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'	
 }
 

--- a/qmito/build.gradle
+++ b/qmito/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation project(':qbamfilter')
     implementation project(':qpicard')
 
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }

--- a/qmotif/build.gradle
+++ b/qmotif/build.gradle
@@ -14,6 +14,6 @@ dependencies {
     implementation project(':qpicard')
            
     implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'	
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'	
 }
 

--- a/qmule/build.gradle
+++ b/qmule/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(':qio')
     implementation project(':qpicard')
     implementation 'com.google.code.findbugs:findbugs:1.3.9'	
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'com.github.broadinstitute:picard:3.1.1'
-    implementation 'org.broadinstitute:barclay:2.0.0'
+    implementation 'org.broadinstitute:barclay:5.0.0'
 }

--- a/qmule/src/org/qcmg/qmule/Options.java
+++ b/qmule/src/org/qcmg/qmule/Options.java
@@ -1,512 +1,521 @@
 /**
  * © Copyright The University of Queensland 2010-2014.
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
  */
 package org.qcmg.qmule;
 
-import static java.util.Arrays.asList;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
+import static java.util.Arrays.asList;
 
 /**
  * The Class Options.
  */
 public final class Options {
-	
-	public enum Ids{
-		PATIENT,
-		SOMATIC_ANALYSIS,
-		GEMLINE_ANALYSIS,
-		TUMOUR_SAMPLE,
-		NORMAL_SAMPLE;
-	}
-	
-	/** The Constant HELP_DESCRIPTION. */
-	private static final String HELP_DESCRIPTION = Messages
-			.getMessage("HELP_OPTION_DESCRIPTION");
 
-	/** The Constant VERSION_DESCRIPTION. */
-	private static final String VERSION_DESCRIPTION = Messages
-			.getMessage("VERSION_OPTION_DESCRIPTION");
-	
-	/** The Constant INPUT_DESCRIPTION. */
-	private static final String INPUT_DESCRIPTION = Messages
-			.getMessage("INPUT_OPTION_DESCRIPTION");
-	
-	/** The Constant OUTPUT_DESCRIPTION. */
-	private static final String OUTPUT_DESCRIPTION = Messages
-			.getMessage("OUTPUT_OPTION_DESCRIPTION");
-	
-	/** The parser. */
-	private final OptionParser parser = new OptionParser();
-	
-	/** The options. */
-	private final OptionSet options;
-	
-	/** The command line. */
-	private final String commandLine;
-	
-	/** The input file names. */
-	private final String[] inputFileNames;
-	
-	/** The output file names. */
-	private final  String[] outputFileNames;
-	
-	/** The log file  */
-	private  String logFile;
-	
-	/** The log level */
-	private  String logLevel;
-	
-	private  String patientId;
-	private  String somaticAnalysisId;
-	private  String germlineAnalysisId;
-	private   String normalSampleId;
-	private  String tumourSampleId;
-	private   String position;
-	private   String pileupFormat;
-	private int normalCoverage;
-	private int numberOfThreads;
-	private int tumourCoverage;
-	private int minCoverage;
-	private  String mafMode;
-	private  String gff;
-	private  String fasta;
-	private   String[] gffRegions;
-	private int noOfBases;
-	private   String mode;
+    public enum Ids {
+        PATIENT,
+        SOMATIC_ANALYSIS,
+        GEMLINE_ANALYSIS,
+        TUMOUR_SAMPLE,
+        NORMAL_SAMPLE;
+    }
+
+    /** The Constant HELP_DESCRIPTION. */
+    private static final String HELP_DESCRIPTION = Messages
+            .getMessage("HELP_OPTION_DESCRIPTION");
+
+    /** The Constant VERSION_DESCRIPTION. */
+    private static final String VERSION_DESCRIPTION = Messages
+            .getMessage("VERSION_OPTION_DESCRIPTION");
+
+    /** The Constant INPUT_DESCRIPTION. */
+    private static final String INPUT_DESCRIPTION = Messages
+            .getMessage("INPUT_OPTION_DESCRIPTION");
+
+    /** The Constant OUTPUT_DESCRIPTION. */
+    private static final String OUTPUT_DESCRIPTION = Messages
+            .getMessage("OUTPUT_OPTION_DESCRIPTION");
+
+    /** The parser. */
+    private final OptionParser parser = new OptionParser();
+
+    /** The options. */
+    private final OptionSet options;
+
+    /** The command line. */
+    private final String commandLine;
+
+    /** The input file names. */
+    private final String[] inputFileNames;
+
+    /** The output file names. */
+    private final String[] outputFileNames;
+
+    /** The log file  */
+    private String logFile;
+
+    /** The log level */
+    private String logLevel;
+
+    private String patientId;
+    private String somaticAnalysisId;
+    private String germlineAnalysisId;
+    private String normalSampleId;
+    private String tumourSampleId;
+    private String position;
+    private String pileupFormat;
+    private int normalCoverage;
+    private int numberOfThreads;
+    private int tumourCoverage;
+    private int minCoverage;
+    private String mafMode;
+    private String gff;
+    private String fasta;
+    private String[] gffRegions;
+    private int noOfBases;
+    private String mode;
 
 
-	private String column;
+    private String column;
 
-	private String annotation;
+    private String annotation;
 
-	private String features;
+    private String features;
 
-	private String tumour;
+    private String tumour;
 
-	private String normal;
+    private String normal;
 
-	private String analysis;
+    private String analysis;
 
-	/**
-	 * Instantiates a new options.
-	 *
-	 * @param args the args
-	 * @throws Exception the exception
-	 */
-	@SuppressWarnings("unchecked")
-	public Options(final String[] args) throws Exception {
-		commandLine = Messages.reconstructCommandLine(args);
-		
+    /**
+     * Instantiates a new options.
+     *
+     * @param args the args
+     * @throws Exception the exception
+     */
+    @SuppressWarnings("unchecked")
+    public Options(final String[] args) throws Exception {
+        commandLine = Messages.reconstructCommandLine(args);
+
 //		parser.accepts("qmule", "Tool").withRequiredArg().ofType(String.class).describedAs("tool name");
-		parser.accepts("output", OUTPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("outputfile");
-		parser.accepts("input", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("inputfile");
-		parser.accepts("log", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("logfile");
-		parser.accepts("loglevel", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("loglevel");
-		parser.accepts("help", HELP_DESCRIPTION);
-		parser.accepts("version", VERSION_DESCRIPTION);
-		parser.accepts("patientId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("patientId");
-		parser.accepts("somaticAnalysisId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("somaticAnalysisId");
-		parser.accepts("germlineAnalysisId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("germlineAnalysisId");
-		parser.accepts("normalSampleId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("normalSampleId");
-		parser.accepts("tumourSampleId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("tumourSampleId");
-		parser.accepts("position", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("position");
-		parser.accepts("pileupFormat", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("pileupFormat");
-		parser.accepts("normalCoverage", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
-		.describedAs("normalCoverage");
-		parser.accepts("numberOfThreads", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
-		.describedAs("numberOfThreads");
-		parser.accepts("tumourCoverage", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
-		.describedAs("tumourCoverage");
-		parser.accepts("minCoverage", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
-		.describedAs("minCoverage");
-		parser.accepts("mafMode", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("mafMode");
-		parser.accepts("mode", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("mode");
-		parser.accepts("column", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("column");
-		parser.accepts("annotation", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("annotation");
-		parser.accepts("gffFile", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("gffFile");
-		parser.accepts("fasta", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("fasta");
-		parser.accepts("feature", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("feature");
-		parser.accepts("tumour", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("tumour");
-		parser.accepts("normal", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("normal");
-		parser.accepts("analysis", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
-		.describedAs("analysis");
-		parser.accepts("verifiedInvalid", INPUT_DESCRIPTION);
-		parser.accepts("gffRegions", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).withValuesSeparatedBy(',').describedAs("gffRegions");
-		parser.accepts("noOfBases", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class).describedAs("noOfBases");
-		parser.accepts("proportion", Messages
-				.getMessage("PROPORTION_OPTION_DESCRIPTION")).withRequiredArg().ofType(Double.class);
-		parser.accepts("stranded", Messages
-				.getMessage("STRANDED_OPTION_DESCRIPTION"));		
-		parser.accepts("compareAll",Messages.getMessage("COMPAREALL_OPTION"));
-		
-		parser.posixlyCorrect(true);
-		options = parser.parse(args);
-		
-		List inputList = options.valuesOf("input");
-		inputFileNames = new String[inputList.size()];
-		inputList.toArray(inputFileNames);
+        parser.accepts("output", OUTPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("outputfile");
+        parser.accepts("input", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("inputfile");
+        parser.accepts("log", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("logfile");
+        parser.accepts("loglevel", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("loglevel");
+        parser.accepts("help", HELP_DESCRIPTION);
+        parser.accepts("version", VERSION_DESCRIPTION);
+        parser.accepts("patientId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("patientId");
+        parser.accepts("somaticAnalysisId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("somaticAnalysisId");
+        parser.accepts("germlineAnalysisId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("germlineAnalysisId");
+        parser.accepts("normalSampleId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("normalSampleId");
+        parser.accepts("tumourSampleId", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("tumourSampleId");
+        parser.accepts("position", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("position");
+        parser.accepts("pileupFormat", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("pileupFormat");
+        parser.accepts("normalCoverage", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
+                .describedAs("normalCoverage");
+        parser.accepts("numberOfThreads", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
+                .describedAs("numberOfThreads");
+        parser.accepts("tumourCoverage", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
+                .describedAs("tumourCoverage");
+        parser.accepts("minCoverage", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class)
+                .describedAs("minCoverage");
+        parser.accepts("mafMode", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("mafMode");
+        parser.accepts("mode", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("mode");
+        parser.accepts("column", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("column");
+        parser.accepts("annotation", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("annotation");
+        parser.accepts("gffFile", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("gffFile");
+        parser.accepts("fasta", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("fasta");
+        parser.accepts("feature", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("feature");
+        parser.accepts("tumour", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("tumour");
+        parser.accepts("normal", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("normal");
+        parser.accepts("analysis", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class)
+                .describedAs("analysis");
+        parser.accepts("verifiedInvalid", INPUT_DESCRIPTION);
+        parser.accepts("gffRegions", INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).withValuesSeparatedBy(',').describedAs("gffRegions");
+        parser.accepts("noOfBases", INPUT_DESCRIPTION).withRequiredArg().ofType(Integer.class).describedAs("noOfBases");
+        parser.accepts("proportion", Messages
+                .getMessage("PROPORTION_OPTION_DESCRIPTION")).withRequiredArg().ofType(Double.class);
+        parser.accepts("stranded", Messages
+                .getMessage("STRANDED_OPTION_DESCRIPTION"));
+        parser.accepts("compareAll", Messages.getMessage("COMPAREALL_OPTION"));
 
-		List outputList = options.valuesOf("output");
-		outputFileNames = new String[outputList.size()];
-		outputList.toArray(outputFileNames);
-		
-		logFile = (String) options.valueOf("log");
-		logLevel = (String) options.valueOf("loglevel");
-		
-		patientId = (String) options.valueOf("patientId");
-		somaticAnalysisId = (String) options.valueOf("somaticAnalysisId");
-		germlineAnalysisId = (String) options.valueOf("germlineAnalysisId");
-		normalSampleId = (String) options.valueOf("normalSampleId");
-		tumourSampleId = (String) options.valueOf("tumourSampleId");
-		
-		// WiggleFromPileup specific options
-		pileupFormat = (String) options.valueOf("pileupFormat");
-		if (null != options.valueOf("normalCoverage"))
-			normalCoverage = (Integer) options.valueOf("normalCoverage");
-		if (null != options.valueOf("tumourCoverage"))
-			tumourCoverage = (Integer) options.valueOf("tumourCoverage");
-		// end of WiggleFromPileup specific options
-		
-		//compareReferenceRegions
-		mode = (String) options.valueOf("mode");
-		column = (String) options.valueOf("column");
-		annotation = (String) options.valueOf("annotation");
-		features = (String) options.valueOf("feature");
-		position = (String) options.valueOf("position");
-		mafMode = (String) options.valueOf("mafMode");
-		
-		gff = (String) options.valueOf("gffFile");
-		fasta = (String) options.valueOf("fasta");
-		
-		tumour = (String) options.valueOf("tumour");
-		normal = (String) options.valueOf("normal");
-		analysis = (String) options.valueOf("analysis");
-		
-		// gffRegions
-		List<String> gffRegionsArgs = (List<String>) options.valuesOf("gffRegions");
-		gffRegions = new String[gffRegionsArgs.size()];
-		gffRegionsArgs.toArray(gffRegions);
+        parser.posixlyCorrect(true);
+        options = parser.parse(args);
 
-		// MafAddCPG specific
-		if (null != options.valueOf("noOfBases"))
-			noOfBases = (Integer) options.valueOf("noOfBases");
-		
-		// qsignature
-		if (null != options.valueOf("minCoverage"))
-			minCoverage = (Integer) options.valueOf("minCoverage");
-		
-		if (null != options.valueOf("numberOfThreads"))
-			numberOfThreads = (Integer) options.valueOf("numberOfThreads");
-		
-	}
+        List inputList = options.valuesOf("input");
+        inputFileNames = new String[inputList.size()];
+        inputList.toArray(inputFileNames);
 
-	/**
-	 * 
-	 * @param className
-	 * @param args
-	 * @throws Exception
-	 */
-	public Options( final Class myclass,  final String[] args) throws Exception {
-		commandLine = Messages.reconstructCommandLine(args);
-		
-		parser.acceptsAll( asList("h", "help"),   HELP_DESCRIPTION );	 
+        List outputList = options.valuesOf("output");
+        outputFileNames = new String[outputList.size()];
+        outputList.toArray(outputFileNames);
+
+        logFile = (String) options.valueOf("log");
+        logLevel = (String) options.valueOf("loglevel");
+
+        patientId = (String) options.valueOf("patientId");
+        somaticAnalysisId = (String) options.valueOf("somaticAnalysisId");
+        germlineAnalysisId = (String) options.valueOf("germlineAnalysisId");
+        normalSampleId = (String) options.valueOf("normalSampleId");
+        tumourSampleId = (String) options.valueOf("tumourSampleId");
+
+        // WiggleFromPileup specific options
+        pileupFormat = (String) options.valueOf("pileupFormat");
+        if (null != options.valueOf("normalCoverage"))
+            normalCoverage = (Integer) options.valueOf("normalCoverage");
+        if (null != options.valueOf("tumourCoverage"))
+            tumourCoverage = (Integer) options.valueOf("tumourCoverage");
+        // end of WiggleFromPileup specific options
+
+        //compareReferenceRegions
+        mode = (String) options.valueOf("mode");
+        column = (String) options.valueOf("column");
+        annotation = (String) options.valueOf("annotation");
+        features = (String) options.valueOf("feature");
+        position = (String) options.valueOf("position");
+        mafMode = (String) options.valueOf("mafMode");
+
+        gff = (String) options.valueOf("gffFile");
+        fasta = (String) options.valueOf("fasta");
+
+        tumour = (String) options.valueOf("tumour");
+        normal = (String) options.valueOf("normal");
+        analysis = (String) options.valueOf("analysis");
+
+        // gffRegions
+        List<String> gffRegionsArgs = (List<String>) options.valuesOf("gffRegions");
+        gffRegions = new String[gffRegionsArgs.size()];
+        gffRegionsArgs.toArray(gffRegions);
+
+        // MafAddCPG specific
+        if (null != options.valueOf("noOfBases"))
+            noOfBases = (Integer) options.valueOf("noOfBases");
+
+        // qsignature
+        if (null != options.valueOf("minCoverage"))
+            minCoverage = (Integer) options.valueOf("minCoverage");
+
+        if (null != options.valueOf("numberOfThreads"))
+            numberOfThreads = (Integer) options.valueOf("numberOfThreads");
+
+    }
+
+    /**
+     *
+     * @param className
+     * @param args
+     * @throws Exception
+     */
+    public Options(final Class myclass, final String[] args) throws Exception {
+        commandLine = Messages.reconstructCommandLine(args);
+
+        parser.acceptsAll(asList("h", "help"), HELP_DESCRIPTION);
 //		parser.acceptsAll( asList("v", "version"), VERSION_DESCRIPTION);				
-		parser.acceptsAll( asList("i", "input"), INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("input");
-		parser.acceptsAll(asList("o", "output"), OUTPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("outputfile");
-		parser.accepts("log", Messages.getMessage("LOG_OPTION_DESCRIPTION")).withRequiredArg().ofType(String.class).describedAs("logfile");
-		parser.accepts("loglevel", Messages.getMessage("LOGLEVEL_OPTION_DESCRIPTION")).withRequiredArg().ofType(String.class).describedAs("loglevel");
-	
- 		if( myclass.equals(AlignerCompare.class) ){ 
-			parser.accepts("compareAll",Messages.getMessage("COMPAREALL_OPTION"));
- 			parser.acceptsAll( asList("o", "output"), Messages.getMessage("OUTPUT_AlignerCompare")).withRequiredArg().ofType(String.class).describedAs("output");			
-		}else if(myclass.equals(SubSample.class)) {
-			parser.accepts("proportion",Messages.getMessage("PROPORTION_OPTION_DESCRIPTION")).withRequiredArg().ofType(Double.class).describedAs("[0,1]");
-		}else if(myclass.equals(BAMCompress.class)){
-			parser.accepts("compressLevel",Messages.getMessage("COMPRESS_LEVEL_DESCRIPTION") ).withRequiredArg().ofType(Integer.class).describedAs("[0,9]");
-		}
+        parser.acceptsAll(asList("i", "input"), INPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("input");
+        parser.acceptsAll(asList("o", "output"), OUTPUT_DESCRIPTION).withRequiredArg().ofType(String.class).describedAs("outputfile");
+        parser.accepts("log", Messages.getMessage("LOG_OPTION_DESCRIPTION")).withRequiredArg().ofType(String.class).describedAs("logfile");
+        parser.accepts("loglevel", Messages.getMessage("LOGLEVEL_OPTION_DESCRIPTION")).withRequiredArg().ofType(String.class).describedAs("loglevel");
 
- 		
-		//else if( myclass.equals(BamMismatchCounts.class)){}
-		
-		options = parser.parse(args);
-		
-		List inputList = options.valuesOf("input");
-		inputFileNames = new String[inputList.size()];
-		inputList.toArray(inputFileNames);
+        if (myclass.equals(AlignerCompare.class)) {
+            parser.accepts("compareAll", Messages.getMessage("COMPAREALL_OPTION"));
+            parser.acceptsAll(asList("o", "output"), Messages.getMessage("OUTPUT_AlignerCompare")).withRequiredArg().ofType(String.class).describedAs("output");
+        } else if (myclass.equals(SubSample.class)) {
+            parser.accepts("proportion", Messages.getMessage("PROPORTION_OPTION_DESCRIPTION")).withRequiredArg().ofType(Double.class).describedAs("[0,1]");
+        } else if (myclass.equals(BAMCompress.class)) {
+            parser.accepts("compressLevel", Messages.getMessage("COMPRESS_LEVEL_DESCRIPTION")).withRequiredArg().ofType(Integer.class).describedAs("[0,9]");
+        }
 
-		List outputList = options.valuesOf("output");
-		outputFileNames = new String[outputList.size()];
-		outputList.toArray(outputFileNames);		
-		
-	}
-	
-	public String getTumour() {
-		return tumour;
-	}
 
-	public void setTumour(String tumour) {
-		this.tumour = tumour;
-	}
+        //else if( myclass.equals(BamMismatchCounts.class)){}
 
-	public String getNormal() {
-		return normal;
-	}
+        options = parser.parse(args);
 
-	public void setNormal(String normal) {
-		this.normal = normal;
-	}
+        List inputList = options.valuesOf("input");
+        inputFileNames = new String[inputList.size()];
+        inputList.toArray(inputFileNames);
 
-	public String getAnalysis() {
-		return analysis;
-	}
+        List outputList = options.valuesOf("output");
+        outputFileNames = new String[outputList.size()];
+        outputList.toArray(outputFileNames);
 
-	public void setAnalysis(String analysis) {
-		this.analysis = analysis;
-	}
+    }
 
-	/**
-	 * Checks for input option.
-	 *
-	 * @return true, if successful
-	 */
-	public boolean hasInputOption() {
-		return options.has("input");
-	}
+    public String getTumour() {
+        return tumour;
+    }
 
-	/**
-	 * Checks for output option.
-	 *
-	 * @return true, if successful
-	 */
-	public boolean hasOutputOption() {
-		return options.has("o") || options.has("output");
-	}
+    public void setTumour(String tumour) {
+        this.tumour = tumour;
+    }
 
-	/**
-	 * Checks for version option.
-	 *
-	 * @return true, if successful
-	 */
-	public boolean hasVersionOption() {
-		return options.has("version");
-	}
-	
-	public boolean getIncludeInvalid() {
-		return options.has("verifiedInvalid");
-	}
+    public String getNormal() {
+        return normal;
+    }
 
-	/**
-	 * Checks for help option.
-	 *
-	 * @return true, if successful
-	 */
-	public boolean hasHelpOption() {
-		return options.has("help");
-	}
-	
-	public boolean hasCompareAllOption() {
-		return options.has("compareAll");
-	}
-	
-	/**
-	 * Checks for log option.
-	 *
-	 * @return true, if successful
-	 */
-	public boolean hasLogOption() {
-		return options.has("log");
-	}
+    public void setNormal(String normal) {
+        this.normal = normal;
+    }
 
-	/**
-	 * Checks for non options.
-	 *
-	 * @return true, if successful
-	 */
-	public boolean hasNonOptions() {
-		return 0 != options.nonOptionArguments().size();
-	}
+    public String getAnalysis() {
+        return analysis;
+    }
 
-	/**
-	 * Gets the input file names.
-	 *
-	 * @return the input file names
-	 */
-	public String[] getInputFileNames() {
-		return inputFileNames;
-	}
+    public void setAnalysis(String analysis) {
+        this.analysis = analysis;
+    }
 
-	/**
-	 * Gets the output file names.
-	 *
-	 * @return the output file names
-	 */
-	public String[] getOutputFileNames() {
-		return outputFileNames;
-	}
+    /**
+     * Checks for input option.
+     *
+     * @return true, if successful
+     */
+    public boolean hasInputOption() {
+        return options.has("input");
+    }
 
-	/**
-	 * Gets the command line.
-	 *
-	 * @return the command line
-	 */
-	public String getCommandLine() {
-		return commandLine;
-	}
-	
-	public boolean hasStrandedOption() {
-		return options.has("stranded");
-	}
-	
-	public String getPosition() {
-		return position;
-	}
-	public String getPileupFormat() {
-		return pileupFormat;
-	}
-	public int getNormalCoverage() {
-		return normalCoverage;
-	}
-	public int getTumourCoverage() {
-		return tumourCoverage;
-	}
-	public int getMinCoverage() {
-		return minCoverage;
-	}
-	public int getNumberOfThreads() {
-		return numberOfThreads;
-	}
-	public String getMafMode() {
-		return mafMode;
-	}
-	public String getGffFile() {
-		return gff;
-	}
-	public String getFastaFile() {
-		return fasta;
-	}
-	
-	public String getMode() {
-		return mode;
-	}
+    /**
+     * Checks for output option.
+     *
+     * @return true, if successful
+     */
+    public boolean hasOutputOption() {
+        return options.has("o") || options.has("output");
+    }
 
-	public int getcompressLevel() throws Exception{
-		if(options.has("compressLevel")){
-			int l = (int) options.valueOf("compressLevel");
-			if(l >= 0 && l <= 9)
-				return l;
-			else
-				throw new Exception("compressLevel must between [0,9]");
-		}
-		
-		return 5;
-	}
-	//subSample
-	public double getPROPORTION() throws Exception{
-		if(options.has("proportion")){	
-			
- 			double prop =  (double) options.valueOf("proportion");
+    /**
+     * Checks for version option.
+     *
+     * @return true, if successful
+     */
+    public boolean hasVersionOption() {
+        return options.has("version");
+    }
+
+    public boolean getIncludeInvalid() {
+        return options.has("verifiedInvalid");
+    }
+
+    /**
+     * Checks for help option.
+     *
+     * @return true, if successful
+     */
+    public boolean hasHelpOption() {
+        return options.has("help");
+    }
+
+    public boolean hasCompareAllOption() {
+        return options.has("compareAll");
+    }
+
+    /**
+     * Checks for log option.
+     *
+     * @return true, if successful
+     */
+    public boolean hasLogOption() {
+        return options.has("log");
+    }
+
+    /**
+     * Checks for non options.
+     *
+     * @return true, if successful
+     */
+    public boolean hasNonOptions() {
+        return 0 != options.nonOptionArguments().size();
+    }
+
+    /**
+     * Gets the input file names.
+     *
+     * @return the input file names
+     */
+    public String[] getInputFileNames() {
+        return inputFileNames;
+    }
+
+    /**
+     * Gets the output file names.
+     *
+     * @return the output file names
+     */
+    public String[] getOutputFileNames() {
+        return outputFileNames;
+    }
+
+    /**
+     * Gets the command line.
+     *
+     * @return the command line
+     */
+    public String getCommandLine() {
+        return commandLine;
+    }
+
+    public boolean hasStrandedOption() {
+        return options.has("stranded");
+    }
+
+    public String getPosition() {
+        return position;
+    }
+
+    public String getPileupFormat() {
+        return pileupFormat;
+    }
+
+    public int getNormalCoverage() {
+        return normalCoverage;
+    }
+
+    public int getTumourCoverage() {
+        return tumourCoverage;
+    }
+
+    public int getMinCoverage() {
+        return minCoverage;
+    }
+
+    public int getNumberOfThreads() {
+        return numberOfThreads;
+    }
+
+    public String getMafMode() {
+        return mafMode;
+    }
+
+    public String getGffFile() {
+        return gff;
+    }
+
+    public String getFastaFile() {
+        return fasta;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public int getcompressLevel() throws Exception {
+        if (options.has("compressLevel")) {
+            int l = (int) options.valueOf("compressLevel");
+            if (l >= 0 && l <= 9)
+                return l;
+            else
+                throw new Exception("compressLevel must between [0,9]");
+        }
+
+        return 5;
+    }
+
+    //subSample
+    public double getPROPORTION() throws Exception {
+        if (options.has("proportion")) {
+
+            double prop = (double) options.valueOf("proportion");
 //			double prop = Double.parseDouble(  (String) options.valueOf("proportion")  );
-			if(prop > 0 && prop <= 1){
- 				return  prop;
-				
-			} 
-		}		
-		throw new Exception("no proportion are specified"); 
-	}
-	
+            if (prop > 0 && prop <= 1) {
+                return prop;
 
-	/**
-	 * Display help.
-	 *
-	 * @throws Exception the exception
-	 */
-	public void displayHelp() throws IOException {
-		parser.printHelpOn(System.out);
-	}
+            }
+        }
+        throw new Exception("no proportion are specified");
+    }
 
-	/**
-	 * Detect bad options.
-	 *
-	 * @throws Exception the exception
-	 */
-	public void detectBadOptions() throws Exception {
-		if (hasNonOptions()) {
-			throw new Exception("ALL_ARGUMENTS_MUST_BE_OPTIONS");
-		}
-		if (hasOutputOption() && 1 != getOutputFileNames().length) {
-			throw new Exception("MULTIPLE_OUTPUT_FILES_SPECIFIED");
-		}
-		if (!hasInputOption()) {
-			throw new Exception("MISSING_INPUT_OPTIONS");
-		}
-	}
 
-	public String getLogFile(){	 		
-		return logFile;
-	}
+    /**
+     * Display help.
+     *
+     * @throws Exception the exception
+     */
+    public void displayHelp() throws IOException {
+        parser.printHelpOn(System.out);
+    }
 
-	public String getLogLevel(){ 
-		return logLevel;
-	}
-	
-	public Properties getIds() {
-		Properties props = new Properties();
-		props.put(Ids.PATIENT, patientId);
-		props.put(Ids.SOMATIC_ANALYSIS, somaticAnalysisId);
-		props.put(Ids.GEMLINE_ANALYSIS, germlineAnalysisId);
-		props.put(Ids.NORMAL_SAMPLE, normalSampleId);
-		props.put(Ids.TUMOUR_SAMPLE, tumourSampleId);
-		return props;
-	}
+    /**
+     * Detect bad options.
+     *
+     * @throws Exception the exception
+     */
+    public void detectBadOptions() throws Exception {
+        if (hasNonOptions()) {
+            throw new Exception("ALL_ARGUMENTS_MUST_BE_OPTIONS");
+        }
+        if (hasOutputOption() && 1 != getOutputFileNames().length) {
+            throw new Exception("MULTIPLE_OUTPUT_FILES_SPECIFIED");
+        }
+        if (!hasInputOption()) {
+            throw new Exception("MISSING_INPUT_OPTIONS");
+        }
+    }
 
-	public String[] getGffRegions() {
-		
-		return gffRegions;
-	}
+    public String getLogFile() {
+        return logFile;
+    }
 
-	public int getNoOfBases() {
-		
-		return noOfBases;
-	}
+    public String getLogLevel() {
+        return logLevel;
+    }
 
-	public String getColumn() {
-		return column;
-	}
+    public Properties getIds() {
+        Properties props = new Properties();
+        props.put(Ids.PATIENT, patientId);
+        props.put(Ids.SOMATIC_ANALYSIS, somaticAnalysisId);
+        props.put(Ids.GEMLINE_ANALYSIS, germlineAnalysisId);
+        props.put(Ids.NORMAL_SAMPLE, normalSampleId);
+        props.put(Ids.TUMOUR_SAMPLE, tumourSampleId);
+        return props;
+    }
 
-	public String getAnnotation() {
-		return annotation;
-	}
+    public String[] getGffRegions() {
 
-	public String[] getFeature() {
-		if (features != null) {
-		return features.split(",");
-		} 
-		return null;		
-	}
+        return gffRegions;
+    }
+
+    public int getNoOfBases() {
+
+        return noOfBases;
+    }
+
+    public String getColumn() {
+        return column;
+    }
+
+    public String getAnnotation() {
+        return annotation;
+    }
+
+    public String[] getFeature() {
+        if (features != null) {
+            return features.split(",");
+        }
+        return null;
+    }
 
 }

--- a/qmule/test/org/qcmg/qmule/AlignerCompareTest.java
+++ b/qmule/test/org/qcmg/qmule/AlignerCompareTest.java
@@ -1,118 +1,115 @@
 package org.qcmg.qmule;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SAMFileWriter;
-import htsjdk.samtools.SAMRecord;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.qcmg.picard.SAMFileReaderFactory;
-import org.qcmg.picard.SAMWriterFactory;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class AlignerCompareTest {
-	public static final String INPUT_SAM1 = "./input1.sam";	
-	public static final String INPUT_SAM2 = "./input2.sam";	
-	public static final String OUTPUT_BAM = "./output.bam";	
-	
-	@After
-	public void deleteFiles(){ 
-		//delete inputs
-		File in1 = new File(INPUT_SAM1);
-		File in2 = new File(INPUT_SAM2);				
-		in1.delete();
-		in2.delete();
+    public static final String INPUT_SAM1 = "./input1.sam";
+    public static final String INPUT_SAM2 = "./input2.sam";
+    public static final String OUTPUT_BAM = "./output.bam";
 
-		//delete output
-		File[] files = new File("./").listFiles();
-		for(File f :  files)
-			if(f.toString().startsWith(OUTPUT_BAM))
+    @After
+    public void deleteFiles() {
+        //delete inputs
+        File in1 = new File(INPUT_SAM1);
+        File in2 = new File(INPUT_SAM2);
+        in1.delete();
+        in2.delete();
+
+        //delete output
+        File[] files = new File("./").listFiles();
+        assert files != null;
+        for (File f : files) {
+			if (f.toString().startsWith(OUTPUT_BAM)) {
 				f.delete();
-			
-	}
-	
-	@Before
-	public void before(){		 
-		CreateSAMs( );	
-	}
-	
-	
- 
-	@Test
-	public void mainTest() throws Exception{
-  
-  		final String[] args1 = { "-i", INPUT_SAM1, "-i", INPUT_SAM2, "-o", OUTPUT_BAM };
-		AlignerCompare.main(args1);
-		
-	}
-	
-	
-	public static void CreateSAMs(){
-		List<String> mydata = new ArrayList<String>();
-		
-		//common
-		mydata.add("@HD	VN:1.4	SO:queryname");  
-		mydata.add("@SQ	SN:GL000196.1	LN:38914");
-		
-		mydata.add("@RG	ID:2010072264129530	LB:Library_20100413_C	DS:RUNTYPE{50F}	SM:S0414_20100607_2_FragBC_bcSample1_F3_bcA10_05");
-		mydata.add("@PG	ID:2010072264129500	PN:MANUAL");
-		mydata.add("603_1107_1232	0	GL000196.1	480	1	25M25H	*	0	0	AATCACTTGAACCCAGGAGGCGGAG	IIIIIIIIIIIIIIIIIIIIIIII:	RG:Z:2010072264129530	CS:Z:T30321120120100120220330223100133302310303131133123	AS:i:24	CQ:Z:BBBB@AAA>><>B@;9AA<:BB=@>:AB<<=@9@7'9<22>?921<:/'1	XN:i:24	NH:i:10	IH:i:2	HI:i:1	CC:Z:GL000247.1	CP:i:35405	MD:Z:25");
- 		mydata.add("603_1107_1233	163	GL000196.1	36008	29	75M	=	36083	142	GGATCTAGAATGCTGAAGGATCTAGTGTGTTGAGGGATCTAGCATGCTGAAGGATCTAGCATGTTAAGGGATCTA	BBBFFFFFFFFFFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFI	X0:i:1	X1:i:0	ZC:i:5	MD:Z:8G66	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:U");
- 		mydata.add("603_1107_1233	83	GL000196.1	36083	29	4S67M4S	=	36008	-142	TCTAGCATGTCGAGAGATCTAGCATGCTGAAGGATCTAGCATGCTGAAGGATCTAGCATGTTGAGGGTTCTAGTG	FFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFFFFFFFBBB	ZC:i:5	MD:Z:63A3	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:M");
-//??    mydata.add("603_1107_1233	87	GL000196.1	36083	29	4S67M4S	=	36008	-142	TCTAGCATGTCGAGAGATCTAGCATGCTGAAGGATCTAGCATGCTGAAGGATCTAGCATGTTGAGGGTTCTAGTG	FFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFFFFFFFBBB	ZC:i:5	MD:Z:63A3	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:M");
-
- 		mydata.add("603_1108_0001	0	GL000196.1	38525	3	37M5D13H	*	0	0	AGGCTGAGGTGGGCGGATCACTTGAGGTCCAGAGTTC	IIIIIIIIIIIIIIIII;?IIIB@IIIBAIIIIIIII	RG:Z:2010072264129530	CS:Z:T32032122011003302321120122012012221023222003301200	AS:i:30	CQ:Z:<?=?8?9<<=@?<@@?@5'96<:)8;?9*8@?:7B?@<:A@;<+?0-8:8	XN:i:28	NH:i:10	IH:i:2	HI:i:2	MD:Z:29C7");
-
- 		List<String> mydata1 = new ArrayList<String>();
- 		mydata1.add("603_1108_0002	73	GL000196.1	319	3	50M	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA" + 	"	X0:i:1	X1:i:0	MD:Z:100	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:0	NM:i:0	SM:i:37	XM:i:0	XO:i:0	XT:A:U");
- 		mydata1.add("603_1108_0002	133	GL000196.1	319	0	*	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530	CS:Z:T22012220200333113323133321010013112111011113333112	AS:i:34	CQ:Z:/3:8@62B-*46?-A+B;'A'<9+-/@@6.'@B4,/;@2=+@B)>/?B@A	XN:i:34	HI:i:2");
-
- 		List<String> mydata2 = new ArrayList<String>();
- 		mydata2.add("603_1108_0002	73	GL000196.1	319	3	50M	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530	CS:Z:T22012220200333113323133321010013112111011113333112	AS:i:34	CQ:Z:/3:8@62B-*46?-A+B;'A'<9+-/@@6.'@B4,/;@2=+@B)>/?B@A	XN:i:34	NH:i:2	IH:i:2	HI:i:2	MD:Z:26T3CG18");
-		mydata2.add("603_1108_0002	133	GL000196.1	319	0	*	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530");
-		
- 		//add invalide record since mapq is not zero for unmapped reads
-		
-		try {
-
-			BufferedWriter writer1 = new BufferedWriter(new FileWriter(INPUT_SAM1));
-			BufferedWriter writer2 = new BufferedWriter(new FileWriter(INPUT_SAM2));
-			
-			//create SAM 
-			for (String line : mydata){ 
-				writer1.write(line + "\n");	
-				writer2.write(line + "\n");
 			}
-			
-			for (String line : mydata1) 
-				writer1.write(line + "\n");	
-			
-			for (String line : mydata2) 
-				writer2.write(line + "\n");	
-
-			
-			writer1.close();
-			writer2.close();
- 			
-		} catch (IOException e) {
-			System.err.println(e.toString() + "\n\t can't write to : " + INPUT_SAM1 + " or " + INPUT_SAM2   );
 		}
-		
+
+    }
+
+    @Before
+    public void before() {
+        createSAMs();
+    }
+
+    @Test
+    public void mainTest() throws Exception {
+
+        final String[] args1 = {"-i", INPUT_SAM1, "-i", INPUT_SAM2, "-o", OUTPUT_BAM};
+        AlignerCompare.main(args1);
+    }
+
+    public static void createSAMs() {
+		List<String> myData = getMyData();
+
+		List<String> myData1 = getMyData1();
+
+		List<String> myData2 = getMyData2();
+
+		//add invalid record since mapq is not zero for unmapped reads
+
+        try {
+
+            BufferedWriter writer1 = new BufferedWriter(new FileWriter(INPUT_SAM1));
+            BufferedWriter writer2 = new BufferedWriter(new FileWriter(INPUT_SAM2));
+
+            //create SAM
+            for (String line : myData) {
+                writer1.write(line + "\n");
+                writer2.write(line + "\n");
+            }
+
+            for (String line : myData1)
+                writer1.write(line + "\n");
+
+            for (String line : myData2)
+                writer2.write(line + "\n");
+
+            writer1.close();
+            writer2.close();
+
+        } catch (IOException e) {
+            System.err.println(e + "\n\t can't write to : " + INPUT_SAM1 + " or " + INPUT_SAM2);
+        }
+    }
+
+	private static List<String> getMyData2() {
+		List<String> mydata2 = new ArrayList<>();
+		mydata2.add("603_1108_0002	73	GL000196.1	319	3	50M	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530	CS:Z:T22012220200333113323133321010013112111011113333112	AS:i:34	CQ:Z:/3:8@62B-*46?-A+B;'A'<9+-/@@6.'@B4,/;@2=+@B)>/?B@A	XN:i:34	NH:i:2	IH:i:2	HI:i:2	MD:Z:26T3CG18");
+		mydata2.add("603_1108_0002	133	GL000196.1	319	0	*	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530");
+		return mydata2;
 	}
-	
-	 
+
+	private static List<String> getMyData1() {
+		List<String> mydata1 = new ArrayList<>();
+		mydata1.add("603_1108_0002	73	GL000196.1	319	3	50M	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA" + "	X0:i:1	X1:i:0	MD:Z:100	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:0	NM:i:0	SM:i:37	XM:i:0	XO:i:0	XT:A:U");
+		mydata1.add("603_1108_0002	133	GL000196.1	319	0	*	=	319	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530	CS:Z:T22012220200333113323133321010013112111011113333112	AS:i:34	CQ:Z:/3:8@62B-*46?-A+B;'A'<9+-/@@6.'@B4,/;@2=+@B)>/?B@A	XN:i:34	HI:i:2");
+		return mydata1;
+	}
+
+	private static List<String> getMyData() {
+		List<String> myData = new ArrayList<>();
+
+		//common
+		myData.add("@HD	VN:1.4	SO:queryname");
+		myData.add("@SQ	SN:GL000196.1	LN:38914");
+
+		myData.add("@RG	ID:2010072264129530	LB:Library_20100413_C	DS:RUNTYPE{50F}	SM:S0414_20100607_2_FragBC_bcSample1_F3_bcA10_05");
+		myData.add("@PG	ID:2010072264129500	PN:MANUAL");
+		myData.add("603_1107_1232	0	GL000196.1	480	1	25M25H	*	0	0	AATCACTTGAACCCAGGAGGCGGAG	IIIIIIIIIIIIIIIIIIIIIIII:	RG:Z:2010072264129530	CS:Z:T30321120120100120220330223100133302310303131133123	AS:i:24	CQ:Z:BBBB@AAA>><>B@;9AA<:BB=@>:AB<<=@9@7'9<22>?921<:/'1	XN:i:24	NH:i:10	IH:i:2	HI:i:1	CC:Z:GL000247.1	CP:i:35405	MD:Z:25");
+		myData.add("603_1107_1233	163	GL000196.1	36008	29	75M	=	36083	142	GGATCTAGAATGCTGAAGGATCTAGTGTGTTGAGGGATCTAGCATGCTGAAGGATCTAGCATGTTAAGGGATCTA	BBBFFFFFFFFFFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFI	X0:i:1	X1:i:0	ZC:i:5	MD:Z:8G66	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:U");
+		myData.add("603_1107_1233	83	GL000196.1	36083	29	4S67M4S	=	36008	-142	TCTAGCATGTCGAGAGATCTAGCATGCTGAAGGATCTAGCATGCTGAAGGATCTAGCATGTTGAGGGTTCTAGTG	FFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFFFFFFFBBB	ZC:i:5	MD:Z:63A3	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:M");
+
+		myData.add("603_1108_0001	0	GL000196.1	38525	3	37M5D13H	*	0	0	AGGCTGAGGTGGGCGGATCACTTGAGGTCCAGAGTTC	IIIIIIIIIIIIIIIII;?IIIB@IIIBAIIIIIIII	RG:Z:2010072264129530	CS:Z:T32032122011003302321120122012012221023222003301200	AS:i:30	CQ:Z:<?=?8?9<<=@?<@@?@5'96<:)8;?9*8@?:7B?@<:A@;<+?0-8:8	XN:i:28	NH:i:10	IH:i:2	HI:i:2	MD:Z:29C7");
+		return myData;
+	}
 }

--- a/qmule/test/org/qcmg/qmule/BamCompressTest.java
+++ b/qmule/test/org/qcmg/qmule/BamCompressTest.java
@@ -1,93 +1,73 @@
 package org.qcmg.qmule;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-
-
-import java.util.ArrayList;
-import java.util.List;
-
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SAMFileWriter;
-import htsjdk.samtools.SAMRecord;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.qcmg.picard.SAMFileReaderFactory;
-import org.qcmg.picard.SAMWriterFactory;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class BamCompressTest {
-	public static final String INPUT_SAM = "./input.sam";	
-	public static final String OUTPUT_BAM = "./output.bam";	
-	
-	@After
-	public void deleteFiles(){ 
-		File in = new File(INPUT_SAM);
-		File out = new File(OUTPUT_BAM);
-				
-		in.delete();
-		out.delete();
-		
-	 
-	}
-	
-	@Before
-	public void before(){		 
-		CreateBAM(INPUT_SAM);		
+    public static final String INPUT_SAM = "./input.sam";
+    public static final String OUTPUT_BAM = "./output.bam";
 
-	}
-	
-	@Test
-	public void mainTest() throws Exception{ 
-		final String[] args1 = { "-i", INPUT_SAM, "-o",  OUTPUT_BAM, "--compressLevel", "1" };
-		final String[] args2 = { "-i", INPUT_SAM, "-o",  OUTPUT_BAM, "--compressLevel", "9" };
-		
-		
-		BAMCompress.main(args1);
-		BAMCompress.main(args2);
-		
-	}
-	
-	
-	public static void CreateBAM(String INPUT_SAM ){
-		List<String> mydata = new ArrayList<String>();
-		
-		//common
-		mydata.add("@HD	VN:1.0");  
-		mydata.add("@SQ	SN:GL000196.1	LN:38914");
-		
-		mydata.add("@RG	ID:2010072264129530	LB:Library_20100413_C	DS:RUNTYPE{50F}	SM:S0414_20100607_2_FragBC_bcSample1_F3_bcA10_05");
-		mydata.add("@PG	ID:2010072264129500	PN:MANUAL");
-		mydata.add("1035_217_1202	272	GL000196.1	319	3	50M	*	0	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530	CS:Z:T22012220200333113323133321010013112111011113333112	AS:i:34	CQ:Z:/3:8@62B-*46?-A+B;'A'<9+-/@@6.'@B4,/;@2=+@B)>/?B@A	XN:i:34	NH:i:2	IH:i:2	HI:i:2	MD:Z:26T3CG18");
- 		mydata.add("603_1107_1232	0	GL000196.1	480	1	25M25H	*	0	0	AATCACTTGAACCCAGGAGGCGGAG	IIIIIIIIIIIIIIIIIIIIIIII:	RG:Z:2010072264129530	CS:Z:T30321120120100120220330223100133302310303131133123	AS:i:24	CQ:Z:BBBB@AAA>><>B@;9AA<:BB=@>:AB<<=@9@7'9<22>?921<:/'1	XN:i:24	NH:i:10	IH:i:2	HI:i:1	CC:Z:GL000247.1	CP:i:35405	MD:Z:25");
- 		mydata.add("828_1019_1921	0	GL000196.1	38525	3	37M5D13H	*	0	0	AGGCTGAGGTGGGCGGATCACTTGAGGTCCAGAGTTC	IIIIIIIIIIIIIIIII;?IIIB@IIIBAIIIIIIII	RG:Z:2010072264129530	CS:Z:T32032122011003302321120122012012221023222003301200	AS:i:30	CQ:Z:<?=?8?9<<=@?<@@?@5'96<:)8;?9*8@?:7B?@<:A@;<+?0-8:8	XN:i:28	NH:i:10	IH:i:2	HI:i:2	MD:Z:29C7");
- 		
- 		//add invalide record since mapq is not zero for unmapped reads
- 		mydata.add("HWI-ST1240:142:H089FADXX:2:1107:3855:25088	163	GL000196.1	36008	29	75M	=	36083	142	GGATCTAGAATGCTGAAGGATCTAGTGTGTTGAGGGATCTAGCATGCTGAAGGATCTAGCATGTTAAGGGATCTA	BBBFFFFFFFFFFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFI	X0:i:1	X1:i:0	ZC:i:5	MD:Z:8G66	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:U");
-//?? 		mydata.add("HWI-ST1240:142:H089FADXX:2:1107:3855:25088	87	GL000196.1	36083	29	4S67M4S	=	36008	-142	TCTAGCATGTCGAGAGATCTAGCATGCTGAAGGATCTAGCATGCTGAAGGATCTAGCATGTTGAGGGTTCTAGTG	FFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFFFFFFFBBB	ZC:i:5	MD:Z:63A3	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:M");
- 		mydata.add("HWI-ST1240:142:H089FADXX:2:1107:3855:25088	83	GL000196.1	36083	29	4S67M4S	=	36008	-142	TCTAGCATGTCGAGAGATCTAGCATGCTGAAGGATCTAGCATGCTGAAGGATCTAGCATGTTGAGGGTTCTAGTG	FFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFFFFFFFBBB	ZC:i:5	MD:Z:63A3	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:M");
- 		
-		try {
+    @After
+    public void deleteFiles() {
+        File in = new File(INPUT_SAM);
+        File out = new File(OUTPUT_BAM);
 
-			BufferedWriter writer = new BufferedWriter(new FileWriter(INPUT_SAM));
-			
-			//create SAM
-			for (String line : mydata) 
-				writer.write(line + "\n");			 
-			writer.close();
- 			
-		} catch (IOException e) {
-			System.err.println(e.toString() + "\n\t can't write to : " + INPUT_SAM   );
-		}
-		
-	}
-	
-	 
+        in.delete();
+        out.delete();
+    }
+
+    @Before
+    public void before() {
+        createBAM(INPUT_SAM);
+    }
+
+    @Test
+    public void mainTest() throws Exception {
+        final String[] args1 = {"-i", INPUT_SAM, "-o", OUTPUT_BAM, "--compressLevel", "1"};
+        final String[] args2 = {"-i", INPUT_SAM, "-o", OUTPUT_BAM, "--compressLevel", "9"};
+
+        BAMCompress.main(args1);
+        BAMCompress.main(args2);
+    }
+
+    public static void createBAM(String INPUT_SAM) {
+        List<String> mydata = new ArrayList<>();
+
+        //common
+        mydata.add("@HD	VN:1.0");
+        mydata.add("@SQ	SN:GL000196.1	LN:38914");
+
+        mydata.add("@RG	ID:2010072264129530	LB:Library_20100413_C	DS:RUNTYPE{50F}	SM:S0414_20100607_2_FragBC_bcSample1_F3_bcA10_05");
+        mydata.add("@PG	ID:2010072264129500	PN:MANUAL");
+        mydata.add("1035_217_1202	272	GL000196.1	319	3	50M	*	0	0	GACATATACACAACACTGTACCCAACTATACGATACATATTCTTCTCAAG	!IIIIIFIIIGIIII:?IIF4CIII;7CI''''IIIIIII**IIGIIIIA	RG:Z:2010072264129530	CS:Z:T22012220200333113323133321010013112111011113333112	AS:i:34	CQ:Z:/3:8@62B-*46?-A+B;'A'<9+-/@@6.'@B4,/;@2=+@B)>/?B@A	XN:i:34	NH:i:2	IH:i:2	HI:i:2	MD:Z:26T3CG18");
+        mydata.add("603_1107_1232	0	GL000196.1	480	1	25M25H	*	0	0	AATCACTTGAACCCAGGAGGCGGAG	IIIIIIIIIIIIIIIIIIIIIIII:	RG:Z:2010072264129530	CS:Z:T30321120120100120220330223100133302310303131133123	AS:i:24	CQ:Z:BBBB@AAA>><>B@;9AA<:BB=@>:AB<<=@9@7'9<22>?921<:/'1	XN:i:24	NH:i:10	IH:i:2	HI:i:1	CC:Z:GL000247.1	CP:i:35405	MD:Z:25");
+        mydata.add("828_1019_1921	0	GL000196.1	38525	3	37M5D13H	*	0	0	AGGCTGAGGTGGGCGGATCACTTGAGGTCCAGAGTTC	IIIIIIIIIIIIIIIII;?IIIB@IIIBAIIIIIIII	RG:Z:2010072264129530	CS:Z:T32032122011003302321120122012012221023222003301200	AS:i:30	CQ:Z:<?=?8?9<<=@?<@@?@5'96<:)8;?9*8@?:7B?@<:A@;<+?0-8:8	XN:i:28	NH:i:10	IH:i:2	HI:i:2	MD:Z:29C7");
+
+        //add invalid record since mapq is not zero for unmapped reads
+        mydata.add("HWI-ST1240:142:H089FADXX:2:1107:3855:25088	163	GL000196.1	36008	29	75M	=	36083	142	GGATCTAGAATGCTGAAGGATCTAGTGTGTTGAGGGATCTAGCATGCTGAAGGATCTAGCATGTTAAGGGATCTA	BBBFFFFFFFFFFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFI	X0:i:1	X1:i:0	ZC:i:5	MD:Z:8G66	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:U");
+        mydata.add("HWI-ST1240:142:H089FADXX:2:1107:3855:25088	83	GL000196.1	36083	29	4S67M4S	=	36008	-142	TCTAGCATGTCGAGAGATCTAGCATGCTGAAGGATCTAGCATGCTGAAGGATCTAGCATGTTGAGGGTTCTAGTG	FFIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFFFFFFFFFFBBB	ZC:i:5	MD:Z:63A3	PG:Z:MarkDuplicates	RG:Z:2010072264129530	XG:i:0	AM:i:29	NM:i:1	SM:i:29	XM:i:1	XO:i:0	XT:A:M");
+
+        try {
+
+            BufferedWriter writer = new BufferedWriter(new FileWriter(INPUT_SAM));
+
+            //create SAM
+            for (String line : mydata) {
+				writer.write(line + "\n");
+			}
+            writer.close();
+
+        } catch (IOException e) {
+            System.err.println(e + "\n\t can't write to : " + INPUT_SAM);
+        }
+    }
 }

--- a/qmule/test/org/qcmg/qmule/FixCutAdapterTest.java
+++ b/qmule/test/org/qcmg/qmule/FixCutAdapterTest.java
@@ -1,6 +1,14 @@
 package org.qcmg.qmule;
 
-import static org.junit.Assert.assertEquals;
+import htsjdk.samtools.fastq.FastqReader;
+import htsjdk.samtools.fastq.FastqRecord;
+import htsjdk.samtools.fastq.FastqWriter;
+import htsjdk.samtools.fastq.FastqWriterFactory;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.commandline.Executor;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -9,92 +17,91 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.qcmg.common.commandline.Executor;
-
-import htsjdk.samtools.fastq.FastqReader;
-import htsjdk.samtools.fastq.FastqRecord;
-import htsjdk.samtools.fastq.FastqWriter;
-import htsjdk.samtools.fastq.FastqWriterFactory;
+import static org.junit.Assert.assertEquals;
 
 public class FixCutAdapterTest {
-	
-	
-	@ClassRule
-	public static TemporaryFolder testFolder = new TemporaryFolder();
-	public static File INPUT;
-	public static File OUTPUT;
-	
-	private final static FastqRecord r1 = new FastqRecord("ST-E00129:529:HF5FTALXX:4:2206:13200:50656 1:N:0:TCCGCGAA", "ATGCATGC","", "AAFFFJJJ");
-	private final static FastqRecord r2 = new FastqRecord("ST-E00129:529:HF5FTALXX:4:2206:15899:50656", "","", "");
-	private final static FastqRecord r3 = new FastqRecord("others", "ATGCATGC","", "");
-	
-	@BeforeClass
-	public static void setup() throws IOException {
-		INPUT = testFolder.newFile("input.fastq");	
-		OUTPUT = testFolder.newFile("output.fastq");
-		
-		ArrayList<FastqRecord> data = new ArrayList<>(Arrays.asList( r1,r2,r3 ) );	
-	    try( FastqWriter writer = (new FastqWriterFactory()).newWriter(INPUT);) {			 
-			 for (FastqRecord re : data)  writer.write(re);      	
-	    }  
-	}
-	
-	private int execute() throws Exception {
-		String command = " -I " + INPUT.getAbsolutePath() + " -O " + OUTPUT.getAbsolutePath();
-		return (new Executor(command, "org.qcmg.qmule.FixCutAdapter")).getErrCode();
-	}
-	
-	@Test
-	public void stdTest() throws Exception{		
-		String command = " -I " + INPUT.getAbsolutePath();		
-		assertEquals(0 ,(new Executor(command, "org.qcmg.qmule.FixCutAdapter")).getErrCode());
-	}
-		
-	@Test
-	public void inValidTest() throws Exception{
-  		
-		//different length bwt seq and qual  
-		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\nATGC\n+\nA");	} 		
-		assertEquals(0 , execute());
-		
-		//missing qual 
-		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\nATGC\n");	} 
-		assertEquals(1 , execute());
-		
-		//two seq line
-		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\n\nATGC\n+\nA");	} 		
-		assertEquals(1 , execute());
-		
-		//two records but one is wrong
-		try(BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) { out.write("@f1\nATGC\n+\nA\n@f2\nATGC\n");	} 
-		assertEquals(1 , execute());		
-	}
-	
-	@Test
-	public void emptyTest() throws Exception{
-		
-		assertEquals(0 , execute());
-		
-		int i = 0;
-		try (FastqReader reader =  new FastqReader(OUTPUT)) {
-			for (FastqRecord record : reader) {								
-				if(record.equals(r1)) assertEquals(0 , i); // first record are same
-				else if(record.getReadName().equals(r2.getReadName())) {
-					//second record
-					assertEquals(1 , i); 
-					assertEquals(record.getReadString() , "N");  
-                	assertEquals(record.getBaseQualityString(), "!");
-				} else {
-					//third record
-					assertEquals(2 , i); 
-					assertEquals(record.toFastQString() , "@others\nN\n+\n!"); 
- 				}
-				i ++;				
-			}			
-		}
- 	}
+
+
+    @ClassRule
+    public static TemporaryFolder testFolder = new TemporaryFolder();
+    public static File INPUT;
+    public static File OUTPUT;
+
+    private final static FastqRecord r1 = new FastqRecord("ST-E00129:529:HF5FTALXX:4:2206:13200:50656 1:N:0:TCCGCGAA", "ATGCATGC", "", "AAFFFJJJ");
+    private final static FastqRecord r2 = new FastqRecord("ST-E00129:529:HF5FTALXX:4:2206:15899:50656", "", "", "");
+    private final static FastqRecord r3 = new FastqRecord("others", "ATGCATGC", "", "");
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        INPUT = testFolder.newFile("input.fastq");
+        OUTPUT = testFolder.newFile("output.fastq");
+
+        ArrayList<FastqRecord> data = new ArrayList<>(Arrays.asList(r1, r2, r3));
+        try (FastqWriter writer = (new FastqWriterFactory()).newWriter(INPUT)) {
+            for (FastqRecord re : data) writer.write(re);
+        }
+    }
+
+    private int execute() throws Exception {
+        String command = "-I " + INPUT.getAbsolutePath() + " -O " + OUTPUT.getAbsolutePath();
+        return (new Executor(command, "org.qcmg.qmule.FixCutAdapter")).getErrCode();
+    }
+
+    @Test
+    public void stdTest() throws Exception {
+        String command = "-I " + INPUT.getAbsolutePath();
+        assertEquals(0, (new Executor(command, "org.qcmg.qmule.FixCutAdapter")).getErrCode());
+    }
+
+    @Test
+    public void inValidTest() throws Exception {
+
+        //different length bwt seq and qual
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) {
+            out.write("@f1\nATGC\n+\nA");
+        }
+        assertEquals(0, execute());
+
+        //missing qual
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) {
+            out.write("@f1\nATGC\n");
+        }
+        assertEquals(1, execute());
+
+        //two seq line
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) {
+            out.write("@f1\n\nATGC\n+\nA");
+        }
+        assertEquals(1, execute());
+
+        //two records but one is wrong
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(INPUT))) {
+            out.write("@f1\nATGC\n+\nA\n@f2\nATGC\n");
+        }
+        assertEquals(1, execute());
+    }
+
+    @Test
+    public void emptyTest() throws Exception {
+
+        assertEquals(0, execute());
+
+        int i = 0;
+        try (FastqReader reader = new FastqReader(OUTPUT)) {
+            for (FastqRecord record : reader) {
+                if (record.equals(r1)) assertEquals(0, i); // first record are same
+                else if (record.getReadName().equals(r2.getReadName())) {
+                    //second record
+                    assertEquals(1, i);
+                    assertEquals(record.getReadString(), "N");
+                    assertEquals(record.getBaseQualityString(), "!");
+                } else {
+                    //third record
+                    assertEquals(2, i);
+                    assertEquals(record.toFastQString(), "@others\nN\n+\n!");
+                }
+                i++;
+            }
+        }
+    }
 }

--- a/qmule/test/org/qcmg/qmule/WiggleFromPileupTakeTwoTest.java
+++ b/qmule/test/org/qcmg/qmule/WiggleFromPileupTakeTwoTest.java
@@ -1,428 +1,221 @@
 package org.qcmg.qmule;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.commandline.Executor;
 import org.qcmg.common.util.FileUtils;
 
-public class WiggleFromPileupTakeTwoTest {
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-	
-	private File pileupFile;
-	private File gff3File;
-	private File wiggleFile;
-	private File pileupFileGZIP;
-	private File wiggleFileGZIP;
-	
-	@Before
-	public final void before() {
-		try {
-			pileupFile = tempFolder.newFile("wigglePileupTest.pileup");
-			wiggleFile = tempFolder.newFile("wigglePileupTest.wiggle");
-			gff3File = tempFolder.newFile("wigglePileupTest.gff3");
-			pileupFileGZIP = tempFolder.newFile("wigglePileupTest.pileup.gz");
-			wiggleFileGZIP = tempFolder.newFile("wigglePileupTest.wiggle.gz");
-			createPileupFile(pileupFile);
-			createPileupFile(pileupFileGZIP);
-			createGFF3File(gff3File);
-			assertTrue(pileupFile.exists());
-			assertTrue(gff3File.exists());
-			assertTrue(pileupFileGZIP.exists());
-		} catch (Exception e) {
-			System.err.println("File creation error in test harness: " + e.getMessage());
-		}
-	}
-	
-	
-//	@Test
-//	public void testIsPositionInBaitSingleGff() {
-//		GFF3Record gff = new GFF3Record();
-//		gff.setSeqId("chr1");
-//		gff.setStart(1);
-//		gff.setEnd(10);
-//		
-//		List<GFF3Record> gffs = new ArrayList<GFF3Record>();
-//		gffs.add(gff);
-//		Iterator<GFF3Record> iter = gffs.iterator();
-////		WiggleFromPileup.setGffRecord(gff);
-//		
-//		Assert.assertEquals(false, WiggleFromPileupTakeTwo.isPositionInBait("chr0", 0, iter, iter.next()));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 0, iter, gff));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff));
-//		
-//		gff.setSeqId("chrX");
-//		gff.setStart(1000123);
-//		gff.setEnd(1000223);
-//		
-////		WiggleFromPileup.setGffRecord(gff);
-//		
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 0, iter, gff));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 1, iter, gff));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrx", 1000124, iter, gff));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrx", 11, iter, gff));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 11, iter, gff));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 1000123, iter, gff));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 1000124, iter, gff));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 1000223, iter, gff));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 1000224, iter, gff));
-//	}
-	
-//	@Test
-//	public void testIsPositionInBaitMultipleGff() {
-//		GFF3Record gff1 = new GFF3Record();
-//		gff1.setSeqId("chr1");
-//		gff1.setStart(1);
-//		gff1.setEnd(10);
-//		GFF3Record gff2 = new GFF3Record();
-//		gff2.setSeqId("chr1");
-//		gff2.setStart(11);
-//		gff2.setEnd(20);
-//		GFF3Record gff3 = new GFF3Record();
-//		gff3.setSeqId("chr1");
-//		gff3.setStart(31);
-//		gff3.setEnd(40);
-//		
-//		List<GFF3Record> gffs = new ArrayList<GFF3Record>();
-//		gffs.add(gff1);
-//		gffs.add(gff2);
-//		gffs.add(gff3);
-//		Iterator<GFF3Record> iter = gffs.iterator();
-//		
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 0, iter, iter.next()));
-//		
-////		Assert.assertEquals(gff1, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff1));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff1));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff1));
-//		// iterator should have been advanced
-//		Assert.assertEquals(gff2, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 20, iter, gff2));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 21, iter, gff2));
-//		// iterator should have been advanced
-//		Assert.assertEquals(gff3, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 29, iter, gff3));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 31, iter, gff3));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 40, iter, gff3));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 41, iter, gff3));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 141, iter, gff3));
-//	}
-	
-//	@Test
-//	public void testIsPositionInBaitMultipleGffMultipleChromosomes() {
-//		GFF3Record gff1 = new GFF3Record();
-//		gff1.setSeqId("chr1");
-//		gff1.setStart(1);
-//		gff1.setEnd(10);
-//		GFF3Record gff2 = new GFF3Record();
-//		gff2.setSeqId("chr1");
-//		gff2.setStart(11);
-//		gff2.setEnd(20);
-//		GFF3Record gff3 = new GFF3Record();
-//		gff3.setSeqId("chr1");
-//		gff3.setStart(31);
-//		gff3.setEnd(40);
-//		GFF3Record gff4 = new GFF3Record();
-//		gff4.setSeqId("chr2");
-//		gff4.setStart(15);
-//		gff4.setEnd(25);
-//		GFF3Record gff5 = new GFF3Record();
-//		gff5.setSeqId("chr2");
-//		gff5.setStart(26);
-//		gff5.setEnd(40);
-//		GFF3Record gff6 = new GFF3Record();
-//		gff6.setSeqId("chrX");
-//		gff6.setStart(100026);
-//		gff6.setEnd(100040);
-//		
-//		List<GFF3Record> gffs = new ArrayList<GFF3Record>();
-//		gffs.add(gff1);
-//		gffs.add(gff2);
-//		gffs.add(gff3);
-//		gffs.add(gff4);
-//		gffs.add(gff5);
-//		gffs.add(gff6);
-//		Iterator<GFF3Record> iter = gffs.iterator();
-//		
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr0", 0, iter, iter.next()));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 0, iter, gff1));
-//		
-////		Assert.assertEquals(gff1, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff1));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff1));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff1));
-//		// iterator should have been advanced
-//		Assert.assertEquals(gff2, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 20, iter, gff2));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 21, iter, gff2));
-//		// iterator should have been advanced
-//		Assert.assertEquals(gff3, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 29, iter, gff3));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 31, iter, gff3));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 40, iter, gff3));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 41, iter, gff3));
-//		// iterator should have been advanced
-//		Assert.assertEquals(gff4, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 141, iter, gff4));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 142, iter, gff4));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 1000142, iter, gff4));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr2", 1, iter, gff4));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr2", 2, iter, gff4));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 15, iter, gff4));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 25, iter, gff4));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 26, iter, gff4));
-//		// iterator should have been advanced
-//		Assert.assertEquals(gff5, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 40, iter, gff5));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr2", 41, iter, gff5));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr3", 15, iter, gff5));
-//		// iterator should have been advanced
-//		Assert.assertEquals(gff6, WiggleFromPileup.getGffRecord());
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr3", 10015, iter, gff6));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr4", 10015, iter, gff6));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr5", 10015, iter, gff6));
-//		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr15", 10015, iter, gff6));
-//		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 100026, iter, gff6));
-//		
-//	}
-	
-	@Test
-	public final void callWithNoArgs() throws Exception {
-		String command = "";
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
-		assertTrue(1 == exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
-	}
-	
-	@Test
-	public final void callWithNoInputFile() throws Exception {
-		String command = "-log ./logfile -o " + tempFolder.getRoot().getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
-		assertTrue(1 == exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
-	}
-	
-	@Test
-	public final void callWithMissingArgs() throws Exception {
-		String command = "-log ./logfile -o blah.wiggle -i " + pileupFile.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
-		assertTrue(1 == exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
-	}
-	
-	@Test
-	public final void callWithValidArguments() throws Exception {
-		ExpectedException.none();
-		String command = "-log ./logfile  -pileupFormat NNTT -normalCoverage 1 -tumourCoverage 1 -i " + pileupFile.getAbsolutePath() 
-		+ " -i " + gff3File.getAbsolutePath()
-		+ " -gffRegions exon"
-		+ " -o " + wiggleFile.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
-		assertEquals(0, exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		
-		// check the wiggle file
-		InputStream reader = new FileInputStream(wiggleFile);
-		assertEquals(29, examineWiggle(reader));
-	}
-	
-	@Test
-	public final void callWithValidArgumentsLargeCoverage() throws Exception {
-		ExpectedException.none();
-		String command = "-log ./logfile  -pileupFormat NNTT -normalCoverage 50 -tumourCoverage 50 -i " + pileupFile.getAbsolutePath() 
-		+ " -i " + gff3File.getAbsolutePath()
-		+ " -gffRegions exon"
-		+ " -o " + wiggleFile.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
-		assertEquals(0, exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		
-		// check the wiggle file
-		InputStream reader = new FileInputStream(wiggleFile);
-		assertEquals(0, examineWiggle(reader));
-	}
-	
-	@Test
-	public final void callWithZippedFiles() throws Exception {
-		ExpectedException.none();
-		String command = "-log ./logfile  -pileupFormat NNTT -normalCoverage 20 -tumourCoverage 20 -i " + pileupFileGZIP.getAbsolutePath() 
-		+ " -i " + gff3File.getAbsolutePath()
-		+ " -gffRegions exon"
-		+ " -o " + wiggleFileGZIP.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
-		assertEquals(0, exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		
-		// check the wiggle file
-		InputStream reader = new GZIPInputStream(new FileInputStream(wiggleFileGZIP));
-		assertEquals(14, examineWiggle(reader));
-	}
-	
-	private int examineWiggle(InputStream reader) throws IOException {
-		int count = 0;
-		BufferedReader fr = new BufferedReader(new InputStreamReader(reader));
-		String line = fr.readLine();	// first line has the header
-		while ((line = fr.readLine()) != null) {
-			if (line.startsWith("fixedStep")) continue;
-			count += Integer.parseInt(line);
-		}
-		return count;
-	}
-	
-	private void createPileupFile(File pileupFile) throws IOException {
-		
-		OutputStream os = FileUtils.isFileNameGZip(pileupFile) ? new GZIPOutputStream( new FileOutputStream(pileupFile)) 
-		: new FileOutputStream(pileupFile);
-		
-//		OutputStream os = new FileOutputStream(pileupFile);
-		PrintStream ps = new PrintStream(os);
-		
-		ps.println("chr1\t14923\tG\t8\t.......^!.\tIIIIIIIE\t7\t,.....^!.\t5IIIIIE\t10\t.........^T.\t0IIIIIIIIE\t7\t...,...\tIIIIIII");
-		ps.println("chr1\t14924\tA\t9\t........^!.\tEI@III?IB\t7\t,......\t@IIIIII\t10\t..........\t-IIIIIIIII\t8\t...,...^!.\tIIII/IIB");
-		ps.println("chr1\t14925\tA\t11\t.........^!.^P.\tIIDIIIHIEEE\t8\t,......^N.\tBIIIIIIE\t10\t..........\t)IIIIIIIII\t8\t...,....\tIII:4IIE");
-		ps.println("chr1\t14926\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t9IIIIIII\t10\t..........\t-IIIIIIIII\t8\t...,....\tIIH;DIII");
-		ps.println("chr1\t14927\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t8IIIIIII\t11\t..........^O.\t&FIIIIIIIIE\t8\t...,....\tII:>IIII");
-		ps.println("chr1\t14928\tA\t11\t...........\tIIIIIIIIIII\t9\t,.......^(.\tGAIIIIIIE\t12\t...........^G.\t&CIBIIII9IIE\t8\t...,....\tII;0DIII");
-		ps.println("chr1\t14929\tC\t11\t...........\t<HIIIIIIIII\t9\t,........\tA3IIIIIII\t12\t............\t'DI?IIIIIIII\t8\t...,....\tHIB%5III");
-		ps.println("chr1\t14930\tA\t11\t..G..G.....\t8I7CI7GIIII\t9\t,.G..G...\t6,7%I7III\t12\t.G.GG.......\t(:I77IIIIIII\t8\tG..,..G.\t1I:%9I7I");
-		ps.println("chr1\t14931\tA\t11\t...........\tBI7BI7>IIII\t9\t,........\tB37%I7III\t12\t............\t9FI77IIIIIII\t8\t...,....\t?I;>4I7I");
-		ps.println("chr1\t14932\tG\t11\t...........\tI=IIIIIIIII\t9\t,........\t?@IIIIIII\t12\t............\t>IIIIIIIIIII\t8\t...,....\t?ICI@III");
-		ps.println("chr1\t14933\tG\t11\t...........\tEAIIIIDIIII\t9\t,........\tD8III?III\t12\t............\t3EIIIIIIIIII\t9\t...,....^L.\t8I9HIIIIE");
-		ps.println("chr1\t14934\tT\t11\t...........\t9I>III<IIII\t9\t,........\tIGIIIIIII\t12\t............\t+IIIIIIIIIII\t9\t...,.....\tIIAAGIGII");
-		ps.println("chr1\t14935\tG\t12\t...........^!.\tIF>IIIFIIIIE\t9\t,........\tHCIIIIIII\t12\t............\t*IIIIIIIIIII\t9\t...,.....\tIII7IIIII");
-		ps.println("chr1\t14936\tC\t12\t............\tI@IIIIIIIIII\t9\t,........\tBIIDIIIII\t12\t............\t8GIIIIIIIIII\t9\t...,.....\tIII,BIIII");
-		ps.println("chr1\t14937\tT\t12\t............\tIIIIIIIIIIII\t9\t,........\t8IIIIFIII\t12\t............\t:IIIIIIIIIII\t9\t...,.....\tBII?)IIII");
-		ps.println("chr1\t14938\tG\t12\t....$........\t%=I1II6IFIII\t9\t,........\tD%IIB/IHI\t12\t............\t3II>IIIIIIHI\t9\t...,.....\t0IAI/I?II");
-		ps.println("chr1\t14939\tG\t11\t...........\t%@IHI:IIIHI\t9\t,........\tI%II@CIDI\t12\t............\t7IICIIIIII9A\t9\t...,.....\t1IAI;I9II");
-		ps.println("chr1\t14940\tC\t11\t...........\t:IF?I-IIIII\t9\t,........\tF+II+IIII\t12\t......$......\t2%I%A>I>IIIA\t9\t...,.....\t3?)G:I<IIv");
-		ps.println("chr1\t14941\tC\t11\t...........\t7IF?I-III=I\t9\t,........\tD,II+IIGI\t11\t.......$....\t7%E%1I/IIII\t9\t...,.....\tE1)B%ICIA");
-		ps.println("chr1\t14942\tC\t11\t...........\tDFIIIIIIG=I\t9\t,........\tC4IIIEIII\t10\t..........\t7IIIIIIIII\t9\t...,.....\tIDII%IIII");
-		ps.println("chr1\t14943\tA\t11\t...........\t)9EFI%IICFI\t9\t,........\tI@FII+I&G\t10\t.$.........\t'IIIIIEIII\t9\t.$..,.....\t@I@?=I>II");
-		ps.println("chr1\t14944\tG\t11\t.....C.....\t(//AI%IIIFI\t9\t,$........\tI<BIB2I&F\t9\t.........\tE87EI?EI?\t8\t..,.....\t3.I&H:I:"); 
-		ps.println("chr1\t14945\tG\t11\t.....C.....\t/>=II%ICIII\t8\t.$.......\t2II@6IBI\t9\t.........\t?:16IIB=,\t8\t..,.....\t9/%&>CI0");
-		ps.println("chr1\t14946\tG\t11\t...........\t3I>II%I@I(I\t7\t.......\tIICIIII\t9\t.........\t4ID?II@GD\t8\t..,.....\tI@%;HIII");
-		ps.println("chr1\t14947\tC\t11\t...$........\tDI?IIAIDI(I\t7\t.......\tIIIIIII\t9\t.$.....N$..\tEI58II!(B\t8\t..,.....\tI@C?IIII");
-		ps.println("chr1\t14948\tG\t10\t.$.$........\t=;-%3I6I<I\t7\t.......\tEIC%IG<\t7\t.$......\t5%),A%,\t8\t..,.$....\t90I0BF;>");
-		ps.println("chr1\t14949\tG\t8\t.......$.\t5%6I>I%D\t7\t.......\tBI:%I;B\t6\t......\t*1,:0%\t7\t.$.,....\t'1I59;'");
-		ps.println("chr1\t14950\tG\t7\t.$......\t?H3B+B7\t7\t.$......\t:+%%D7@\t6\t......\t%-%50%\t6\t.,....\t-I3'C'");
-		ps.println("chr1\t14951\tC\t6\t......\tG2=+95\t6\t......\t)%%A6C\t6\t......\t%9%C89\t6\t.,....\t8H6(=%");
+import java.io.*;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
-		ps.close();
-		os.close();
-	}
-	
-	private void createGFF3File(File pileupFile) throws IOException {
-		
-		OutputStream os = FileUtils.isFileNameGZip( pileupFile) ? new GZIPOutputStream( new FileOutputStream(pileupFile)) 
-		: new FileOutputStream(pileupFile);
-		
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WiggleFromPileupTakeTwoTest {
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private File pileupFile;
+    private File gff3File;
+    private File wiggleFile;
+    private File pileupFileGZIP;
+    private File wiggleFileGZIP;
+
+    @Before
+    public final void before() {
+        try {
+            pileupFile = tempFolder.newFile("wigglePileupTest.pileup");
+            wiggleFile = tempFolder.newFile("wigglePileupTest.wiggle");
+            gff3File = tempFolder.newFile("wigglePileupTest.gff3");
+            pileupFileGZIP = tempFolder.newFile("wigglePileupTest.pileup.gz");
+            wiggleFileGZIP = tempFolder.newFile("wigglePileupTest.wiggle.gz");
+            createPileupFile(pileupFile);
+            createPileupFile(pileupFileGZIP);
+            createGFF3File(gff3File);
+            assertTrue(pileupFile.exists());
+            assertTrue(gff3File.exists());
+            assertTrue(pileupFileGZIP.exists());
+        } catch (Exception e) {
+            System.err.println("File creation error in test harness: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public final void callWithNoArgs() throws Exception {
+        String command = "";
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
+        assertEquals(1, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+        assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
+    }
+
+    @Test
+    public final void callWithNoInputFile() throws Exception {
+        String command = "-log ./logfile -o " + tempFolder.getRoot().getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
+        assertEquals(1, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+        assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
+    }
+
+    @Test
+    public final void callWithMissingArgs() throws Exception {
+        String command = "-log ./logfile -o blah.wiggle -i " + pileupFile.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
+        assertEquals(1, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+        assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
+    }
+
+    @Test
+    public final void callWithValidArguments() throws Exception {
+        String command = "-log ./logfile -pileupFormat NNTT -normalCoverage 1 -tumourCoverage 1 -i " + pileupFile.getAbsolutePath()
+                + " -i " + gff3File.getAbsolutePath()
+                + " -gffRegions exon"
+                + " -o " + wiggleFile.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
+        assertEquals(0, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+
+        // check the wiggle file
+        InputStream reader = new FileInputStream(wiggleFile);
+        assertEquals(29, examineWiggle(reader));
+    }
+
+    @Test
+    public final void callWithValidArgumentsLargeCoverage() throws Exception {
+        String command = "-log ./logfile -pileupFormat NNTT -normalCoverage 50 -tumourCoverage 50 -i " + pileupFile.getAbsolutePath()
+                + " -i " + gff3File.getAbsolutePath()
+                + " -gffRegions exon"
+                + " -o " + wiggleFile.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
+        assertEquals(0, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+
+        // check the wiggle file
+        InputStream reader = new FileInputStream(wiggleFile);
+        assertEquals(0, examineWiggle(reader));
+    }
+
+    @Test
+    public final void callWithZippedFiles() throws Exception {
+        String command = "-log ./logfile -pileupFormat NNTT -normalCoverage 20 -tumourCoverage 20 -i " + pileupFileGZIP.getAbsolutePath()
+                + " -i " + gff3File.getAbsolutePath()
+                + " -gffRegions exon"
+                + " -o " + wiggleFileGZIP.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileupTakeTwo");
+        assertEquals(0, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+
+        // check the wiggle file
+        InputStream reader = new GZIPInputStream(new FileInputStream(wiggleFileGZIP));
+        assertEquals(14, examineWiggle(reader));
+    }
+
+    private int examineWiggle(InputStream reader) throws IOException {
+        int count = 0;
+        BufferedReader fr = new BufferedReader(new InputStreamReader(reader));
+        String line;    // first line has the header
+        while ((line = fr.readLine()) != null) {
+            if (line.startsWith("fixedStep")) continue;
+            count += Integer.parseInt(line);
+        }
+        return count;
+    }
+
+    private void createPileupFile(File pileupFile) throws IOException {
+
+        OutputStream os = FileUtils.isFileNameGZip(pileupFile) ? new GZIPOutputStream(new FileOutputStream(pileupFile))
+                : new FileOutputStream(pileupFile);
+
+        PrintStream ps = new PrintStream(os);
+
+        ps.println("chr1\t14923\tG\t8\t.......^!.\tIIIIIIIE\t7\t,.....^!.\t5IIIIIE\t10\t.........^T.\t0IIIIIIIIE\t7\t...,...\tIIIIIII");
+        ps.println("chr1\t14924\tA\t9\t........^!.\tEI@III?IB\t7\t,......\t@IIIIII\t10\t..........\t-IIIIIIIII\t8\t...,...^!.\tIIII/IIB");
+        ps.println("chr1\t14925\tA\t11\t.........^!.^P.\tIIDIIIHIEEE\t8\t,......^N.\tBIIIIIIE\t10\t..........\t)IIIIIIIII\t8\t...,....\tIII:4IIE");
+        ps.println("chr1\t14926\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t9IIIIIII\t10\t..........\t-IIIIIIIII\t8\t...,....\tIIH;DIII");
+        ps.println("chr1\t14927\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t8IIIIIII\t11\t..........^O.\t&FIIIIIIIIE\t8\t...,....\tII:>IIII");
+        ps.println("chr1\t14928\tA\t11\t...........\tIIIIIIIIIII\t9\t,.......^(.\tGAIIIIIIE\t12\t...........^G.\t&CIBIIII9IIE\t8\t...,....\tII;0DIII");
+        ps.println("chr1\t14929\tC\t11\t...........\t<HIIIIIIIII\t9\t,........\tA3IIIIIII\t12\t............\t'DI?IIIIIIII\t8\t...,....\tHIB%5III");
+        ps.println("chr1\t14930\tA\t11\t..G..G.....\t8I7CI7GIIII\t9\t,.G..G...\t6,7%I7III\t12\t.G.GG.......\t(:I77IIIIIII\t8\tG..,..G.\t1I:%9I7I");
+        ps.println("chr1\t14931\tA\t11\t...........\tBI7BI7>IIII\t9\t,........\tB37%I7III\t12\t............\t9FI77IIIIIII\t8\t...,....\t?I;>4I7I");
+        ps.println("chr1\t14932\tG\t11\t...........\tI=IIIIIIIII\t9\t,........\t?@IIIIIII\t12\t............\t>IIIIIIIIIII\t8\t...,....\t?ICI@III");
+        ps.println("chr1\t14933\tG\t11\t...........\tEAIIIIDIIII\t9\t,........\tD8III?III\t12\t............\t3EIIIIIIIIII\t9\t...,....^L.\t8I9HIIIIE");
+        ps.println("chr1\t14934\tT\t11\t...........\t9I>III<IIII\t9\t,........\tIGIIIIIII\t12\t............\t+IIIIIIIIIII\t9\t...,.....\tIIAAGIGII");
+        ps.println("chr1\t14935\tG\t12\t...........^!.\tIF>IIIFIIIIE\t9\t,........\tHCIIIIIII\t12\t............\t*IIIIIIIIIII\t9\t...,.....\tIII7IIIII");
+        ps.println("chr1\t14936\tC\t12\t............\tI@IIIIIIIIII\t9\t,........\tBIIDIIIII\t12\t............\t8GIIIIIIIIII\t9\t...,.....\tIII,BIIII");
+        ps.println("chr1\t14937\tT\t12\t............\tIIIIIIIIIIII\t9\t,........\t8IIIIFIII\t12\t............\t:IIIIIIIIIII\t9\t...,.....\tBII?)IIII");
+        ps.println("chr1\t14938\tG\t12\t....$........\t%=I1II6IFIII\t9\t,........\tD%IIB/IHI\t12\t............\t3II>IIIIIIHI\t9\t...,.....\t0IAI/I?II");
+        ps.println("chr1\t14939\tG\t11\t...........\t%@IHI:IIIHI\t9\t,........\tI%II@CIDI\t12\t............\t7IICIIIIII9A\t9\t...,.....\t1IAI;I9II");
+        ps.println("chr1\t14940\tC\t11\t...........\t:IF?I-IIIII\t9\t,........\tF+II+IIII\t12\t......$......\t2%I%A>I>IIIA\t9\t...,.....\t3?)G:I<IIv");
+        ps.println("chr1\t14941\tC\t11\t...........\t7IF?I-III=I\t9\t,........\tD,II+IIGI\t11\t.......$....\t7%E%1I/IIII\t9\t...,.....\tE1)B%ICIA");
+        ps.println("chr1\t14942\tC\t11\t...........\tDFIIIIIIG=I\t9\t,........\tC4IIIEIII\t10\t..........\t7IIIIIIIII\t9\t...,.....\tIDII%IIII");
+        ps.println("chr1\t14943\tA\t11\t...........\t)9EFI%IICFI\t9\t,........\tI@FII+I&G\t10\t.$.........\t'IIIIIEIII\t9\t.$..,.....\t@I@?=I>II");
+        ps.println("chr1\t14944\tG\t11\t.....C.....\t(//AI%IIIFI\t9\t,$........\tI<BIB2I&F\t9\t.........\tE87EI?EI?\t8\t..,.....\t3.I&H:I:");
+        ps.println("chr1\t14945\tG\t11\t.....C.....\t/>=II%ICIII\t8\t.$.......\t2II@6IBI\t9\t.........\t?:16IIB=,\t8\t..,.....\t9/%&>CI0");
+        ps.println("chr1\t14946\tG\t11\t...........\t3I>II%I@I(I\t7\t.......\tIICIIII\t9\t.........\t4ID?II@GD\t8\t..,.....\tI@%;HIII");
+        ps.println("chr1\t14947\tC\t11\t...$........\tDI?IIAIDI(I\t7\t.......\tIIIIIII\t9\t.$.....N$..\tEI58II!(B\t8\t..,.....\tI@C?IIII");
+        ps.println("chr1\t14948\tG\t10\t.$.$........\t=;-%3I6I<I\t7\t.......\tEIC%IG<\t7\t.$......\t5%),A%,\t8\t..,.$....\t90I0BF;>");
+        ps.println("chr1\t14949\tG\t8\t.......$.\t5%6I>I%D\t7\t.......\tBI:%I;B\t6\t......\t*1,:0%\t7\t.$.,....\t'1I59;'");
+        ps.println("chr1\t14950\tG\t7\t.$......\t?H3B+B7\t7\t.$......\t:+%%D7@\t6\t......\t%-%50%\t6\t.,....\t-I3'C'");
+        ps.println("chr1\t14951\tC\t6\t......\tG2=+95\t6\t......\t)%%A6C\t6\t......\t%9%C89\t6\t.,....\t8H6(=%");
+
+        ps.close();
+        os.close();
+    }
+
+    private void createGFF3File(File pileupFile) throws IOException {
+
+        OutputStream os = FileUtils.isFileNameGZip(pileupFile) ? new GZIPOutputStream(new FileOutputStream(pileupFile))
+                : new FileOutputStream(pileupFile);
+
 //		OutputStream os = new FileOutputStream(pileupFile);
-		PrintStream ps = new PrintStream(os);
-		
-		
-		ps.println("##gff-version 3");
-		ps.println("# Created by: simple_segmenter.pl[v2940]");
-		ps.println("# Created on: Tue May 24 01:48:54 2011");
-		ps.println("# Commandline: -v -g -l -i SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524.gff3 -o SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524_shoulders.gff3 -f exon,100,100,100 -f highexon,300 -f lowexon");
-		ps.println("chr1	simple_segmenter.pl[v2940]	fill	1	14166	.	.	.	ID=gnl|fill");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	14167	14266	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	14267	14366	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14367	14466	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14467	14587	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14588	14638	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14639	14883	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon	14884	14942	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14943	15064	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15065	15164	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15165	15264	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15265	15364	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	fill	15365	15370	.	.	.	ID=gnl|fill");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15371	15470	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15471	15570	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15571	15670	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	15671	15990	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15991	16090	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16091	16190	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	16191	16390	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16391	16490	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16491	16590	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16591	16719	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16720	16749	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16750	17074	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17075	17177	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17178	17420	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17421	17442	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17443	18108	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18109	18202	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	18203	18448	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18449	18548	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	18549	18648	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	18649	18848	.	+	.	ID=gnl|exon_3_100");
-//		ps.println("##gff-version 3");
-//		ps.println("# Created by: simple_segmenter.pl[v2940]");
-//		ps.println("# Created on: Tue May 24 01:48:54 2011");
-//		ps.println("# Commandline: -v -g -l -i SureSelect_All_Exon_50mb_filtered_baits_1-200_20110524.gff3 -o SureSelect_All_Exon_50mb_filtered_baits_1-200_20110524_shoulders.gff3 -f bait,100,100,100 -f highbait,300 -f lowbait");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	fill	1	14166	.	.	.	ID=gnl|fill");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_3_100	14167	14266	.	+	.	ID=gnl|bait_3_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_2_100	14267	14366	.	+	.	ID=gnl|bait_2_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	14367	14466	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	14467	14587	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	14588	14638	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	14639	14883	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	14884	14942	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	14943	15064	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	15065	15164	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_2_100	15165	15264	.	+	.	ID=gnl|bait_2_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_3_100	15265	15364	.	+	.	ID=gnl|bait_3_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	fill	15365	15370	.	.	.	ID=gnl|fill");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_3_100	15371	15470	.	+	.	ID=gnl|bait_3_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_2_100	15471	15570	.	+	.	ID=gnl|bait_2_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	15571	15670	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	15671	15990	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	15991	16090	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_2_100	16091	16190	.	+	.	ID=gnl|bait_2_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_3_100	16191	16390	.	+	.	ID=gnl|bait_3_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_2_100	16391	16490	.	+	.	ID=gnl|bait_2_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	16491	16590	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	16591	16719	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	16720	16749	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	16750	17074	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	17075	17177	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	17178	17420	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	17421	17442	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	17443	18108	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	18109	18202	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	bait	18203	18448	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_1_100	18449	18548	.	+	.	ID=gnl|bait_1_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_2_100	18549	18648	.	+	.	ID=gnl|bait_2_100");
-//		ps.println("chr1	simple_segmenter.pl[v2940]	bait_3_100	18649	18848	.	+	.	ID=gnl|bait_3_100");
-		
-		ps.close();
-		os.close();
-	}
+        PrintStream ps = new PrintStream(os);
+
+
+        ps.println("##gff-version 3");
+        ps.println("# Created by: simple_segmenter.pl[v2940]");
+        ps.println("# Created on: Tue May 24 01:48:54 2011");
+        ps.println("# Commandline: -v -g -l -i SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524.gff3 -o SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524_shoulders.gff3 -f exon,100,100,100 -f highexon,300 -f lowexon");
+        ps.println("chr1	simple_segmenter.pl[v2940]	fill	1	14166	.	.	.	ID=gnl|fill");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	14167	14266	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	14267	14366	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14367	14466	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14467	14587	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14588	14638	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14639	14883	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon	14884	14942	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14943	15064	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15065	15164	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15165	15264	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15265	15364	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	fill	15365	15370	.	.	.	ID=gnl|fill");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15371	15470	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15471	15570	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15571	15670	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	15671	15990	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15991	16090	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16091	16190	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	16191	16390	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16391	16490	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16491	16590	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16591	16719	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16720	16749	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16750	17074	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17075	17177	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17178	17420	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17421	17442	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17443	18108	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18109	18202	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	18203	18448	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18449	18548	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	18549	18648	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	18649	18848	.	+	.	ID=gnl|exon_3_100");
+
+        ps.close();
+        os.close();
+    }
 }

--- a/qmule/test/org/qcmg/qmule/WiggleFromPileupTest.java
+++ b/qmule/test/org/qcmg/qmule/WiggleFromPileupTest.java
@@ -1,391 +1,374 @@
 package org.qcmg.qmule;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.qcmg.common.commandline.Executor;
+import org.qcmg.common.util.FileUtils;
+import org.qcmg.qio.gff3.Gff3Record;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.PrintStream;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.qcmg.common.commandline.Executor;
-import org.qcmg.common.util.FileUtils;
-import org.qcmg.qio.gff3.Gff3Record;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class WiggleFromPileupTest {
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-	
-	private File pileupFile;
-	private File gff3File;
-	private File wiggleFile;
-	private File pileupFileGZIP;
-	private File wiggleFileGZIP;
-	
-	@Before
-	public final void before() {
-		try {
-			pileupFile = tempFolder.newFile("wigglePileupTest.pileup");
-			wiggleFile = tempFolder.newFile("wigglePileupTest.wiggle");
-			gff3File = tempFolder.newFile("wigglePileupTest.gff3");
-			pileupFileGZIP = tempFolder.newFile("wigglePileupTest.pileup.gz");
-			wiggleFileGZIP = tempFolder.newFile("wigglePileupTest.wiggle.gz");
-			createPileupFile(pileupFile);
-			createPileupFile(pileupFileGZIP);
-			createGFF3File(gff3File);
-			assertTrue(pileupFile.exists());
-			assertTrue(gff3File.exists());
-			assertTrue(pileupFileGZIP.exists());
-		} catch (Exception e) {
-			System.err.println("File creation error in test harness: " + e.getMessage());
-		}
-	}
-	
-	
-	@Test
-	public void testIsPositionInBaitSingleGff() {
-		Gff3Record gff = new Gff3Record();
-		gff.setSeqId("chr1");
-		gff.setStart(1);
-		gff.setEnd(10);
-		
-		List<Gff3Record> gffs = new ArrayList<Gff3Record>();
-		gffs.add(gff);
-		Iterator<Gff3Record> iter = gffs.iterator();
-//		WiggleFromPileup.setGffRecord(gff);
-		
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr0", 0, iter, iter.next()));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 0, iter, gff));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff));
-		
-		gff.setSeqId("chrX");
-		gff.setStart(1000123);
-		gff.setEnd(1000223);
-		
-//		WiggleFromPileup.setGffRecord(gff);
-		
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 0, iter, gff));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 1, iter, gff));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrx", 1000124, iter, gff));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrx", 11, iter, gff));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 11, iter, gff));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 1000123, iter, gff));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 1000124, iter, gff));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 1000223, iter, gff));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chrX", 1000224, iter, gff));
-	}
-	
-	@Test
-	public void testIsPositionInBaitMultipleGff() {
-		Gff3Record gff1 = new Gff3Record();
-		gff1.setSeqId("chr1");
-		gff1.setStart(1);
-		gff1.setEnd(10);
-		Gff3Record gff2 = new Gff3Record();
-		gff2.setSeqId("chr1");
-		gff2.setStart(11);
-		gff2.setEnd(20);
-		Gff3Record gff3 = new Gff3Record();
-		gff3.setSeqId("chr1");
-		gff3.setStart(31);
-		gff3.setEnd(40);
-		
-		List<Gff3Record> gffs = new ArrayList<Gff3Record>();
-		gffs.add(gff1);
-		gffs.add(gff2);
-		gffs.add(gff3);
-		Iterator<Gff3Record> iter = gffs.iterator();
-		
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 0, iter, iter.next()));
-		
-//		Assert.assertEquals(gff1, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff1));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff1));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff1));
-		// iterator should have been advanced
-		Assert.assertEquals(gff2, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 20, iter, gff2));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 21, iter, gff2));
-		// iterator should have been advanced
-		Assert.assertEquals(gff3, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 29, iter, gff3));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 31, iter, gff3));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 40, iter, gff3));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 41, iter, gff3));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 141, iter, gff3));
-	}
-	
-	@Test
-	public void testIsPositionInBaitMultipleGffMultipleChromosomes() {
-		Gff3Record gff1 = new Gff3Record();
-		gff1.setSeqId("chr1");
-		gff1.setStart(1);
-		gff1.setEnd(10);
-		Gff3Record gff2 = new Gff3Record();
-		gff2.setSeqId("chr1");
-		gff2.setStart(11);
-		gff2.setEnd(20);
-		Gff3Record gff3 = new Gff3Record();
-		gff3.setSeqId("chr1");
-		gff3.setStart(31);
-		gff3.setEnd(40);
-		Gff3Record gff4 = new Gff3Record();
-		gff4.setSeqId("chr2");
-		gff4.setStart(15);
-		gff4.setEnd(25);
-		Gff3Record gff5 = new Gff3Record();
-		gff5.setSeqId("chr2");
-		gff5.setStart(26);
-		gff5.setEnd(40);
-		Gff3Record gff6 = new Gff3Record();
-		gff6.setSeqId("chrX");
-		gff6.setStart(100026);
-		gff6.setEnd(100040);
-		
-		List<Gff3Record> gffs = new ArrayList<Gff3Record>();
-		gffs.add(gff1);
-		gffs.add(gff2);
-		gffs.add(gff3);
-		gffs.add(gff4);
-		gffs.add(gff5);
-		gffs.add(gff6);
-		Iterator<Gff3Record> iter = gffs.iterator();
-		
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr0", 0, iter, iter.next()));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 0, iter, gff1));
-		
-//		Assert.assertEquals(gff1, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff1));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff1));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff1));
-		// iterator should have been advanced
-		Assert.assertEquals(gff2, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 20, iter, gff2));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 21, iter, gff2));
-		// iterator should have been advanced
-		Assert.assertEquals(gff3, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 29, iter, gff3));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 31, iter, gff3));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr1", 40, iter, gff3));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 41, iter, gff3));
-		// iterator should have been advanced
-		Assert.assertEquals(gff4, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 141, iter, gff4));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 142, iter, gff4));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr1", 1000142, iter, gff4));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr2", 1, iter, gff4));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr2", 2, iter, gff4));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 15, iter, gff4));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 25, iter, gff4));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 26, iter, gff4));
-		// iterator should have been advanced
-		Assert.assertEquals(gff5, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chr2", 40, iter, gff5));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr2", 41, iter, gff5));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr3", 15, iter, gff5));
-		// iterator should have been advanced
-		Assert.assertEquals(gff6, WiggleFromPileup.getGffRecord());
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr3", 10015, iter, gff6));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr4", 10015, iter, gff6));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr5", 10015, iter, gff6));
-		Assert.assertEquals(false, WiggleFromPileup.isPositionInBait("chr15", 10015, iter, gff6));
-		Assert.assertEquals(true, WiggleFromPileup.isPositionInBait("chrX", 100026, iter, gff6));
-		
-	}
-	
-	@Test
-	public final void callWithNoArgs() throws Exception {
-		String command = "";
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
-		assertTrue(1 == exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
-	}
-	
-	@Test
-	public final void callWithNoInputFile() throws Exception {
-		String command = "-log ./logfile -o " + tempFolder.getRoot().getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
-		assertTrue(1 == exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
-	}
-	
-	@Test
-	public final void callWithMissingArgs() throws Exception {
-		String command = "-log ./logfile -o blah.wiggle -i " + pileupFile.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
-		assertTrue(1 == exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
-	}
-	
-	@Test
-	public final void callWithValidArguments() throws Exception {
-		ExpectedException.none();
-		String command = "-log ./logfile  -pileupFormat NNTT -normalCoverage 1 -tumourCoverage 1 -i " + pileupFile.getAbsolutePath() 
-		+ " -i " + gff3File.getAbsolutePath()
-		+ " -o " + wiggleFile.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
-		assertEquals(0, exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		
-		// check the wiggle file
-		InputStream reader = new FileInputStream(wiggleFile);
-		assertEquals(29, examineWiggle(reader));
-	}
-	
-	@Test
-	public final void callWithValidArgumentsLargeCoverage() throws Exception {
-		ExpectedException.none();
-		String command = "-log ./logfile  -pileupFormat NNTT -normalCoverage 50 -tumourCoverage 50 -i " + pileupFile.getAbsolutePath() 
-		+ " -i " + gff3File.getAbsolutePath()
-		+ " -o " + wiggleFile.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
-		assertEquals(0, exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		
-		// check the wiggle file
-		InputStream reader = new FileInputStream(wiggleFile);
-		assertEquals(0, examineWiggle(reader));
-	}
-	
-	@Test
-	public final void callWithZippedFiles() throws Exception {
-		ExpectedException.none();
-		String command = "-log ./logfile  -pileupFormat NNTT -normalCoverage 20 -tumourCoverage 20 -i " + pileupFileGZIP.getAbsolutePath() 
-		+ " -i " + gff3File.getAbsolutePath()
-		+ " -o " + wiggleFileGZIP.getAbsolutePath();
-		Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
-		assertEquals(0, exec.getErrCode());
-		assertTrue(0 == exec.getOutputStreamConsumer().getLines().length);
-		
-		// check the wiggle file
-		InputStream reader = new GZIPInputStream(new FileInputStream(wiggleFileGZIP));
-		assertEquals(14, examineWiggle(reader));
-	}
-	
-	private int examineWiggle(InputStream reader) throws IOException {
-		int count = 0;
-		BufferedReader fr = new BufferedReader(new InputStreamReader(reader));
-		String line = fr.readLine();	// first line has the header
-		while ((line = fr.readLine()) != null) {
-			if (line.startsWith("fixedStep")) continue;
-			count += Integer.parseInt(line);
-		}
-		return count;
-	}
-	
-	private void createPileupFile(File pileupFile) throws IOException {
-		
-		OutputStream os = FileUtils.isFileNameGZip(pileupFile) ? new GZIPOutputStream( new FileOutputStream(pileupFile)) 
-		: new FileOutputStream(pileupFile);
-		
-//		OutputStream os = new FileOutputStream(pileupFile);
-		PrintStream ps = new PrintStream(os);
-		
-		ps.println("chr1\t14923\tG\t8\t.......^!.\tIIIIIIIE\t7\t,.....^!.\t5IIIIIE\t10\t.........^T.\t0IIIIIIIIE\t7\t...,...\tIIIIIII");
-		ps.println("chr1\t14924\tA\t9\t........^!.\tEI@III?IB\t7\t,......\t@IIIIII\t10\t..........\t-IIIIIIIII\t8\t...,...^!.\tIIII/IIB");
-		ps.println("chr1\t14925\tA\t11\t.........^!.^P.\tIIDIIIHIEEE\t8\t,......^N.\tBIIIIIIE\t10\t..........\t)IIIIIIIII\t8\t...,....\tIII:4IIE");
-		ps.println("chr1\t14926\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t9IIIIIII\t10\t..........\t-IIIIIIIII\t8\t...,....\tIIH;DIII");
-		ps.println("chr1\t14927\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t8IIIIIII\t11\t..........^O.\t&FIIIIIIIIE\t8\t...,....\tII:>IIII");
-		ps.println("chr1\t14928\tA\t11\t...........\tIIIIIIIIIII\t9\t,.......^(.\tGAIIIIIIE\t12\t...........^G.\t&CIBIIII9IIE\t8\t...,....\tII;0DIII");
-		ps.println("chr1\t14929\tC\t11\t...........\t<HIIIIIIIII\t9\t,........\tA3IIIIIII\t12\t............\t'DI?IIIIIIII\t8\t...,....\tHIB%5III");
-		ps.println("chr1\t14930\tA\t11\t..G..G.....\t8I7CI7GIIII\t9\t,.G..G...\t6,7%I7III\t12\t.G.GG.......\t(:I77IIIIIII\t8\tG..,..G.\t1I:%9I7I");
-		ps.println("chr1\t14931\tA\t11\t...........\tBI7BI7>IIII\t9\t,........\tB37%I7III\t12\t............\t9FI77IIIIIII\t8\t...,....\t?I;>4I7I");
-		ps.println("chr1\t14932\tG\t11\t...........\tI=IIIIIIIII\t9\t,........\t?@IIIIIII\t12\t............\t>IIIIIIIIIII\t8\t...,....\t?ICI@III");
-		ps.println("chr1\t14933\tG\t11\t...........\tEAIIIIDIIII\t9\t,........\tD8III?III\t12\t............\t3EIIIIIIIIII\t9\t...,....^L.\t8I9HIIIIE");
-		ps.println("chr1\t14934\tT\t11\t...........\t9I>III<IIII\t9\t,........\tIGIIIIIII\t12\t............\t+IIIIIIIIIII\t9\t...,.....\tIIAAGIGII");
-		ps.println("chr1\t14935\tG\t12\t...........^!.\tIF>IIIFIIIIE\t9\t,........\tHCIIIIIII\t12\t............\t*IIIIIIIIIII\t9\t...,.....\tIII7IIIII");
-		ps.println("chr1\t14936\tC\t12\t............\tI@IIIIIIIIII\t9\t,........\tBIIDIIIII\t12\t............\t8GIIIIIIIIII\t9\t...,.....\tIII,BIIII");
-		ps.println("chr1\t14937\tT\t12\t............\tIIIIIIIIIIII\t9\t,........\t8IIIIFIII\t12\t............\t:IIIIIIIIIII\t9\t...,.....\tBII?)IIII");
-		ps.println("chr1\t14938\tG\t12\t....$........\t%=I1II6IFIII\t9\t,........\tD%IIB/IHI\t12\t............\t3II>IIIIIIHI\t9\t...,.....\t0IAI/I?II");
-		ps.println("chr1\t14939\tG\t11\t...........\t%@IHI:IIIHI\t9\t,........\tI%II@CIDI\t12\t............\t7IICIIIIII9A\t9\t...,.....\t1IAI;I9II");
-		ps.println("chr1\t14940\tC\t11\t...........\t:IF?I-IIIII\t9\t,........\tF+II+IIII\t12\t......$......\t2%I%A>I>IIIA\t9\t...,.....\t3?)G:I<IIv");
-		ps.println("chr1\t14941\tC\t11\t...........\t7IF?I-III=I\t9\t,........\tD,II+IIGI\t11\t.......$....\t7%E%1I/IIII\t9\t...,.....\tE1)B%ICIA");
-		ps.println("chr1\t14942\tC\t11\t...........\tDFIIIIIIG=I\t9\t,........\tC4IIIEIII\t10\t..........\t7IIIIIIIII\t9\t...,.....\tIDII%IIII");
-		ps.println("chr1\t14943\tA\t11\t...........\t)9EFI%IICFI\t9\t,........\tI@FII+I&G\t10\t.$.........\t'IIIIIEIII\t9\t.$..,.....\t@I@?=I>II");
-		ps.println("chr1\t14944\tG\t11\t.....C.....\t(//AI%IIIFI\t9\t,$........\tI<BIB2I&F\t9\t.........\tE87EI?EI?\t8\t..,.....\t3.I&H:I:"); 
-		ps.println("chr1\t14945\tG\t11\t.....C.....\t/>=II%ICIII\t8\t.$.......\t2II@6IBI\t9\t.........\t?:16IIB=,\t8\t..,.....\t9/%&>CI0");
-		ps.println("chr1\t14946\tG\t11\t...........\t3I>II%I@I(I\t7\t.......\tIICIIII\t9\t.........\t4ID?II@GD\t8\t..,.....\tI@%;HIII");
-		ps.println("chr1\t14947\tC\t11\t...$........\tDI?IIAIDI(I\t7\t.......\tIIIIIII\t9\t.$.....N$..\tEI58II!(B\t8\t..,.....\tI@C?IIII");
-		ps.println("chr1\t14948\tG\t10\t.$.$........\t=;-%3I6I<I\t7\t.......\tEIC%IG<\t7\t.$......\t5%),A%,\t8\t..,.$....\t90I0BF;>");
-		ps.println("chr1\t14949\tG\t8\t.......$.\t5%6I>I%D\t7\t.......\tBI:%I;B\t6\t......\t*1,:0%\t7\t.$.,....\t'1I59;'");
-		ps.println("chr1\t14950\tG\t7\t.$......\t?H3B+B7\t7\t.$......\t:+%%D7@\t6\t......\t%-%50%\t6\t.,....\t-I3'C'");
-		ps.println("chr1\t14951\tC\t6\t......\tG2=+95\t6\t......\t)%%A6C\t6\t......\t%9%C89\t6\t.,....\t8H6(=%");
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
-		ps.close();
-		os.close();
-	}
-	
-	private void createGFF3File(File pileupFile) throws IOException {
-		
-		OutputStream os = FileUtils.isFileNameGZip(pileupFile) ? new GZIPOutputStream( new FileOutputStream(pileupFile)) 
-		: new FileOutputStream(pileupFile);
-		
-		PrintStream ps = new PrintStream(os);
-		
-		
-		ps.println("##gff-version 3");
-		ps.println("# Created by: simple_segmenter.pl[v2940]");
-		ps.println("# Created on: Tue May 24 01:48:54 2011");
-		ps.println("# Commandline: -v -g -l -i SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524.gff3 -o SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524_shoulders.gff3 -f exon,100,100,100 -f highexon,300 -f lowexon");
-		ps.println("chr1	simple_segmenter.pl[v2940]	fill	1	14166	.	.	.	ID=gnl|fill");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	14167	14266	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	14267	14366	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14367	14466	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14467	14587	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14588	14638	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14639	14883	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon	14884	14942	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14943	15064	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15065	15164	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15165	15264	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15265	15364	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	fill	15365	15370	.	.	.	ID=gnl|fill");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15371	15470	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15471	15570	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15571	15670	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	15671	15990	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15991	16090	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16091	16190	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	16191	16390	.	+	.	ID=gnl|exon_3_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16391	16490	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16491	16590	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16591	16719	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16720	16749	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16750	17074	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17075	17177	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17178	17420	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17421	17442	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17443	18108	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18109	18202	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	18203	18448	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18449	18548	.	+	.	ID=gnl|exon_1_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	18549	18648	.	+	.	ID=gnl|exon_2_100");
-		ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	18649	18848	.	+	.	ID=gnl|exon_3_100");
-		
-		ps.close();
-		os.close();
-	}
+    private File pileupFile;
+    private File gff3File;
+    private File wiggleFile;
+    private File pileupFileGZIP;
+    private File wiggleFileGZIP;
+
+    @Before
+    public final void before() {
+        try {
+            pileupFile = tempFolder.newFile("wigglePileupTest.pileup");
+            wiggleFile = tempFolder.newFile("wigglePileupTest.wiggle");
+            gff3File = tempFolder.newFile("wigglePileupTest.gff3");
+            pileupFileGZIP = tempFolder.newFile("wigglePileupTest.pileup.gz");
+            wiggleFileGZIP = tempFolder.newFile("wigglePileupTest.wiggle.gz");
+            createPileupFile(pileupFile);
+            createPileupFile(pileupFileGZIP);
+            createGFF3File(gff3File);
+            assertTrue(pileupFile.exists());
+            assertTrue(gff3File.exists());
+            assertTrue(pileupFileGZIP.exists());
+        } catch (Exception e) {
+            System.err.println("File creation error in test harness: " + e.getMessage());
+        }
+    }
+
+
+    @Test
+    public void testIsPositionInBaitSingleGff() {
+        Gff3Record gff = new Gff3Record();
+        gff.setSeqId("chr1");
+        gff.setStart(1);
+        gff.setEnd(10);
+
+        List<Gff3Record> gffs = new ArrayList<Gff3Record>();
+        gffs.add(gff);
+        Iterator<Gff3Record> iter = gffs.iterator();
+//		WiggleFromPileup.setGffRecord(gff);
+
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr0", 0, iter, iter.next()));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 0, iter, gff));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff));
+
+        gff.setSeqId("chrX");
+        gff.setStart(1000123);
+        gff.setEnd(1000223);
+
+//		WiggleFromPileup.setGffRecord(gff);
+
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chrX", 0, iter, gff));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chrX", 1, iter, gff));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chrx", 1000124, iter, gff));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chrx", 11, iter, gff));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chrX", 11, iter, gff));
+        assertTrue(WiggleFromPileup.isPositionInBait("chrX", 1000123, iter, gff));
+        assertTrue(WiggleFromPileup.isPositionInBait("chrX", 1000124, iter, gff));
+        assertTrue(WiggleFromPileup.isPositionInBait("chrX", 1000223, iter, gff));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chrX", 1000224, iter, gff));
+    }
+
+    @Test
+    public void testIsPositionInBaitMultipleGff() {
+        Gff3Record gff1 = new Gff3Record();
+        gff1.setSeqId("chr1");
+        gff1.setStart(1);
+        gff1.setEnd(10);
+        Gff3Record gff2 = new Gff3Record();
+        gff2.setSeqId("chr1");
+        gff2.setStart(11);
+        gff2.setEnd(20);
+        Gff3Record gff3 = new Gff3Record();
+        gff3.setSeqId("chr1");
+        gff3.setStart(31);
+        gff3.setEnd(40);
+
+        List<Gff3Record> gffs = new ArrayList<>();
+        gffs.add(gff1);
+        gffs.add(gff2);
+        gffs.add(gff3);
+        Iterator<Gff3Record> iter = gffs.iterator();
+
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 0, iter, iter.next()));
+
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff1));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff1));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff1));
+        // iterator should have been advanced
+        Assert.assertEquals(gff2, WiggleFromPileup.getGffRecord());
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 20, iter, gff2));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 21, iter, gff2));
+        // iterator should have been advanced
+        Assert.assertEquals(gff3, WiggleFromPileup.getGffRecord());
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 29, iter, gff3));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 31, iter, gff3));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 40, iter, gff3));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 41, iter, gff3));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 141, iter, gff3));
+    }
+
+    @Test
+    public void testIsPositionInBaitMultipleGffMultipleChromosomes() {
+        Gff3Record gff1 = new Gff3Record();
+        gff1.setSeqId("chr1");
+        gff1.setStart(1);
+        gff1.setEnd(10);
+        Gff3Record gff2 = new Gff3Record();
+        gff2.setSeqId("chr1");
+        gff2.setStart(11);
+        gff2.setEnd(20);
+        Gff3Record gff3 = new Gff3Record();
+        gff3.setSeqId("chr1");
+        gff3.setStart(31);
+        gff3.setEnd(40);
+        Gff3Record gff4 = new Gff3Record();
+        gff4.setSeqId("chr2");
+        gff4.setStart(15);
+        gff4.setEnd(25);
+        Gff3Record gff5 = new Gff3Record();
+        gff5.setSeqId("chr2");
+        gff5.setStart(26);
+        gff5.setEnd(40);
+        Gff3Record gff6 = new Gff3Record();
+        gff6.setSeqId("chrX");
+        gff6.setStart(100026);
+        gff6.setEnd(100040);
+
+        List<Gff3Record> gffs = new ArrayList<Gff3Record>();
+        gffs.add(gff1);
+        gffs.add(gff2);
+        gffs.add(gff3);
+        gffs.add(gff4);
+        gffs.add(gff5);
+        gffs.add(gff6);
+        Iterator<Gff3Record> iter = gffs.iterator();
+
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr0", 0, iter, iter.next()));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 0, iter, gff1));
+
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 1, iter, gff1));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 10, iter, gff1));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 11, iter, gff1));
+        // iterator should have been advanced
+        Assert.assertEquals(gff2, WiggleFromPileup.getGffRecord());
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 20, iter, gff2));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 21, iter, gff2));
+        // iterator should have been advanced
+        Assert.assertEquals(gff3, WiggleFromPileup.getGffRecord());
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 29, iter, gff3));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 31, iter, gff3));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr1", 40, iter, gff3));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 41, iter, gff3));
+        // iterator should have been advanced
+        Assert.assertEquals(gff4, WiggleFromPileup.getGffRecord());
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 141, iter, gff4));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 142, iter, gff4));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr1", 1000142, iter, gff4));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr2", 1, iter, gff4));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr2", 2, iter, gff4));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr2", 15, iter, gff4));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr2", 25, iter, gff4));
+        assertTrue(WiggleFromPileup.isPositionInBait("chr2", 26, iter, gff4));
+        // iterator should have been advanced
+        Assert.assertEquals(gff5, WiggleFromPileup.getGffRecord());
+        assertTrue(WiggleFromPileup.isPositionInBait("chr2", 40, iter, gff5));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr2", 41, iter, gff5));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr3", 15, iter, gff5));
+        // iterator should have been advanced
+        Assert.assertEquals(gff6, WiggleFromPileup.getGffRecord());
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr3", 10015, iter, gff6));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr4", 10015, iter, gff6));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr5", 10015, iter, gff6));
+        Assert.assertFalse(WiggleFromPileup.isPositionInBait("chr15", 10015, iter, gff6));
+        assertTrue(WiggleFromPileup.isPositionInBait("chrX", 100026, iter, gff6));
+
+    }
+
+    @Test
+    public final void callWithNoArgs() throws Exception {
+        String command = "";
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
+        assertEquals(1, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+        assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
+    }
+
+    @Test
+    public final void callWithNoInputFile() throws Exception {
+        String command = "-log ./logfile -o " + tempFolder.getRoot().getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
+        assertEquals(1, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+        assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
+    }
+
+    @Test
+    public final void callWithMissingArgs() throws Exception {
+        String command = "-log ./logfile -o blah.wiggle -i " + pileupFile.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
+        assertEquals(1, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+        assertTrue(0 < exec.getErrorStreamConsumer().getLines().length);
+    }
+
+    @Test
+    public final void callWithValidArguments() throws Exception {
+        String command = "-log ./logfile -pileupFormat NNTT -normalCoverage 1 -tumourCoverage 1 -i " + pileupFile.getAbsolutePath()
+                + " -i " + gff3File.getAbsolutePath()
+                + " -o " + wiggleFile.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
+        assertEquals(0, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+
+        // check the wiggle file
+        InputStream reader = new FileInputStream(wiggleFile);
+        assertEquals(29, examineWiggle(reader));
+    }
+
+    @Test
+    public final void callWithValidArgumentsLargeCoverage() throws Exception {
+        String command = "-log ./logfile -pileupFormat NNTT -normalCoverage 50 -tumourCoverage 50 -i " + pileupFile.getAbsolutePath()
+                + " -i " + gff3File.getAbsolutePath()
+                + " -o " + wiggleFile.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
+        assertEquals(0, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+
+        // check the wiggle file
+        InputStream reader = new FileInputStream(wiggleFile);
+        assertEquals(0, examineWiggle(reader));
+    }
+
+    @Test
+    public final void callWithZippedFiles() throws Exception {
+        String command = "-log ./logfile -pileupFormat NNTT -normalCoverage 20 -tumourCoverage 20 -i " + pileupFileGZIP.getAbsolutePath()
+                + " -i " + gff3File.getAbsolutePath()
+                + " -o " + wiggleFileGZIP.getAbsolutePath();
+        Executor exec = new Executor(command, "org.qcmg.qmule.WiggleFromPileup");
+        assertEquals(0, exec.getErrCode());
+        assertEquals(0, exec.getOutputStreamConsumer().getLines().length);
+
+        // check the wiggle file
+        InputStream reader = new GZIPInputStream(new FileInputStream(wiggleFileGZIP));
+        assertEquals(14, examineWiggle(reader));
+    }
+
+    private int examineWiggle(InputStream reader) throws IOException {
+        int count = 0;
+        BufferedReader fr = new BufferedReader(new InputStreamReader(reader));
+        String line = fr.readLine();    // first line has the header
+        while ((line = fr.readLine()) != null) {
+            if (line.startsWith("fixedStep")) continue;
+            count += Integer.parseInt(line);
+        }
+        return count;
+    }
+
+    private void createPileupFile(File pileupFile) throws IOException {
+
+        OutputStream os = FileUtils.isFileNameGZip(pileupFile) ? new GZIPOutputStream(new FileOutputStream(pileupFile))
+                : new FileOutputStream(pileupFile);
+
+        PrintStream ps = new PrintStream(os);
+
+        ps.println("chr1\t14923\tG\t8\t.......^!.\tIIIIIIIE\t7\t,.....^!.\t5IIIIIE\t10\t.........^T.\t0IIIIIIIIE\t7\t...,...\tIIIIIII");
+        ps.println("chr1\t14924\tA\t9\t........^!.\tEI@III?IB\t7\t,......\t@IIIIII\t10\t..........\t-IIIIIIIII\t8\t...,...^!.\tIIII/IIB");
+        ps.println("chr1\t14925\tA\t11\t.........^!.^P.\tIIDIIIHIEEE\t8\t,......^N.\tBIIIIIIE\t10\t..........\t)IIIIIIIII\t8\t...,....\tIII:4IIE");
+        ps.println("chr1\t14926\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t9IIIIIII\t10\t..........\t-IIIIIIIII\t8\t...,....\tIIH;DIII");
+        ps.println("chr1\t14927\tT\t11\t...........\tDIIIIIIIIII\t8\t,.......\t8IIIIIII\t11\t..........^O.\t&FIIIIIIIIE\t8\t...,....\tII:>IIII");
+        ps.println("chr1\t14928\tA\t11\t...........\tIIIIIIIIIII\t9\t,.......^(.\tGAIIIIIIE\t12\t...........^G.\t&CIBIIII9IIE\t8\t...,....\tII;0DIII");
+        ps.println("chr1\t14929\tC\t11\t...........\t<HIIIIIIIII\t9\t,........\tA3IIIIIII\t12\t............\t'DI?IIIIIIII\t8\t...,....\tHIB%5III");
+        ps.println("chr1\t14930\tA\t11\t..G..G.....\t8I7CI7GIIII\t9\t,.G..G...\t6,7%I7III\t12\t.G.GG.......\t(:I77IIIIIII\t8\tG..,..G.\t1I:%9I7I");
+        ps.println("chr1\t14931\tA\t11\t...........\tBI7BI7>IIII\t9\t,........\tB37%I7III\t12\t............\t9FI77IIIIIII\t8\t...,....\t?I;>4I7I");
+        ps.println("chr1\t14932\tG\t11\t...........\tI=IIIIIIIII\t9\t,........\t?@IIIIIII\t12\t............\t>IIIIIIIIIII\t8\t...,....\t?ICI@III");
+        ps.println("chr1\t14933\tG\t11\t...........\tEAIIIIDIIII\t9\t,........\tD8III?III\t12\t............\t3EIIIIIIIIII\t9\t...,....^L.\t8I9HIIIIE");
+        ps.println("chr1\t14934\tT\t11\t...........\t9I>III<IIII\t9\t,........\tIGIIIIIII\t12\t............\t+IIIIIIIIIII\t9\t...,.....\tIIAAGIGII");
+        ps.println("chr1\t14935\tG\t12\t...........^!.\tIF>IIIFIIIIE\t9\t,........\tHCIIIIIII\t12\t............\t*IIIIIIIIIII\t9\t...,.....\tIII7IIIII");
+        ps.println("chr1\t14936\tC\t12\t............\tI@IIIIIIIIII\t9\t,........\tBIIDIIIII\t12\t............\t8GIIIIIIIIII\t9\t...,.....\tIII,BIIII");
+        ps.println("chr1\t14937\tT\t12\t............\tIIIIIIIIIIII\t9\t,........\t8IIIIFIII\t12\t............\t:IIIIIIIIIII\t9\t...,.....\tBII?)IIII");
+        ps.println("chr1\t14938\tG\t12\t....$........\t%=I1II6IFIII\t9\t,........\tD%IIB/IHI\t12\t............\t3II>IIIIIIHI\t9\t...,.....\t0IAI/I?II");
+        ps.println("chr1\t14939\tG\t11\t...........\t%@IHI:IIIHI\t9\t,........\tI%II@CIDI\t12\t............\t7IICIIIIII9A\t9\t...,.....\t1IAI;I9II");
+        ps.println("chr1\t14940\tC\t11\t...........\t:IF?I-IIIII\t9\t,........\tF+II+IIII\t12\t......$......\t2%I%A>I>IIIA\t9\t...,.....\t3?)G:I<IIv");
+        ps.println("chr1\t14941\tC\t11\t...........\t7IF?I-III=I\t9\t,........\tD,II+IIGI\t11\t.......$....\t7%E%1I/IIII\t9\t...,.....\tE1)B%ICIA");
+        ps.println("chr1\t14942\tC\t11\t...........\tDFIIIIIIG=I\t9\t,........\tC4IIIEIII\t10\t..........\t7IIIIIIIII\t9\t...,.....\tIDII%IIII");
+        ps.println("chr1\t14943\tA\t11\t...........\t)9EFI%IICFI\t9\t,........\tI@FII+I&G\t10\t.$.........\t'IIIIIEIII\t9\t.$..,.....\t@I@?=I>II");
+        ps.println("chr1\t14944\tG\t11\t.....C.....\t(//AI%IIIFI\t9\t,$........\tI<BIB2I&F\t9\t.........\tE87EI?EI?\t8\t..,.....\t3.I&H:I:");
+        ps.println("chr1\t14945\tG\t11\t.....C.....\t/>=II%ICIII\t8\t.$.......\t2II@6IBI\t9\t.........\t?:16IIB=,\t8\t..,.....\t9/%&>CI0");
+        ps.println("chr1\t14946\tG\t11\t...........\t3I>II%I@I(I\t7\t.......\tIICIIII\t9\t.........\t4ID?II@GD\t8\t..,.....\tI@%;HIII");
+        ps.println("chr1\t14947\tC\t11\t...$........\tDI?IIAIDI(I\t7\t.......\tIIIIIII\t9\t.$.....N$..\tEI58II!(B\t8\t..,.....\tI@C?IIII");
+        ps.println("chr1\t14948\tG\t10\t.$.$........\t=;-%3I6I<I\t7\t.......\tEIC%IG<\t7\t.$......\t5%),A%,\t8\t..,.$....\t90I0BF;>");
+        ps.println("chr1\t14949\tG\t8\t.......$.\t5%6I>I%D\t7\t.......\tBI:%I;B\t6\t......\t*1,:0%\t7\t.$.,....\t'1I59;'");
+        ps.println("chr1\t14950\tG\t7\t.$......\t?H3B+B7\t7\t.$......\t:+%%D7@\t6\t......\t%-%50%\t6\t.,....\t-I3'C'");
+        ps.println("chr1\t14951\tC\t6\t......\tG2=+95\t6\t......\t)%%A6C\t6\t......\t%9%C89\t6\t.,....\t8H6(=%");
+
+        ps.close();
+        os.close();
+    }
+
+    private void createGFF3File(File pileupFile) throws IOException {
+
+        OutputStream os = FileUtils.isFileNameGZip(pileupFile) ? new GZIPOutputStream(new FileOutputStream(pileupFile))
+                : new FileOutputStream(pileupFile);
+
+        PrintStream ps = new PrintStream(os);
+
+
+        ps.println("##gff-version 3");
+        ps.println("# Created by: simple_segmenter.pl[v2940]");
+        ps.println("# Created on: Tue May 24 01:48:54 2011");
+        ps.println("# Commandline: -v -g -l -i SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524.gff3 -o SureSelect_All_Exon_50mb_filtered_exons_1-200_20110524_shoulders.gff3 -f exon,100,100,100 -f highexon,300 -f lowexon");
+        ps.println("chr1	simple_segmenter.pl[v2940]	fill	1	14166	.	.	.	ID=gnl|fill");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	14167	14266	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	14267	14366	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14367	14466	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14467	14587	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	14588	14638	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14639	14883	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon	14884	14942	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	14943	15064	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15065	15164	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15165	15264	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15265	15364	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	fill	15365	15370	.	.	.	ID=gnl|fill");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	15371	15470	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	15471	15570	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15571	15670	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	15671	15990	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	15991	16090	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16091	16190	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	16191	16390	.	+	.	ID=gnl|exon_3_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	16391	16490	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16491	16590	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16591	16719	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	16720	16749	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	16750	17074	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17075	17177	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17178	17420	.	+	.	ID=ens|ENST00000423562,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	17421	17442	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	17443	18108	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18109	18202	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	SureSelect_All_Exon_50mb_with_annotation.hg19.bed	exon	18203	18448	.	+	.	ID=ens|ENST00000423562,ens|ENST00000430492,ens|ENST00000438504,ens|ENST00000488147,ref|NR_024540,ref|WASH7P");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_1_100	18449	18548	.	+	.	ID=gnl|exon_1_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_2_100	18549	18648	.	+	.	ID=gnl|exon_2_100");
+        ps.println("chr1	simple_segmenter.pl[v2940]	exon_3_100	18649	18848	.	+	.	ID=gnl|exon_3_100");
+
+        ps.close();
+        os.close();
+    }
 }

--- a/qpileup/build.gradle
+++ b/qpileup/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation project(':qio')
     implementation project(':qbamfilter')
 	
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
     implementation name: 'jhdf'
     implementation name: 'jhdf5'

--- a/qprofiler/build.gradle
+++ b/qprofiler/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     implementation project(':qvisualise')
 
     implementation 'org.apache.commons:commons-math3:3.3'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 	
 }

--- a/qprofiler2/build.gradle
+++ b/qprofiler2/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation project(':qpicard')
     implementation project(':qio')
 
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }
 

--- a/qprofiler2/test/org/qcmg/qprofiler2/QProfiler2Test.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/QProfiler2Test.java
@@ -1,262 +1,259 @@
 package org.qcmg.qprofiler2;
 
-import static org.junit.Assert.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.xml.parsers.ParserConfigurationException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.qcmg.common.messages.Messages;
-import org.qcmg.qprofiler2.QProfiler2;
+
+import static org.junit.Assert.*;
 
 public class QProfiler2Test {
-	
-	private static final String DODGY_FILE_NAME =  "solid0039_20091125_DODGY.vcf";
-	private static final String GFF_FILE_NAME =  "solid0039_20091125_2.gff";
-	private static final String BAM_FILE_NAME =  "solid0039_20091125_2.sam";
-	
-	@ClassRule
-	public static TemporaryFolder testFolder = new TemporaryFolder();
-	public static File BAM_FILE;
-	
-	@BeforeClass
-	public static void setup() throws IOException {
-		BAM_FILE = testFolder.newFile(BAM_FILE_NAME);
- 		createTestFile(BAM_FILE, null);	
-	}
-	
-	@AfterClass
-	public  static void cleanup() throws IOException {
-		// delete qprofiler.xml which was default output		
-		String outputFile = System.getProperty("user.dir") + System.getProperty("file.separator") + "qprofiler.xml";
-		File output = new File(outputFile);
-		if (output.exists()) {
-			output.delete();
-		}
-	}
 
-	@Test
-	public final void executeWithValidArguments() throws Exception {
-		File logFile = testFolder.newFile("executeWithValidArguments.log");
-		File outputFile = testFolder.newFile("executeWithValidArguments.xml");
-		// qprofiler2 accept two same input once type are XML, VCF, FASTQ or BAM
-		String[] args = {"-log",  logFile.getAbsolutePath(), "-input", BAM_FILE.getAbsolutePath(),
-				"-input", BAM_FILE.getAbsolutePath(), "-o", outputFile.getAbsolutePath()};
-		int exitStatus = new QProfiler2().setup(args);
-		assertEquals(0, exitStatus);
-		
-		File dodgyFile = testFolder.newFile(DODGY_FILE_NAME);
-		createTestFile(dodgyFile, getDodgyFileContents());			
-		// argument are correct input is doggy , the exception are caught
-		args = new String[] {"-log",  logFile.getAbsolutePath(), "-input", dodgyFile.getAbsolutePath(),
-				 "-o", outputFile.getAbsolutePath()};
-		exitStatus = new QProfiler2().setup(args);
-		assertEquals(1, exitStatus);
-		
-		assertTrue(outputFile.exists());
-	}
-	
-	@Test
-	public final void executeWithNoArgs() throws Exception {
-		String[] args = {};
-		try {
-			int exitStatus = new QProfiler2().setup(args);
-			assertEquals(1, exitStatus);
-		} catch (Exception e) {
-			fail("no exception should have been thrown from executeWithNoArgs()");
-		}
-	}
-		
-	@Test 
-	public final void executeWithInvalidArgs() throws Exception {
-		File logFile = testFolder.newFile("executeWithInvalidArguments.log");
-		
-		//"-include" will be treat as "-i"; "-i" was short option for both "input" and "index"				
-		//eg. String[] args2 = new String[] {"-input", BAM_FILE.getAbsolutePath(), "-log",logFile.getAbsolutePath(), "-include", "html,all,matricies,coverage" };
-		//get error: assertEquals("'i' is not a recognized option", e.getMessage() );
-		
-		try {
-			//"--include" is long option, it won't ambiguous with "input"
-			String[] args2 = new String[] {"-i", BAM_FILE.getAbsolutePath(), "-log",logFile.getAbsolutePath(), "--include", "html,all,matricies,coverage" };
-			new QProfiler2().setup(args2);
-			fail("no exception should have been thrown from executeWithExcludeArgs()");			 
-		} catch (Exception e) {			
-			//here "include" is invalid, so it throw the error with long option
-			assertEquals("'include' is not a recognized option", e.getMessage() );
-		}
-	}
-	
-	@Test
-	public final void executeWithInvalidFileType() throws Exception {
-		File gffFile = testFolder.newFile(GFF_FILE_NAME);		
-		File logFile = testFolder.newFile("executeWithInvalidFileType.log");
-		File inputFile = testFolder.newFile("executeWithInvalidFileType.test");
-		
-		String[] args1 = {"-input",inputFile.getAbsolutePath(), "-log", logFile.getAbsolutePath()};
-		String[] args2 = new String[] {"-input",gffFile.getAbsolutePath(), "-log", logFile.getAbsolutePath()};	
-		
-		for (String[] args : new String[][] {args1, args2}) {
-			try {
-				new QProfiler2().setup(args);
-				fail("Should have thrown a QProfilerException");
-			} catch (Exception qpe) {
-				assertTrue(qpe.getMessage().contains( "Unsupported file type" ));
-			}
-		}
-	}
-	
-	@Ignore
-	public final void executeWithNonexistantInputFile() throws Exception {
-		File logFile = testFolder.newFile("executeWithNonexistantInputFile.log");
-		
-		String[] args = {"-input","test123.sam", "-log", logFile.getAbsolutePath()};
-		try {
-			new QProfiler2().setup(args);
-			fail("Should have thrown a QProfilerException");
-		} catch (Exception qpe) {
-			qpe.printStackTrace();
-			assertTrue(qpe.getMessage().startsWith("Cannot read supplied input file"));
-		}
-	}
-	
-	@Test
-	public void schmeFileTest() throws IOException {
-		String nameSpace = "https://adamajava.org/xsd/qprofiler2/v2";
-		String xmlns = "xmlns=\"" + nameSpace + "\"";
-		
-		String schemaXsi = "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"";
-		String schemaStr = "xsi:schemaLocation=\"" + nameSpace + " https://purl.org/adamajava/xsd/qprofiler2/v2/qprofiler2.xsd\"";
-		String input = BAM_FILE.getAbsolutePath();		
-		File logFile = testFolder.newFile("qProfilerNode.log");
-		String[] args = {"-input",input, "-log", logFile.getAbsolutePath()};
-		try {		
-			// print full header		
-			new QProfiler2().setup( args );	
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains(schemaStr)).count()== 1);
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains(schemaXsi)).count()== 1);
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains(xmlns)).count()== 1);			 
-		} catch (Exception qpe) {
-			fail("a QProfilerException for args: " + Arrays.toString(args));			 
-		}
-	}
-	
-	@Test
-	public void bamHeaderOptionTest() throws IOException, ParserConfigurationException {
-		
-		String input = BAM_FILE.getAbsolutePath();
-		File logFile = testFolder.newFile();
-		String[] args = {"-input", input , "-log", logFile.getAbsolutePath()};
-		try {		
-			// print full header		
-			new QProfiler2().setup( args );	
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"HD\"")).count()== 1);	
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"SQ\"")).count()== 1);
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"PG\"")).count()== 0);	
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"RG\"")).count()== 0);							
-			// only one line for whole file
-			assertTrue( Files.lines(Paths.get(  "qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=")).count()== 1);						
-			// default mode, only HD and RG
-			args = new String[] {"-input",input, "-log", logFile.getAbsolutePath(), "--bam-full-header"};
-			new QProfiler2().setup( args );	
-			assertTrue( Files.lines(Paths.get(  "qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"HD\"")).count()== 1);	
-			assertTrue( Files.lines(Paths.get(  "qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"SQ\"")).count()== 1);			
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"PG\"")).count()== 1);	
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("<headerRecords TAG=\"RG\"")).count()== 1);					
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("@RG	ID:1959T")).count()== 1);
-			assertTrue( Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains("@RG	ID:1959N")).count()== 1);				 
-		} catch (Exception qpe) {
-			fail("a QProfilerException for args: " + Arrays.toString(args));		 
-		}
-	}
-	
-	private static void createTestFile(File file, List<String> data) {
-		
-		if (data == null) {		
-			data = new ArrayList<String>();
-	        data.add("@HD	VN:1.0	SO:coordinate");
-	        data.add("@RG	ID:1959T	SM:eBeads_20091110_CD	DS:rl=50");
-	        data.add("@RG	ID:1959N	SM:eBeads_20091110_ND	DS:rl=50");
-	        data.add("@PG	ID:SOLID-GffToSam	VN:1.4.3");
-	        data.add("@SQ	SN:chr1	LN:249250621");
-	        data.add("@SQ	SN:chr11	LN:243199373");
-			// unmapped
-			data.add("243_146_1	101	chr1	10075	0	*	=	10167	0	" +		 
-					"ACCCTAACCCTAACCCTAACCNTAACCCTAACCCAAC	+3?GH##;9@D7HI5,:IIB\"!\"II##>II$$BIIC3	" +
-					"RG:Z:1959T	CS:Z:T11010020320310312010320010320013320012232201032202	CQ:Z:**:921$795*#5:;##):<5&'/=,,9(2*#453-'%(.2$6&39$+4'");
-		}
-                
-		try(BufferedWriter out = new BufferedWriter(new FileWriter(file))) {	    
-			for (String line : data)  out.write(line + "\n");	               
-		}catch (IOException e) {
-			System.err.println("IOException caught whilst attempting to write to test file: " + file.getAbsolutePath());
-			e.printStackTrace();
-		}		
-	}
-	
-	private List<String> getDodgyFileContents() {
-		List<String> data = new ArrayList<String>();
-		data.add("##gff-version 3");
-		data.add("##solid-gff-version 3.5");
-		data.add("##source-version Gff3Merger 0.1");
-		data.add("##date 2010-03-10");
-		data.add("##time 15:04:36");
-		data.add("##reference-file /path/reference/hg19.fa");
-		data.add("##color-code AA=0,AC=1,AG=2,AT=3,CA=1,CC=0,CG=3,CT=2,GA=2,GC=3,GG=0,GT=1,TA=3,TC=2,TG=1,TT=0");
-		data.add("##primer-base F3=T");
-		data.add("##max-num-mismatches 10");
-		data.add("##max-read-length 50");
-		data.add("##line-order fragment");
-		data.add("##contig 1 chr1");
-		data.add("##contig 2 chr2");
-		data.add("##contig 3 chr3");
-		data.add("##contig 4 chr4");
-		data.add("##contig 5 chr5");
-		data.add("##contig 6 chr6");
-		data.add("##contig 7 chr7");
-		data.add("##contig 8 chr8");
-		data.add("##contig 9 chr9");
-		data.add("##contig 10 chr10");
-		data.add("##contig 11 chr11");
-		data.add("##contig 12 chr12");
-		data.add("##contig 13 chr13");
-		data.add("##contig 14 chr14");
-		data.add("##contig 15 chr15");
-		data.add("##contig 16 chr16");
-		data.add("##contig 17 chr17");
-		data.add("##contig 18 chr18");
-		data.add("##contig 19 chr19");
-		data.add("##contig 20 chr20");
-		data.add("##contig 21 chr21");
-		data.add("##contig 22 chr22");
-		data.add("##contig 23 chrX");
-		data.add("	##contig 24 chrY");
-		data.add("	##contig 25 chrM");
-		data.add("##conversion unique");
-		data.add("##clear-zone 5");
-		data.add("##history AnnotateGff3Changes.java /path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/outputs/../intermediate_maToGff3/output.325614874493032/output.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0.gff3 /path/reference/hg19.fa --out=/path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/outputs/../intermediate_maToGff3/output.325614874493032/output.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0.annotated.gff3 --tints=agy --qvThreshold=15 --b=true --cn=true");
-		data.add("##history mapping/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma 50 3 0.200000 B=1.000000 P=1 L=25 F=0 m=-2.000000");
-		data.add("##history MaToGff3.java /path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/temp_maToGff3/split.323675630031032/temp.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0 --out=/path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/outputs/../intermediate_maToGff3/output.325614874493032/output.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0.gff3 --clear=5 --qvs=/data/results/Aditya/gabe/gabe_raw_reads/solid0039_20091125_2_TD04_LMP_F3/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3_QV.qual --mmp=-2.0 --tempdir=/scratch/solid");
-		data.add("##history filter_fasta.pl --output=/data/results/solid0039/solid0039_20091125_2_TD04_LMP/eBeads_20091110_CD/results.01/primary.20091221012849245 --name=solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD --tag=F3 --minlength=50 --mincalls=25 --prefix=T /data/results/solid0039/solid0039_20091125_2_TD04_LMP/eBeads_20091110_CD/jobs/postPrimerSetPrimary.937/rawseq");
-		data.add("##hdr seqid	source	type	start	end	score	strand	phase	attributes");
-		data.add("1	solid	read	10148	10190	14.4	-	.	aID=1212_1636_246;at=F3;b=GGTTAGGGTTAGGTTAGGGTTAGGGTTAGGGTTAGGGTTAGGG;g=G0103200103201032001033001032001032001032001032001;mq=43;o=0;q=31,30,32,26,26,26,23,24,29,31,31,23,25,18,14,20,18,11,27,22,18,23,2,18,29,20,25,11,19,18,18,13,14,18,19,16,14,5,16,23,18,21,16,16,14,20,13,17,20,11;r=23_2;s=a23;u=0,4,1,1");
-		data.add("1	solid	read	10236	10275	19.6	-	.	aID=681_1482_392;at=F3;b=TTAGGGTTAGGGTTAGGGTTTAGGGTTTAGGGTTAGGGTT;g=T0320010320010320010032001003200103200100320000320;mq=18;o=0;q=25,27,28,29,25,27,28,28,23,26,27,26,27,28,28,24,28,24,30,26,20,29,23,25,27,10,27,26,22,24,20,13,23,24,29,17,26,26,23,27,25,13,22,23,27,8,16,28,20,26;u=8,0,46,1,27,3,1");
-		data.add("1	solid	read	10248	10290	10.5	+	.	aID=1578_430_829;at=F3;b=AAACCCTAAACCCTAACCCTAACCCTAACCCTAACCCTAACCC;g=A0010023001002301003301002301002300002301002300003;mq=72;o=0;q=8,23,18,16,18,14,20,21,20,9,11,28,14,18,11,14,7,15,13,5,14,20,5,21,8,11,11,14,8,25,22,7,5,20,7,20,8,11,8,11,7,13,11,14,8,11,20,21,8,5;r=20_2,35_1;s=a20,a35;u=0,0,1");
-		data.add("1	solid	read	10456	10480	9.4	+	.	aID=266_752_1391;at=F3;b=TAACCCTAACCCTCGCGGTACCCTC;g=T1303013131001013013023010022333003100220000000202;mq=7;o=15;q=13,11,20,18,15,5,25,16,16,31,8,7,8,14,6,26,11,5,5,11,5,10,5,5,8,18,15,8,24,7,7,19,7,26,10,19,21,5,8,8,8,21,8,18,7,20,19,14,9,14;r=20_0,34_1;s=a20,a34;u=0,0,1");
-		data.add("1	solid	read	13290	13336	7.9	-	.	");
-		data.add("1	solid	read	13301	13342	4.9	+	.	aID=1986_1440_4;at=F3;b=ACGCTGTTGGCCTGGATCTGAGCCCTGGgtGAGGTCAAAGCC;g=A1333110103021023221223202100112201213023020022210;mq=21;o=0;q=13,2,15,5,3,11,13,4,9,7,19,12,2,7,3,2,11,11,3,4,19,8,6,2,11,9,2,4,2,2,4,4,4,2,9,16,4,2,2,19,5,2,4,2,2,2,13,17,11,6;r=5_2,24_0,29_1,31_0,38_0;rb=29_T,30_G;s=a5,a24,y29,y30,y31,a38;u=0,0,0,0,0,1,0,1");
-		data.add("1	solid	read	14933	14973	9.5	+	.	aID=2140_530_759;at=F3;b=GTGCTGGCCCAGGGCGGGCAGCGGCCCTGCCTCCTACCCTT;g=G1132103001200330031233230022302202312020222222202;mq=54;o=0;q=27,20,20,17,21,22,13,15,6,22,20,19,3,9,25,23,14,17,2,25,24,7,2,3,25,26,5,18,8,22,25,21,20,14,5,26,5,5,23,20,23,19,19,13,5,13,20,16,8,5;r=24_0,29_1,38_0;s=a24,a29,a38;u=0,0,0,1");
-		return data;
-	}
-	
+    private static final String DODGY_FILE_NAME = "solid0039_20091125_DODGY.vcf";
+    private static final String GFF_FILE_NAME = "solid0039_20091125_2.gff";
+    private static final String BAM_FILE_NAME = "solid0039_20091125_2.sam";
+
+    @ClassRule
+    public static TemporaryFolder testFolder = new TemporaryFolder();
+    public static File BAM_FILE;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        BAM_FILE = testFolder.newFile(BAM_FILE_NAME);
+        createTestFile(BAM_FILE, null);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        // delete qprofiler.xml which was default output
+        String outputFile = System.getProperty("user.dir") + FileSystems.getDefault().getSeparator() + "qprofiler.xml";
+        File output = new File(outputFile);
+        if (output.exists()) {
+            output.delete();
+        }
+    }
+
+    @Test
+    public final void executeWithValidArguments() throws Exception {
+        File logFile = testFolder.newFile("executeWithValidArguments.log");
+        File outputFile = testFolder.newFile("executeWithValidArguments.xml");
+        // qprofiler2 accept two same input once type are XML, VCF, FASTQ or BAM
+        String[] args = {"-log", logFile.getAbsolutePath(), "-input", BAM_FILE.getAbsolutePath(),
+                "-input", BAM_FILE.getAbsolutePath(), "-o", outputFile.getAbsolutePath()};
+        int exitStatus = new QProfiler2().setup(args);
+        assertEquals(0, exitStatus);
+
+        File dodgyFile = testFolder.newFile(DODGY_FILE_NAME);
+        createTestFile(dodgyFile, getDodgyFileContents());
+        // argument are correct input is doggy , the exception are caught
+        args = new String[]{"-log", logFile.getAbsolutePath(), "-input", dodgyFile.getAbsolutePath(),
+                "-o", outputFile.getAbsolutePath()};
+        exitStatus = new QProfiler2().setup(args);
+        assertEquals(1, exitStatus);
+
+        assertTrue(outputFile.exists());
+    }
+
+    @Test
+    public final void executeWithNoArgs() {
+        String[] args = {};
+        try {
+            int exitStatus = new QProfiler2().setup(args);
+            assertEquals(1, exitStatus);
+        } catch (Exception e) {
+            fail("no exception should have been thrown from executeWithNoArgs()");
+        }
+    }
+
+    @Test
+    public final void executeWithInvalidArgs() throws Exception {
+        File logFile = testFolder.newFile("executeWithInvalidArguments.log");
+
+        //"-include" will be treated as "-i"; "-i" was short option for both "input" and "index"
+        //eg. String[] args2 = new String[] {"-input", BAM_FILE.getAbsolutePath(), "-log",logFile.getAbsolutePath(), "-include", "html,all,matricies,coverage" };
+        //get error: assertEquals("'i' is not a recognized option", e.getMessage() );
+
+        try {
+            //"--include" is long option, it won't be ambiguous with "input"
+            String[] args2 = new String[]{"-i", BAM_FILE.getAbsolutePath(), "-log", logFile.getAbsolutePath(), "--include", "html,all,matricies,coverage"};
+            new QProfiler2().setup(args2);
+            fail("no exception should have been thrown from executeWithExcludeArgs()");
+        } catch (Exception e) {
+            //here "include" is invalid, so it throw the error with long option
+            assertEquals("include is not a recognized option", e.getMessage());
+        }
+    }
+
+    @Test
+    public final void executeWithInvalidFileType() throws Exception {
+        File gffFile = testFolder.newFile(GFF_FILE_NAME);
+        File logFile = testFolder.newFile("executeWithInvalidFileType.log");
+        File inputFile = testFolder.newFile("executeWithInvalidFileType.test");
+
+        String[] args1 = {"-input", inputFile.getAbsolutePath(), "-log", logFile.getAbsolutePath()};
+        String[] args2 = new String[]{"-input", gffFile.getAbsolutePath(), "-log", logFile.getAbsolutePath()};
+
+        for (String[] args : new String[][]{args1, args2}) {
+            try {
+                new QProfiler2().setup(args);
+                fail("Should have thrown a QProfilerException");
+            } catch (Exception qpe) {
+                assertTrue(qpe.getMessage().contains("Unsupported file type"));
+            }
+        }
+    }
+
+    @Test
+    public void schmeFileTest() throws IOException {
+        String nameSpace = "https://adamajava.org/xsd/qprofiler2/v2";
+        String xmlns = "xmlns=\"" + nameSpace + "\"";
+
+        String schemaXsi = "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"";
+        String schemaStr = "xsi:schemaLocation=\"" + nameSpace + " https://purl.org/adamajava/xsd/qprofiler2/v2/qprofiler2.xsd\"";
+        String input = BAM_FILE.getAbsolutePath();
+        File logFile = testFolder.newFile("qProfilerNode.log");
+        String[] args = {"-input", input, "-log", logFile.getAbsolutePath()};
+        try {
+            // print full header
+            new QProfiler2().setup(args);
+            assertEquals(1, Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains(schemaStr)).count());
+            assertEquals(1, Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains(schemaXsi)).count());
+            assertEquals(1, Files.lines(Paths.get("qprofiler.xml")).filter(s -> s.contains(xmlns)).count());
+        } catch (Exception qpe) {
+            fail("a QProfilerException for args: " + Arrays.toString(args));
+        }
+    }
+
+    @Test
+    public void bamHeaderOptionTest() throws IOException, ParserConfigurationException {
+
+        String input = BAM_FILE.getAbsolutePath();
+        File logFile = testFolder.newFile();
+        String[] args = {"-input", input, "-log", logFile.getAbsolutePath()};
+        try {
+            // print full header
+            new QProfiler2().setup(args);
+            Path path = Paths.get("qprofiler.xml");
+            List<String> lines = Files.readAllLines(path);
+            assertEquals(1, lines.size());
+            String line = lines.getFirst();
+
+            assertTrue(line.contains("<headerRecords TAG=\"HD\""));
+            assertTrue(line.contains("<headerRecords TAG=\"SQ\""));
+            assertFalse(line.contains("<headerRecords TAG=\"PG\""));
+            assertFalse(line.contains("<headerRecords TAG=\"RG\""));
+
+            // default mode, only HD and RG
+            args = new String[]{"-input", input, "-log", logFile.getAbsolutePath(), "--bam-full-header"};
+            new QProfiler2().setup(args);
+
+            lines = Files.readAllLines(path);
+            assertEquals(1, lines.size());
+            line = lines.getFirst();
+
+            assertTrue(line.contains("<headerRecords TAG=\"HD\""));
+            assertTrue(line.contains("<headerRecords TAG=\"SQ\""));
+            assertTrue(line.contains("<headerRecords TAG=\"PG\""));
+            assertTrue(line.contains("<headerRecords TAG=\"RG\""));
+            assertTrue(line.contains("@RG	ID:1959T"));
+            assertTrue(line.contains("@RG	ID:1959N"));
+
+        } catch (Exception qpe) {
+            fail("a QProfilerException for args: " + Arrays.toString(args));
+        }
+    }
+
+    private static void createTestFile(File file, List<String> data) {
+
+        if (data == null) {
+            data = new ArrayList<>();
+            data.add("@HD	VN:1.0	SO:coordinate");
+            data.add("@RG	ID:1959T	SM:eBeads_20091110_CD	DS:rl=50");
+            data.add("@RG	ID:1959N	SM:eBeads_20091110_ND	DS:rl=50");
+            data.add("@PG	ID:SOLID-GffToSam	VN:1.4.3");
+            data.add("@SQ	SN:chr1	LN:249250621");
+            data.add("@SQ	SN:chr11	LN:243199373");
+            // unmapped
+            data.add("243_146_1	101	chr1	10075	0	*	=	10167	0	" +
+                    "ACCCTAACCCTAACCCTAACCNTAACCCTAACCCAAC	+3?GH##;9@D7HI5,:IIB\"!\"II##>II$$BIIC3	" +
+                    "RG:Z:1959T	CS:Z:T11010020320310312010320010320013320012232201032202	CQ:Z:**:921$795*#5:;##):<5&'/=,,9(2*#453-'%(.2$6&39$+4'");
+        }
+
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(file))) {
+            for (String line : data) out.write(line + "\n");
+        } catch (IOException e) {
+            System.err.println("IOException caught whilst attempting to write to test file: " + file.getAbsolutePath());
+            e.printStackTrace();
+        }
+    }
+
+    private List<String> getDodgyFileContents() {
+        List<String> data = new ArrayList<>();
+        data.add("##gff-version 3");
+        data.add("##solid-gff-version 3.5");
+        data.add("##source-version Gff3Merger 0.1");
+        data.add("##date 2010-03-10");
+        data.add("##time 15:04:36");
+        data.add("##reference-file /path/reference/hg19.fa");
+        data.add("##color-code AA=0,AC=1,AG=2,AT=3,CA=1,CC=0,CG=3,CT=2,GA=2,GC=3,GG=0,GT=1,TA=3,TC=2,TG=1,TT=0");
+        data.add("##primer-base F3=T");
+        data.add("##max-num-mismatches 10");
+        data.add("##max-read-length 50");
+        data.add("##line-order fragment");
+        data.add("##contig 1 chr1");
+        data.add("##contig 2 chr2");
+        data.add("##contig 3 chr3");
+        data.add("##contig 4 chr4");
+        data.add("##contig 5 chr5");
+        data.add("##contig 6 chr6");
+        data.add("##contig 7 chr7");
+        data.add("##contig 8 chr8");
+        data.add("##contig 9 chr9");
+        data.add("##contig 10 chr10");
+        data.add("##contig 11 chr11");
+        data.add("##contig 12 chr12");
+        data.add("##contig 13 chr13");
+        data.add("##contig 14 chr14");
+        data.add("##contig 15 chr15");
+        data.add("##contig 16 chr16");
+        data.add("##contig 17 chr17");
+        data.add("##contig 18 chr18");
+        data.add("##contig 19 chr19");
+        data.add("##contig 20 chr20");
+        data.add("##contig 21 chr21");
+        data.add("##contig 22 chr22");
+        data.add("##contig 23 chrX");
+        data.add("	##contig 24 chrY");
+        data.add("	##contig 25 chrM");
+        data.add("##conversion unique");
+        data.add("##clear-zone 5");
+        data.add("##history AnnotateGff3Changes.java /path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/outputs/../intermediate_maToGff3/output.325614874493032/output.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0.gff3 /path/reference/hg19.fa --out=/path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/outputs/../intermediate_maToGff3/output.325614874493032/output.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0.annotated.gff3 --tints=agy --qvThreshold=15 --b=true --cn=true");
+        data.add("##history mapping/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma 50 3 0.200000 B=1.000000 P=1 L=25 F=0 m=-2.000000");
+        data.add("##history MaToGff3.java /path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/temp_maToGff3/split.323675630031032/temp.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0 --out=/path/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3/outputs/../intermediate_maToGff3/output.325614874493032/output.0/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3.csfasta.ma.0.gff3 --clear=5 --qvs=/data/results/Aditya/gabe/gabe_raw_reads/solid0039_20091125_2_TD04_LMP_F3/solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD_F3_QV.qual --mmp=-2.0 --tempdir=/scratch/solid");
+        data.add("##history filter_fasta.pl --output=/data/results/solid0039/solid0039_20091125_2_TD04_LMP/eBeads_20091110_CD/results.01/primary.20091221012849245 --name=solid0039_20091125_2_TD04_LMP_eBeads_20091110_CD --tag=F3 --minlength=50 --mincalls=25 --prefix=T /data/results/solid0039/solid0039_20091125_2_TD04_LMP/eBeads_20091110_CD/jobs/postPrimerSetPrimary.937/rawseq");
+        data.add("##hdr seqid	source	type	start	end	score	strand	phase	attributes");
+        data.add("1	solid	read	10148	10190	14.4	-	.	aID=1212_1636_246;at=F3;b=GGTTAGGGTTAGGTTAGGGTTAGGGTTAGGGTTAGGGTTAGGG;g=G0103200103201032001033001032001032001032001032001;mq=43;o=0;q=31,30,32,26,26,26,23,24,29,31,31,23,25,18,14,20,18,11,27,22,18,23,2,18,29,20,25,11,19,18,18,13,14,18,19,16,14,5,16,23,18,21,16,16,14,20,13,17,20,11;r=23_2;s=a23;u=0,4,1,1");
+        data.add("1	solid	read	10236	10275	19.6	-	.	aID=681_1482_392;at=F3;b=TTAGGGTTAGGGTTAGGGTTTAGGGTTTAGGGTTAGGGTT;g=T0320010320010320010032001003200103200100320000320;mq=18;o=0;q=25,27,28,29,25,27,28,28,23,26,27,26,27,28,28,24,28,24,30,26,20,29,23,25,27,10,27,26,22,24,20,13,23,24,29,17,26,26,23,27,25,13,22,23,27,8,16,28,20,26;u=8,0,46,1,27,3,1");
+        data.add("1	solid	read	10248	10290	10.5	+	.	aID=1578_430_829;at=F3;b=AAACCCTAAACCCTAACCCTAACCCTAACCCTAACCCTAACCC;g=A0010023001002301003301002301002300002301002300003;mq=72;o=0;q=8,23,18,16,18,14,20,21,20,9,11,28,14,18,11,14,7,15,13,5,14,20,5,21,8,11,11,14,8,25,22,7,5,20,7,20,8,11,8,11,7,13,11,14,8,11,20,21,8,5;r=20_2,35_1;s=a20,a35;u=0,0,1");
+        data.add("1	solid	read	10456	10480	9.4	+	.	aID=266_752_1391;at=F3;b=TAACCCTAACCCTCGCGGTACCCTC;g=T1303013131001013013023010022333003100220000000202;mq=7;o=15;q=13,11,20,18,15,5,25,16,16,31,8,7,8,14,6,26,11,5,5,11,5,10,5,5,8,18,15,8,24,7,7,19,7,26,10,19,21,5,8,8,8,21,8,18,7,20,19,14,9,14;r=20_0,34_1;s=a20,a34;u=0,0,1");
+        data.add("1	solid	read	13290	13336	7.9	-	.	");
+        data.add("1	solid	read	13301	13342	4.9	+	.	aID=1986_1440_4;at=F3;b=ACGCTGTTGGCCTGGATCTGAGCCCTGGgtGAGGTCAAAGCC;g=A1333110103021023221223202100112201213023020022210;mq=21;o=0;q=13,2,15,5,3,11,13,4,9,7,19,12,2,7,3,2,11,11,3,4,19,8,6,2,11,9,2,4,2,2,4,4,4,2,9,16,4,2,2,19,5,2,4,2,2,2,13,17,11,6;r=5_2,24_0,29_1,31_0,38_0;rb=29_T,30_G;s=a5,a24,y29,y30,y31,a38;u=0,0,0,0,0,1,0,1");
+        data.add("1	solid	read	14933	14973	9.5	+	.	aID=2140_530_759;at=F3;b=GTGCTGGCCCAGGGCGGGCAGCGGCCCTGCCTCCTACCCTT;g=G1132103001200330031233230022302202312020222222202;mq=54;o=0;q=27,20,20,17,21,22,13,15,6,22,20,19,3,9,25,23,14,17,2,25,24,7,2,3,25,26,5,18,8,22,25,21,20,14,5,26,5,5,23,20,23,19,19,13,5,13,20,16,8,5;r=24_0,29_1,38_0;s=a24,a29,a38;u=0,0,0,1");
+        return data;
+    }
+
 }

--- a/qsignature/build.gradle
+++ b/qsignature/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':qio')
     
     implementation 'org.apache.commons:commons-math3:3.3'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
 	
 }

--- a/qsnp/build.gradle
+++ b/qsnp/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
     implementation 'net.sf.trove4j:core:3.1.0'
     implementation 'org.apache.commons:commons-lang3:3.4'
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'org.lz4:lz4-java:1.5.0'
     implementation 'org.scala-lang:scala-library:2.12.18'
 }

--- a/qsplit/build.gradle
+++ b/qsplit/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qpicard')
     testImplementation  project(':qtesting')
-	
-    implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.6'
+
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }
 

--- a/qsv/build.gradle
+++ b/qsv/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qio')
     implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'	
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'	
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'	
 		
     testImplementation  'org.easymock:easymock:5.2.0'
     testImplementation  group: 'commons-io', name: 'commons-io', version: '2.6'

--- a/qvisualise/build.gradle
+++ b/qvisualise/build.gradle
@@ -7,6 +7,6 @@ def isExecutable = true
 
 dependencies {
     implementation project(':qcommon')
-    implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }
 


### PR DESCRIPTION

# Description

If a vcf record being annotated has more than 1 entry in the alt field, then nanno will split that record into 2 records.
eg.
`chr1 1000 A C,T .....`
will become
`chr1 1000 A C .....`
and
`chr1 1000 A T .....`

However, nanno was using the whole of the alt field in snpEff annotation files, which meant that there would not be a match from snpEff (just for records that had more than 1 entry in the alt field).

The fix involves splitting the 'alt' field when it contains more than one value, allowing the VCF record to be annotated to match against each of these values.

Other changes:
 - reverted a change made be the previous PR #341 that removed a build.last step
 - renamed ChePositionRefAlt.getName() to getRef()
 - added GATK GT field to nano output
 - added original_alt field to nanno output (useful when splitting 1/2 variants)
 - keep original GATK_AD values rather than manipulating them (original_alt field allows for this)
 - update Executor so that spaces in the classpath (hello IDEA) don't cause the Process to fall over
 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New unit tests, along with testing on cluster

# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
