### PR TITLE
fix(qsv): no jakarta bindings implementation available on classpath

### DIFF
--- a/q3panel/build.gradle
+++ b/q3panel/build.gradle
@@ -10,10 +10,9 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qio')
 
-    implementation 'org.apache.commons:commons-lang3:3.4'
-    implementation 'net.sf.trove4j:core:3.1.0'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'com.github.samtools:htsjdk:4.0.2'
 
-    implementation group: 'com.io7m.xom',name: 'xom', version: '1.2.10'
+    // https://mvnrepository.com/artifact/xom/xom
+    implementation 'xom:xom:1.3.9'
 }

--- a/q3tiledaligner/build.gradle
+++ b/q3tiledaligner/build.gradle
@@ -10,7 +10,5 @@ dependencies {
     implementation project(':qio')
 
     implementation 'com.github.samtools:htsjdk:4.0.2'
-    implementation 'net.sf.trove4j:core:3.1.0'
-    implementation 'org.apache.commons:commons-lang3:3.4'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }

--- a/q3vcftools/build.gradle
+++ b/q3vcftools/build.gradle
@@ -16,8 +16,7 @@ dependencies {
 
     implementation 'com.github.samtools:htsjdk:4.0.2'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    implementation 'net.sf.trove4j:core:3.1.0'
-    implementation group: 'com.jcraft', name: 'jsch', version: '0.1.54'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
+    // https://mvnrepository.com/artifact/com.github.mwiede/jsch
+    implementation 'com.github.mwiede:jsch:0.2.16'
 }
 

--- a/qannotate/build.gradle
+++ b/qannotate/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation name: 'snpEff', version: '4.0e'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
 }
 //have to specify test classpath for both snpEff and qannotate 
 sourceSets.test.runtimeClasspath = configurations.junit + sourceSets.test.runtimeClasspath

--- a/qbamannotate/build.gradle
+++ b/qbamannotate/build.gradle
@@ -12,14 +12,7 @@ dependencies {
 	
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 
-    // https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
-    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
-    // https://mvnrepository.com/artifact/org.eclipse.persistence/org.eclipse.persistence.moxy
-    implementation 'org.eclipse.persistence:org.eclipse.persistence.moxy:3.0.3'
-
-
     testImplementation project(':qpicard')
     testImplementation  project(':qtesting')
-    // testImplementation 'junit:junit:4.13.2'
 }
 

--- a/qbamfix/build.gradle
+++ b/qbamfix/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     implementation project(':qcommon')
     implementation project(':qpicard')
-    implementation 'commons-cli:commons-cli:1.2'
+    // https://mvnrepository.com/artifact/commons-cli/commons-cli
+    implementation 'commons-cli:commons-cli:1.6.0'
 }
 

--- a/qcnv/build.gradle
+++ b/qcnv/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation project(':qpicard')
     implementation project(':qbamfilter')
 
-    implementation 'commons-cli:commons-cli:1.2'
+    // https://mvnrepository.com/artifact/commons-cli/commons-cli
+    implementation 'commons-cli:commons-cli:1.6.0'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 }
 

--- a/qcommon/build.gradle
+++ b/qcommon/build.gradle
@@ -3,18 +3,16 @@ apply plugin: 'java-library'
 
 dependencies {
 		
-    api 'org.apache.commons:commons-lang3:3.4'  
-    api 'net.sf.trove4j:trove4j:3.0.3'
+    api 'org.apache.commons:commons-lang3:3.14.0'
+    api 'net.sf.trove4j:core:3.1.0'
 		
     api 'com.amazonaws:aws-java-sdk-s3:1.11.241'
     api 'uk.co.lucasweb:aws-v4-signer-java:1.3'	
-    api 'org.slf4j:slf4j-api:1.7.25'
-    api 'org.slf4j:slf4j-simple:1.7.25'
-    api 'com.typesafe:config:1.3.1'
+    api 'org.slf4j:slf4j-api:2.0.11'
+    api 'org.slf4j:slf4j-simple:2.0.11'
+    api 'com.typesafe:config:1.4.3'
     
-    //jaxb is removed from JDK9+
-    //we need below jar in case to run on JDK9 and above
-    //implementation 'javax.xml.bind:jaxb-api:2.2.12' 
     api 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
+    api 'org.eclipse.persistence:org.eclipse.persistence.moxy:3.0.3'
 }
 

--- a/qcommon/src/org/qcmg/common/aws/AWSSigner.java
+++ b/qcommon/src/org/qcmg/common/aws/AWSSigner.java
@@ -102,7 +102,7 @@ public class AWSSigner {
         Map<String, List<String>> signedMVH = addSignatureMVH(service, region, target, method, contentSha256, mvh);
         Map<String, String> signedSimpleHeaders = new HashMap<>();
         for (Map.Entry<String, List<String>> h : signedMVH.entrySet()) {
-            signedSimpleHeaders.put(h.getKey(), h.getValue().get(0));
+            signedSimpleHeaders.put(h.getKey(), h.getValue().getFirst());
         }
         return signedSimpleHeaders;
     }

--- a/qcommon/src/org/qcmg/common/string/StringUtils.java
+++ b/qcommon/src/org/qcmg/common/string/StringUtils.java
@@ -6,11 +6,8 @@
  */
 package org.qcmg.common.string;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.List;
-import java.util.Set;
+import java.math.BigInteger;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.qcmg.common.model.ChrRangePosition;
@@ -35,10 +32,10 @@ public class StringUtils {
 		}
 		return String.valueOf(charArray);
 	}
-	
+
 	public static void updateStringBuilder(StringBuilder sb, CharSequence toAdd, char delim) {
 		if (null != sb) {
-			if (sb.length() > 0) {
+			if (!sb.isEmpty()) {
 				sb.append(delim);
 			}
 			sb.append(toAdd);
@@ -47,7 +44,7 @@ public class StringUtils {
 	
 	public static String parseArray2String(Object[] values){
 		if (null != values) {
-			return Arrays.stream(values).map(s -> s.toString()).collect(Collectors.joining(Constants.COMMA_STRING));
+			return Arrays.stream(values).map(Object::toString).collect(Collectors.joining(Constants.COMMA_STRING));
 		} else {
 			return null;
 		}
@@ -56,15 +53,15 @@ public class StringUtils {
 	
 	public static int[][] getStartPositionsAndLengthOfSubStrings(String reference, String sequence) {
 		List<int[]> results = new ArrayList<>();
-		int previousRefStartPosision = 0;
+		int previousRefStartPosition = 0;
 		for (int i = 0, maxLength = sequence.length() - 13; i < maxLength ; i++) {
 			String nextSeqTile = sequence.substring(i, i + 13);
-			int refNextStartPosition = reference.indexOf(nextSeqTile, previousRefStartPosision);
+			int refNextStartPosition = reference.indexOf(nextSeqTile, previousRefStartPosition);
 			if (refNextStartPosition > -1) {
 				int nextBlockLength = getLengthOfSubStringMatch(reference.substring(refNextStartPosition), sequence.substring(i), true);
 				results.add(new int[] {refNextStartPosition, i, nextBlockLength});
 				i += (nextBlockLength - 1);
-				previousRefStartPosision = refNextStartPosition + nextBlockLength;
+				previousRefStartPosition = refNextStartPosition + nextBlockLength;
 			}
 		}
 		
@@ -187,20 +184,7 @@ public class StringUtils {
 	public static boolean doesStringContainSubString(String outerString, String subString) {
 		return doesStringContainSubString(outerString, subString, true);
 	}
-	
-	public static String getStringFromArray(String [] array, String string) {
-		for (String arr : array) {
-			if (arr.startsWith(string)) return arr;
-		}
-		return null;
-	}
-	public static String getStringFromArray(String [] array, String string, boolean ignoreCase) {
-		for (String arr : array) {
-			if (arr.startsWith(string)) return arr;
-		}
-		return null;
-	}
-	
+
 	/**
 	 * The purpose of this method is to provide a fairly naive measure of sequence complexity
 	 * 
@@ -257,12 +241,12 @@ public class StringUtils {
 	 * @param subString String inner string containing the search text
 	 * @param failIfNull boolean indicating if an IllegalArgumentException should be thrown if either of the supplied strings are null
 	 * @return true if subString is contained within outerString, false otherwise
-	 * @throws IllegalArgumentException if either of the supplied strings are null, and if fialIfNull is set to true
+	 * @throws IllegalArgumentException if either of the supplied strings are null, and if failIfNull is set to true
 	 */
 	public static int indexOfSubStringInString(String outerString, String subString, boolean failIfNull) {
 		if (isNullOrEmpty(outerString) || isNullOrEmpty(subString)) {
 			if (failIfNull) {
-				throw new IllegalArgumentException("Null or empty arguments suppleid to doesStringContainSubString");
+				throw new IllegalArgumentException("Null or empty arguments supplied to doesStringContainSubString");
 			} else {
 				return -1;
 			}
@@ -315,19 +299,7 @@ public class StringUtils {
 		 		
 		return flag;
 	}
-	
-	public static String appendToString(String prefix, String s, boolean dontAddIfAlreadyStartsWithPrefix) {
-		
-		if ( ! s.startsWith(prefix)) {
-			return prefix + s;
-		} else {
-			if ( ! dontAddIfAlreadyStartsWithPrefix) {
-				return prefix + s;
-			}
-		}
-		return s;
-	}
-	
+
 	/**
 	 * Returns a ChrPosition object based on a string of the following format: chr1:123456-123456
 	 * <p>
@@ -354,7 +326,7 @@ public class StringUtils {
 		int firstPosition =  Integer.parseInt(chrPosString.substring(colonIndex + 1, minusIndex));
 		int secondPosition =  Integer.parseInt(chrPosString.substring(minusIndex+1));
 		
-		// if either postion is -ve, throw exception 
+		// if either position is -ve, throw exception
 		if (firstPosition < 0 || secondPosition < 0)
 			throw new IllegalArgumentException("malformed string passed to getChrPositionFromString - negative positions: " + chrPosString);
 		
@@ -393,36 +365,17 @@ public class StringUtils {
 	 */
 	public static String getJoinedString(String a, String b, String glue) {
 		if (null == a) {
-			if (null == b) return null;
-			return b;
+            return b;
 		}
 		if (null == b) {
 			return a;
 		}
-		if (a.length() == 0) return b;
-		if (b.length() == 0) return a;
+		if (a.isEmpty()) return b;
+		if (b.isEmpty()) return a;
 		
 		return a + glue + b;
 	}
-		
-	public static String toTitleCase (String input) {
-		StringBuilder titleCase = new StringBuilder();
-	    boolean nextTitleCase = true;
 
-	    for (char c : input.toCharArray()) {
-	        if (Character.isSpaceChar(c)) {
-	            nextTitleCase = true;
-	        } else if (nextTitleCase) {
-	            c = Character.toTitleCase(c);
-	            nextTitleCase = false;
-	        }
-
-	        titleCase.append(c);
-	    }
-
-	    return titleCase.toString();
-	}
-	
 	/**
 	 * Utility method that returns a boolean indicating if the supplied mainString contains the supplied searchString 
 	 * more than a certain number of times, which is dictated by the supplied cutoff parameter.
@@ -436,7 +389,7 @@ public class StringUtils {
 	 * @param cutoff
 	 * @return
 	 */
-	public static boolean passesOccurenceCountCheck(String mainString, String searchString, int cutoff) {
+	public static boolean passesOccurrenceCountCheck(String mainString, String searchString, int cutoff) {
 		if (isNullOrEmpty(mainString)) return false;
 		if (isNullOrEmpty(searchString)) return false;
 		
@@ -481,38 +434,12 @@ public class StringUtils {
 		if (StringUtils.isNullOrEmpty(existing)) {
 			return addition;
 		} else if ( ! existing.contains(addition)) {
-			return existing += delim + addition;
-		} else {
-			return existing;
-		}
-	}
-	
-	public static String removeFromString(String existing, String addition, char delim) {
-		if (null != existing && null != addition && existing.contains(addition)) {
-			if (existing.equals(addition)) {
-				return null;
-			} else if (existing.startsWith(addition)) {	// need to remove semi-colon along with annotation
-				return  existing.replace(addition + delim, "");
-			} else {
-				return  existing.replace(delim + addition, "");
-			}
+			return existing + (delim + addition);
 		} else {
 			return existing;
 		}
 	}
 
-	/**
-	 * Examines the string and returns true if the character is in it!
-	 * 
-	 * @param string String that we are examining
-	 * @param c upper case char value
-	 * @return boolean if the supplied character exists in the supplied string, in either upper case, or lower case
-	 */
-	public static boolean isCharPresentInString(String string, char c) {
-		return null != string && (string.contains("" + c) 
-				|| string.contains("" + Character.toLowerCase(c))); 
-	}
-	
 	/**
 	 * convert string to number
 	 * @param info: a string of number
@@ -536,14 +463,6 @@ public class StringUtils {
 		return  rate;
 	}
 
-	public static String getStringFromCharSet(Set<Character> set) {
-		final StringBuilder sb = new StringBuilder();
-		if (null != set) {
-			for (final Character c : set) sb.append(c);
-		}
-		return sb.toString();
-	}
-	
 	public static int getCount(String s, char c) {
 		int matchCount = 0;
 		for (char c1 : s.toCharArray()) {

--- a/qcommon/test/org/qcmg/common/string/StringUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/string/StringUtilsTest.java
@@ -9,6 +9,17 @@ import org.qcmg.common.model.ChrRangePosition;
 
 
 public class StringUtilsTest {
+
+	@Test
+	public void printHexBinary() {
+		byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+		String hex = StringUtils.printHexBinary(bytes);
+		assertEquals("000102030405060708090A0B0C0D0E0F".toLowerCase(), hex);
+
+		bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+		hex = StringUtils.printHexBinary(bytes);
+		assertEquals("000102030405060708090A0B0C0D0E0F10".toLowerCase(), hex);
+	}
 	
 	@Test
 	public void testIsNumeric() {
@@ -456,7 +467,7 @@ public class StringUtilsTest {
 "@SQ     SN:chrMT        LN:16569"; 
 		
 		
-		assertEquals(true, StringUtils.passesOccurenceCountCheck(dodgyBamHeader, "@SQ", 100000));
+		assertEquals(true, StringUtils.passesOccurrenceCountCheck(dodgyBamHeader, "@SQ", 100000));
 	}
 	
 }

--- a/qcommon/test/org/qcmg/common/string/StringUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/string/StringUtilsTest.java
@@ -11,17 +11,6 @@ import org.qcmg.common.model.ChrRangePosition;
 public class StringUtilsTest {
 
 	@Test
-	public void printHexBinary() {
-		byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-		String hex = StringUtils.printHexBinary(bytes);
-		assertEquals("000102030405060708090A0B0C0D0E0F".toLowerCase(), hex);
-
-		bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-		hex = StringUtils.printHexBinary(bytes);
-		assertEquals("000102030405060708090A0B0C0D0E0F10".toLowerCase(), hex);
-	}
-	
-	@Test
 	public void testIsNumeric() {
 		assertEquals(false, StringUtils.isNumeric(null));
 		assertEquals(false, StringUtils.isNumeric(""));

--- a/qcoverage/build.gradle
+++ b/qcoverage/build.gradle
@@ -11,10 +11,6 @@ dependencies {
     implementation project(':qbamfilter')
     implementation project(':qpicard')
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    // https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
-    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
-    // https://mvnrepository.com/artifact/org.eclipse.persistence/org.eclipse.persistence.moxy
-    implementation 'org.eclipse.persistence:org.eclipse.persistence.moxy:3.0.3'
 
 }
 

--- a/qmito/build.gradle
+++ b/qmito/build.gradle
@@ -5,7 +5,7 @@ def isExecutable = true
 
 dependencies {
 	
-    implementation 'org.apache.commons:commons-math3:3.3'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
 	
     implementation project(':qcommon')
     implementation project(':qbamfilter')

--- a/qmule/build.gradle
+++ b/qmule/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation project(':qcommon')
     implementation project(':qio')
     implementation project(':qpicard')
-    implementation 'com.google.code.findbugs:findbugs:1.3.9'	
+//    implementation 'com.google.code.findbugs:findbugs:1.3.9'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'com.github.broadinstitute:picard:3.1.1'
     implementation 'org.broadinstitute:barclay:5.0.0'

--- a/qprofiler/build.gradle
+++ b/qprofiler/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':qio')
     implementation project(':qvisualise')
 
-    implementation 'org.apache.commons:commons-math3:3.3'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 	
 }

--- a/qprofiler/src/org/qcmg/qprofiler/bam/BamSummaryReport.java
+++ b/qprofiler/src/org/qcmg/qprofiler/bam/BamSummaryReport.java
@@ -270,7 +270,7 @@ public class BamSummaryReport extends SummaryReport {
 		// xml transformer can't handle large entries in the CDATA section so leave out bam header if its large (I'm looking at you here Platypus)
 		if ( ! StringUtils.isNullOrEmpty(bamHeader)) {
 			int cutoff = 100000;
-			if (StringUtils.passesOccurenceCountCheck(bamHeader, "@SQ", cutoff)) {
+			if (StringUtils.passesOccurrenceCountCheck(bamHeader, "@SQ", cutoff)) {
 				Element headerElement = createSubElement(bamReportElement, "HEADER");
 				SummaryReportUtils.bamHeaderToXml(headerElement, bamHeader);
 			} else {

--- a/qsignature/build.gradle
+++ b/qsignature/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation project(':qpicard')
     implementation project(':qio')
     
-    implementation 'org.apache.commons:commons-math3:3.3'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
 	
 }

--- a/qsnp/build.gradle
+++ b/qsnp/build.gradle
@@ -32,10 +32,8 @@ dependencies {
     implementation project(':qpicard')
     
     implementation group: 'org.ini4j', name: 'ini4j', version: '0.5.2'
-    implementation 'net.sf.trove4j:core:3.1.0'
-    implementation 'org.apache.commons:commons-lang3:3.4'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    implementation 'org.lz4:lz4-java:1.5.0'
+    implementation 'org.lz4:lz4-java:1.8.0'
     implementation 'org.scala-lang:scala-library:2.12.18'
 }
 

--- a/qsv/build.gradle
+++ b/qsv/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'	
 		
     testImplementation  'org.easymock:easymock:5.2.0'
-    testImplementation  group: 'commons-io', name: 'commons-io', version: '2.6'
+    // https://mvnrepository.com/artifact/commons-io/commons-io
+    implementation 'commons-io:commons-io:2.15.1'
 }
 


### PR DESCRIPTION
# Description

I tried to run qsv using java21 and it failed when trying to write the xml output because it couldn't find an implementation of the jakarta.bind package to use.

This fix adds the required jars to the qcommon project, which means that all projects that use qcommon should be able to write xml output.

I've updated some dependencies too as some were marked as having vulnerabilities in maven.



## Type of change



- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Unit tests pass. Will be put through the regression once released.

# Are WDL Updates Required?

nope

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
