### PR TITLE
feat(qannotate confidence mode): allow the user to specify the homopolymer cutoff

### DIFF
--- a/qannotate/build.gradle
+++ b/qannotate/build.gradle
@@ -1,32 +1,7 @@
-plugins {
-  id 'org.hidetake.ssh' version '2.9.0'
-}
-
 apply plugin: 'application'
 mainClassName = 'au.edu.qimr.qannotate.Main'
 def scriptname = 'qannotate'
 def isExecutable = true
-
-remotes {
-  avalon {
-    host = 'hpcpbs01.adqimr.ad.lan'
-    user = 'oliverH'
-    identity = file('../../../../../../.ssh/id_rsa')
-  }
-}
-
-task deploy {
-  doLast {
-    ssh.run {
-      session(remotes.avalon) {
-        put from: "${project.projectDir}/build/flat/qannotate.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
-        put from: "${project.projectDir}/build/flat/qcommon.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
-        put from: "${project.projectDir}/build/flat/qio.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
-        put from: "${project.projectDir}/build/flat/snpEff-5.2a.jar", into: '/mnt/backedup/home/oliverH/qannotate/bin'
-      }
-    }
-  }
-}
 
 /*
 * qannotate requires snpEff and the version currently used is 4.0e
@@ -43,7 +18,6 @@ task deploy {
 */
 
 configurations {  junit }
-configurations {  sshAntTask }
 
 dependencies {
     //this junit is required by snpEff-4.0

--- a/qannotate/src/au/edu/qimr/qannotate/Main.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Main.java
@@ -13,7 +13,7 @@ import au.edu.qimr.qannotate.modes.CaddMode;
 import au.edu.qimr.qannotate.modes.ConfidenceMode;
 import au.edu.qimr.qannotate.modes.DbsnpMode;
 import au.edu.qimr.qannotate.modes.GermlineMode;
-import au.edu.qimr.qannotate.modes.HomoplymersMode;
+import au.edu.qimr.qannotate.modes.HomopolymersMode;
 import au.edu.qimr.qannotate.modes.IndelConfidenceMode;
 import au.edu.qimr.qannotate.modes.MakeValidMode;
 import au.edu.qimr.qannotate.modes.OverlapMode;
@@ -51,7 +51,7 @@ public class Main {
             } else if (options.getMode() == Options.MODE.indelconfidence) {
                 new IndelConfidenceMode(options);
             } else if (options.getMode() == Options.MODE.hom) {
-                new HomoplymersMode(options);
+                new HomopolymersMode(options);
             } else if (options.getMode() == Options.MODE.trf) {
                 new TandemRepeatMode(options);
             } else if (options.getMode() == Options.MODE.make_valid) {

--- a/qannotate/src/au/edu/qimr/qannotate/Main.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Main.java
@@ -1,8 +1,8 @@
 /**
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
-*/
+ */
 package au.edu.qimr.qannotate;
 
 import org.qcmg.common.log.QLogger;
@@ -22,114 +22,114 @@ import au.edu.qimr.qannotate.modes.TandemRepeatMode;
 import au.edu.qimr.qannotate.modes.Vcf2maf;
 
 public class Main {
-	 
-	private static QLogger logger;
-	public static void main(final String[] args) throws Exception {	
 
-		try {
-           final Options options = new Options(args);             
-        		//LoadReferencedClasses.loadClasses(Main.class);    
-           logger = QLoggerFactory.getLogger(Main.class, options.getLogFileName(),  options.getLogLevel());	            		               
-           logger.logInitialExecutionStats(options.getPGName(), options.getVersion(),args);
-           
-           checkOptions(options);
-           
-           if (options.getMode() == Options.MODE.dbsnp) {
-    	   		new DbsnpMode( options );
-           	} else if (options.getMode() == Options.MODE.germline) {
-    	   		new GermlineMode( options );
-			} else if (options.getMode() == Options.MODE.snpeff) {
-	    		new SnpEffMode(   options  );
-			} else if (options.getMode() == Options.MODE.confidence) {
-	    		new ConfidenceMode(   options);
-			} else if (options.getMode() == Options.MODE.ccm) {
-				new CCMMode(   options);
-			} else if (options.getMode() == Options.MODE.vcf2maf) {
-				new Vcf2maf(  options );
-			} else if (options.getMode() == Options.MODE.cadd) {
-    	   		new CaddMode(   options   );
+    private static QLogger logger;
+
+    public static void main(final String[] args) {
+
+        try {
+            final Options options = new Options(args);
+            logger = QLoggerFactory.getLogger(Main.class, options.getLogFileName(), options.getLogLevel());
+            logger.logInitialExecutionStats(options.getPGName(), options.getVersion(), args);
+
+            checkOptions(options);
+
+            if (options.getMode() == Options.MODE.dbsnp) {
+                new DbsnpMode(options);
+            } else if (options.getMode() == Options.MODE.germline) {
+                new GermlineMode(options);
+            } else if (options.getMode() == Options.MODE.snpeff) {
+                new SnpEffMode(options);
+            } else if (options.getMode() == Options.MODE.confidence) {
+                new ConfidenceMode(options);
+            } else if (options.getMode() == Options.MODE.ccm) {
+                new CCMMode(options);
+            } else if (options.getMode() == Options.MODE.vcf2maf) {
+                new Vcf2maf(options);
+            } else if (options.getMode() == Options.MODE.cadd) {
+                new CaddMode(options);
             } else if (options.getMode() == Options.MODE.indelconfidence) {
-    	   		new IndelConfidenceMode(options);
+                new IndelConfidenceMode(options);
             } else if (options.getMode() == Options.MODE.hom) {
-    	   		new HomoplymersMode(options);
+                new HomoplymersMode(options);
             } else if (options.getMode() == Options.MODE.trf) {
-    	   		new TandemRepeatMode( options );
+                new TandemRepeatMode(options);
             } else if (options.getMode() == Options.MODE.make_valid) {
-    	   		new MakeValidMode( options );
-   	   	    } else if (options.getMode() == Options.MODE.overlap) {
-   	   			new OverlapMode( options );
-	   	   	} else if (options.getMode() == null) {
-	   	   		throw new IllegalArgumentException("No mode was specified on the commandline - please add the \"-mode\" option") ;
+                new MakeValidMode(options);
+            } else if (options.getMode() == Options.MODE.overlap) {
+                new OverlapMode(options);
+            } else if (options.getMode() == null) {
+                throw new IllegalArgumentException("No mode was specified on the commandline - please add the \"-mode\" option");
             } else {
-    	   		throw new IllegalArgumentException("No valid mode are specified on commandline - please run \"qannotate -help\" to see the list of available modes");
+                throw new IllegalArgumentException("No valid mode are specified on commandline - please run \"qannotate -help\" to see the list of available modes");
             }
 
             logger.logFinalExecutionStats(0);
-               
+
         } catch (Exception e) {
-        	System.out.println("Exception caught!");
-        	e.printStackTrace();
-        	System.err.println(Thread.currentThread().getName() + " " + e.toString() + " : " + e.getLocalizedMessage());
-        	if (null != logger) {
-	        	logger.info(Thread.currentThread().getName() + " " + e.toString() + " : " + e.getMessage());	            
-	        	logger.logFinalExecutionStats(1);
-        	}
-    		System.out.println("About to return exit code of 1");
-    		System.exit(1);
+            System.out.println("Exception caught!");
+            e.printStackTrace();
+            System.err.println(Thread.currentThread().getName() + " " + e + " : " + e.getLocalizedMessage());
+            if (null != logger) {
+                logger.info(Thread.currentThread().getName() + " " + e + " : " + e.getMessage());
+                logger.logFinalExecutionStats(1);
+            }
+            System.out.println("About to return exit code of 1");
+            System.exit(1);
         }
-	}
-	
-	/**
-	 * Checks the Options object to see if the minimal options (input, output, database) have been supplied.
-	 * Using the switch statements fall through process here.
-	 * 
-	 * Assuming that the individual modes will perform any more specific Options checking internally 
-	 *  
-	 * @param o
-	 */
-	public static void checkOptions(Options o) {
-		Options.MODE m = o.getMode();
-		switch (m) {
-		/*
-		 * some modes need a database
-		 */
-		case dbsnp:
-		case germline:
-		case hom:
-		case cadd:
-		case snpeff:
-		case trf:
-			if (null == o.getDatabaseFileName()) {
-        		throw new IllegalArgumentException("Please supply a reference file using the \"-d\" option");
-        	}
-			
-		/*
-		 * most modes need an output and input
-		 * there is a break after these checks as the vcf2mafs are a slightly special case
-		 */
-		case overlap:
-		case confidence:
-		case indelconfidence:
-		case ccm:
-		case make_valid:
-			if (null == o.getOutputFileName()) {
-				throw new IllegalArgumentException("Please supply an output file using the \"-output\" or \"-o\" option");
-			}
-			if (null == o.getInputFileName()) {
-				throw new IllegalArgumentException("Please supply an input file using the \"-input\" option");
-			}
-			break;
-		/*
-		 * apart from the vcf2maf modes which can take either a outdir or output option
-		 */
-		case vcf2maf:
-		case vcf2maftmp:
-			if (null == o.getInputFileName()) {
-				throw new IllegalArgumentException("Please supply an input file using the \"-input\" option");
-			}
-			if (null == o.getOutputDir() && null == o.getOutputFileName()) {
-				throw new IllegalArgumentException("Please supply an output dir using the \"-outdir\" option, or an output file using the \"-output\" or \"-o\" option");
-			}
-		}
-	}
+    }
+
+    /**
+     * Checks the Options object to see if the minimal options (input, output, database) have been supplied.
+     * Using the switch statements fall through process here.
+     *
+     * Assuming that the individual modes will perform any more specific Options checking internally
+     *
+     * @param o
+     */
+    public static void checkOptions(Options o) {
+        Options.MODE m = o.getMode();
+        switch (m) {
+            /*
+             * some modes need a database
+             */
+            case dbsnp:
+            case germline:
+            case hom:
+            case cadd:
+            case snpeff:
+            case trf:
+                if (null == o.getDatabaseFileName()) {
+                    throw new IllegalArgumentException("Please supply a reference file using the \"-d\" option");
+                }
+
+                /*
+                 * most modes need an output and input
+                 * there is a break after these checks as the vcf2mafs are a slightly special case
+                 */
+            case overlap:
+            case confidence:
+            case indelconfidence:
+            case ccm:
+            case make_valid:
+                if (null == o.getOutputFileName()) {
+                    throw new IllegalArgumentException("Please supply an output file using the \"-output\" or \"-o\" option");
+                }
+                if (null == o.getInputFileName()) {
+                    throw new IllegalArgumentException("Please supply an input file using the \"-input\" option");
+                }
+                break;
+            /*
+             * apart from the vcf2maf modes which can take either a outdir or output option
+             */
+            case vcf2maf:
+            case vcf2maftmp:
+                if (null == o.getInputFileName()) {
+                    throw new IllegalArgumentException("Please supply an input file using the \"-input\" option");
+                }
+                if (null == o.getOutputDir() && null == o.getOutputFileName()) {
+                    throw new IllegalArgumentException("Please supply an output dir using the \"-outdir\" option, or an output file using the \"-output\" or \"-o\" option");
+                }
+        }
+    }
 }

--- a/qannotate/src/au/edu/qimr/qannotate/Options.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Options.java
@@ -70,8 +70,8 @@ public class Options {
 	private  final String summaryFileName ;
 	
 	//hom 
-	private final int homWindow  ;
-	private final int homReportSize;
+	private final int homopolymerWindow;
+	private final int homopolymerCutoff;
 	
     /**
      * check command line and store arguments and option information
@@ -146,8 +146,8 @@ public class Options {
         	( mode == MODE.snpeff ?  outputFileName +  ".snpEff_summary.html" : null);
         	
         //homoplymers
-        homWindow  = (options.has("window"))? (int) options.valueOf("window") : HomoplymersMode.defaultWindow;  //default is 100
-        homReportSize = (options.has("report"))? (int) options.valueOf("report") : HomoplymersMode.defaultreport; //default is 10
+        homopolymerWindow = (options.has("homWindow"))? (int) options.valueOf("homWindow") : HomoplymersMode.DEFAULT_WINDOW;  //default is 100
+        homopolymerCutoff = (options.has("homCutoff"))? (int) options.valueOf("homCutoff") : HomoplymersMode.HOMOPOLYMER_CUTOFF; //default is 10
         		
         checkIO();    //not yet complete         	
     }
@@ -220,11 +220,11 @@ public class Options {
 	            parser.accepts("buffer", "check TRF region on both sides of indel within this nominated size" ).withRequiredArg().ofType(Integer.class);//.describedAs("integer");
 	 
 	         if(mm.equals(MODE.cadd))
-	             parser.accepts("gap", "adjacant variants size").withRequiredArg().ofType(String.class).describedAs("gap size");
+	             parser.accepts("gap", "adjacent variants size").withRequiredArg().ofType(String.class).describedAs("gap size");
 	
-	         if(mm.equals(MODE.hom)){
-	 	        parser.accepts("window", "check homoplymers inside window size on both side of variants. Default value is " + HomoplymersMode.defaultWindow).withRequiredArg().ofType(String.class).describedAs("window size");
-	 	        parser.accepts("report", "report specified number of homoplymers base fallen in the swindow. Default value is " + HomoplymersMode.defaultreport  ).withRequiredArg().ofType(String.class).describedAs("report base number");
+	         if(mm.equals(MODE.confidence) || mm.equals(MODE.hom)){
+	 	        parser.accepts("homWindow", "check for homoplymers inside window size on both sides of variants. Default value is " + HomoplymersMode.DEFAULT_WINDOW).withRequiredArg().ofType(Integer.class).describedAs("window size");
+	 	        parser.accepts("homCutoff", "Cutoff value for number of homoplymer bases within the window. Default value is " + HomoplymersMode.HOMOPOLYMER_CUTOFF).withRequiredArg().ofType(Integer.class).describedAs("report base number");
 	         }
 	        
 	         if( mm.equals(MODE.vcf2maf) ){
@@ -416,12 +416,12 @@ public class Options {
 	
 	//hom
 	public int getHomoplymersWindow(){
-		return (mode == MODE.hom) ? homWindow : -1;
-	} //trf
+		return homopolymerWindow;
+	}
 	
 	public int getHomoplymersReportSize() { 
-		return (mode == MODE.hom) ? homReportSize : -1; 
-	} //cadd
+		return homopolymerCutoff;
+	}
 	
 	public Optional<Integer> getNNSCount() {
 		return Optional.ofNullable(nnsCount);

--- a/qannotate/src/au/edu/qimr/qannotate/Options.java
+++ b/qannotate/src/au/edu/qimr/qannotate/Options.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import au.edu.qimr.qannotate.modes.HomoplymersMode;
+import au.edu.qimr.qannotate.modes.HomopolymersMode;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 /*
@@ -146,8 +146,8 @@ public class Options {
         	( mode == MODE.snpeff ?  outputFileName +  ".snpEff_summary.html" : null);
         	
         //homoplymers
-        homopolymerWindow = (options.has("homWindow"))? (int) options.valueOf("homWindow") : HomoplymersMode.DEFAULT_WINDOW;  //default is 100
-        homopolymerCutoff = (options.has("homCutoff"))? (int) options.valueOf("homCutoff") : HomoplymersMode.HOMOPOLYMER_CUTOFF; //default is 10
+        homopolymerWindow = (options.has("homWindow"))? (int) options.valueOf("homWindow") : HomopolymersMode.DEFAULT_WINDOW;  //default is 100
+        homopolymerCutoff = (options.has("homCutoff"))? (int) options.valueOf("homCutoff") : HomopolymersMode.HOMOPOLYMER_CUTOFF; //default is 10
         		
         checkIO();    //not yet complete         	
     }
@@ -223,8 +223,8 @@ public class Options {
 	             parser.accepts("gap", "adjacent variants size").withRequiredArg().ofType(String.class).describedAs("gap size");
 	
 	         if(mm.equals(MODE.confidence) || mm.equals(MODE.hom)){
-	 	        parser.accepts("homWindow", "check for homoplymers inside window size on both sides of variants. Default value is " + HomoplymersMode.DEFAULT_WINDOW).withRequiredArg().ofType(Integer.class).describedAs("window size");
-	 	        parser.accepts("homCutoff", "Cutoff value for number of homoplymer bases within the window. Default value is " + HomoplymersMode.HOMOPOLYMER_CUTOFF).withRequiredArg().ofType(Integer.class).describedAs("report base number");
+	 	        parser.accepts("homWindow", "check for homoplymers inside window size on both sides of variants. Default value is " + HomopolymersMode.DEFAULT_WINDOW).withRequiredArg().ofType(Integer.class).describedAs("window size");
+	 	        parser.accepts("homCutoff", "Cutoff value for number of homoplymer bases within the window. Default value is " + HomopolymersMode.HOMOPOLYMER_CUTOFF).withRequiredArg().ofType(Integer.class).describedAs("report base number");
 	         }
 	        
 	         if( mm.equals(MODE.vcf2maf) ){

--- a/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/ConfidenceMode.java
@@ -1,8 +1,8 @@
 /**
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
-*/
+ */
 package au.edu.qimr.qannotate.modes;
 
 
@@ -34,530 +34,582 @@ import gnu.trove.list.TShortList;
 
 /**
  * @author christix
- *
  */
 
-public class ConfidenceMode extends AbstractMode{
-	private final QLogger logger = QLoggerFactory.getLogger(ConfidenceMode.class);
-	
-	public static final int HIGH_CONF_NOVEL_STARTS_PASSING_SCORE = 4;
-	public static final int LOW_CONF_NOVEL_STARTS_PASSING_SCORE = 4;
-	
-	public static final int HIGH_CONF_ALT_FREQ_PASSING_SCORE = 5;	
-	public static final int LOW_CONF_ALT_FREQ_PASSING_SCORE = 4;	
-	
-	public static final int CONTROL_COVERAGE_MIN_VALUE_SOMATIC_CALL = 12;
-	public static final int CONTROL_COVERAGE_MIN_VALUE = 8;
-	public static final int TEST_COVERAGE_MIN_VALUE = 8;
-	
-	public static final int MUTATION_IN_NORMAL_MIN_PERCENTAGE = 3;		// setting this to 3 to mirror existing prod pipeline - was 5
-	public static final int MUTATION_IN_NORMAL_MIN_COVERAGE = 2;		// set this to 2, meaning that if defaults are used it will be max(2, 3%) that is used
-	
-	public static final int sBiasAltPercentage = 5;
-	public static final int sBiasCovPercentage = 5;
-	
-	@Deprecated	// using values (both hard cutoff and percentage) from MIN for MIUN annotation
-	public static final int MIUN_CUTOFF = 2;	// based on existing values
-	
-	//filters 
-	
-	public static final String DESCRIPTION_INFO_CONFIDENCE = String.format( "set to HIGH if the variants passed all filter, "
-			+ "appeared on more than %d novel stars reads and more than %d reads contains variants, is adjacent to reference sequence with less than %d homopolymer base; "
-			+ "Or set to LOW if the variants passed MIUN/MIN/GERM filter, appeared on more than %d novel stars reads and more than %d reads contains variants;"
-			+ "Otherwise set to Zero if the variants didn't matched one of above conditions.",
-			HIGH_CONF_NOVEL_STARTS_PASSING_SCORE, HIGH_CONF_ALT_FREQ_PASSING_SCORE,IndelConfidenceMode.DEFAULT_HOMN,  LOW_CONF_NOVEL_STARTS_PASSING_SCORE, LOW_CONF_ALT_FREQ_PASSING_SCORE);
+public class ConfidenceMode extends AbstractMode {
+    private final QLogger logger = QLoggerFactory.getLogger(ConfidenceMode.class);
+
+    public static final int HIGH_CONF_NOVEL_STARTS_PASSING_SCORE = 4;
+    public static final int LOW_CONF_NOVEL_STARTS_PASSING_SCORE = 4;
+
+    public static final int HIGH_CONF_ALT_FREQ_PASSING_SCORE = 5;
+    public static final int LOW_CONF_ALT_FREQ_PASSING_SCORE = 4;
+
+    public static final int CONTROL_COVERAGE_MIN_VALUE_SOMATIC_CALL = 12;
+    public static final int CONTROL_COVERAGE_MIN_VALUE = 8;
+    public static final int TEST_COVERAGE_MIN_VALUE = 8;
+
+    public static final int MUTATION_IN_NORMAL_MIN_PERCENTAGE = 3;        // setting this to 3 to mirror existing prod pipeline - was 5
+    public static final int MUTATION_IN_NORMAL_MIN_COVERAGE = 2;        // set this to 2, meaning that if defaults are used it will be max(2, 3%) that is used
+
+    public static final int sBiasAltPercentage = 5;
+    public static final int sBiasCovPercentage = 5;
+
+    @Deprecated    // using values (both hard cutoff and percentage) from MIN for MIUN annotation
+    public static final int MIUN_CUTOFF = 2;    // based on existing values
+
+    //filters
+
+    public static final String DESCRIPTION_INFO_CONFIDENCE = String.format("set to HIGH if the variants passed all filter, " + "appeared on more than %d novel stars reads and more than %d reads contains variants, is adjacent to reference sequence with less than %d homopolymer base; " + "Or set to LOW if the variants passed MIUN/MIN/GERM filter, appeared on more than %d novel stars reads and more than %d reads contains variants;" + "Otherwise set to Zero if the variants didn't matched one of above conditions.", HIGH_CONF_NOVEL_STARTS_PASSING_SCORE, HIGH_CONF_ALT_FREQ_PASSING_SCORE, IndelConfidenceMode.DEFAULT_HOMN, LOW_CONF_NOVEL_STARTS_PASSING_SCORE, LOW_CONF_ALT_FREQ_PASSING_SCORE);
 
 
-	private TShortList testCols;
-	private TShortList controlCols;
-	private VcfFileMeta meta;
-	
-	private int nnsCount = HIGH_CONF_NOVEL_STARTS_PASSING_SCORE;
-	private int mrCount = HIGH_CONF_ALT_FREQ_PASSING_SCORE;
-	
-	private int controlCovCutoffForSomaticCalls = CONTROL_COVERAGE_MIN_VALUE_SOMATIC_CALL;
-	private int controlCovCutoff = CONTROL_COVERAGE_MIN_VALUE;
-	private int testCovCutoff = TEST_COVERAGE_MIN_VALUE;
-	
-	private int minCov = 0;
-	private double mrPercentage = 0.0f;
-	
-	private int minCutoff = MUTATION_IN_NORMAL_MIN_COVERAGE;
-	private double minPercentage = MUTATION_IN_NORMAL_MIN_PERCENTAGE;
-	
-	//for unit testing
-	ConfidenceMode(){
-	}
-	ConfidenceMode(VcfFileMeta m){
-		this.meta = m;
-		testCols = meta.getAllTestPositions();
-		controlCols = meta.getAllControlPositions();
-	}
+    private TShortList controlCols;
+    private VcfFileMeta meta;
 
-	
-	public ConfidenceMode( Options options) throws Exception{				 
-		logger.tool("input: " + options.getInputFileName());
+    private int nnsCount = HIGH_CONF_NOVEL_STARTS_PASSING_SCORE;
+    private int mrCount = HIGH_CONF_ALT_FREQ_PASSING_SCORE;
+
+    private int controlCovCutoffForSomaticCalls = CONTROL_COVERAGE_MIN_VALUE_SOMATIC_CALL;
+    private int controlCovCutoff = CONTROL_COVERAGE_MIN_VALUE;
+    private int testCovCutoff = TEST_COVERAGE_MIN_VALUE;
+
+    private int homopolymerCutoff = IndelConfidenceMode.DEFAULT_HOMN;
+
+    private int minCov = 0;
+    private double mrPercentage = 0.0f;
+
+    private int minCutoff = MUTATION_IN_NORMAL_MIN_COVERAGE;
+    private double minPercentage = MUTATION_IN_NORMAL_MIN_PERCENTAGE;
+
+    //for unit testing
+    ConfidenceMode() {
+    }
+
+    ConfidenceMode(VcfFileMeta m) {
+        this.meta = m;
+        controlCols = meta.getAllControlPositions();
+    }
+
+
+    public ConfidenceMode(Options options) throws Exception {
+        logger.tool("input: " + options.getInputFileName());
         logger.tool("output annotated records: " + options.getOutputFileName());
         logger.tool("logger file " + options.getLogFileName());
         logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() : options.getLogLevel()));
- 		
-		loadVcfRecordsFromFile(new File(options.getInputFileName()));	
-		
-		options.getNNSCount().ifPresent(i -> nnsCount = i.intValue());
-		options.getMRCount().ifPresent(i -> mrCount = i.intValue());
-		options.getControlCutoff().ifPresent(i -> controlCovCutoff = i.intValue());
-		options.getControlCutoffForSomatic().ifPresent(i -> controlCovCutoffForSomaticCalls = i.intValue());
-		options.getTestCutoff().ifPresent(i -> testCovCutoff = i.intValue());
-		options.getMRPercentage().ifPresent(i -> mrPercentage = i.floatValue());
-		options.getMINCutoff().ifPresent(i -> minCutoff = i.intValue());
-		options.getMINPercentage().ifPresent(i -> minPercentage = i.floatValue());
-		logger.tool("Number of Novel Starts filter value: " + nnsCount);
-		logger.tool("Number of Mutant Reads filter value: " + mrCount);
-		logger.tool("Percentage of Mutant Reads filter value: " + mrPercentage);
-		logger.tool("Control coverage minimum value: " + controlCovCutoff);
-		logger.tool("Control coverage minimum value (for SOMATIC calls): " + controlCovCutoffForSomaticCalls);
-		logger.tool("Test coverage minimum value: " + testCovCutoff);
-		logger.tool("Mutation In Unfiltered Normal (MIUN) will be applied if the Failed Filter (FF) format field contains more than max(" + minCutoff + ", " + minPercentage + "%) occurrences of the alt in the normal (control)");
-		logger.tool("Mutation In Normal (MIN) will be applied if number of alt reads in the normnal (control) are greater than or equal to " + minCutoff + " OR greather than or equal to " + minPercentage +"% of total reads");
-		
-		minCov = Math.min(controlCovCutoff, testCovCutoff);
 
-		//get control and test sample column; here use the header from inputRecord(...)
-		meta = new VcfFileMeta(header);
-		logger.tool("meta: " + meta.getType());
-		testCols = meta.getAllTestPositions();
-		controlCols = meta.getAllControlPositions();
+        loadVcfRecordsFromFile(new File(options.getInputFileName()));
 
-		addAnnotation();
-		addVcfHeaderFilters();
-		reheader(options.getCommandLine(),options.getInputFileName());	
-		writeVCF(new File(options.getOutputFileName()) );
-	}
-	
-	public void addVcfHeaderFilters() {
-		header.addFilter(VcfHeaderUtils.FILTER_COVERAGE, VcfHeaderUtils.FILTER_COVERAGE_DESC
-				+ ", test coverage minimum value: " + testCovCutoff + ", control coverage minimum value (somatic/germline): "
-				+ controlCovCutoffForSomaticCalls + "/" + controlCovCutoff);
-		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL,"Mutation also found in pileup of normal (>= " + minPercentage + "% of reads)");
-		header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL,"Mutation also found in pileup of unfiltered normal (>= " + minCutoff + " reads, and also >= " + minPercentage + "%) of reads)");  
-		header.addFilter(VcfHeaderUtils.FILTER_NOVEL_STARTS,"Less than " + nnsCount + " novel starts not considering read pair");
-		header.addFilter(VcfHeaderUtils.FILTER_MUTANT_READS,"Less than " + (mrPercentage > 0.0f ? mrPercentage +"%" : mrCount) + " mutant reads");
-		header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_ALT,"Alternate allele on only one strand (or percentage alternate allele on other strand is less than " + sBiasAltPercentage + "%)"); 
-		header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_COV,"Sequence coverage on only one strand (or percentage coverage on other strand is less than " + sBiasCovPercentage + "%)");
-		header.addFilter(VcfHeaderUtils.FILTER_END_OF_READ, VcfHeaderUtils.FILTER_END_OF_READ_DESC);
-	}
+        options.getNNSCount().ifPresent(i -> nnsCount = i);
+        options.getMRCount().ifPresent(i -> mrCount = i);
+        if (options.getHomoplymersReportSize() > -1) {
+            homopolymerCutoff = options.getHomoplymersReportSize();
+        }
+        options.getControlCutoff().ifPresent(i -> controlCovCutoff = i);
+        options.getControlCutoffForSomatic().ifPresent(i -> controlCovCutoffForSomaticCalls = i);
+        options.getTestCutoff().ifPresent(i -> testCovCutoff = i);
+        options.getMRPercentage().ifPresent(i -> mrPercentage = i);
+        options.getMINCutoff().ifPresent(i -> minCutoff = i);
+        options.getMINPercentage().ifPresent(i -> minPercentage = i);
+        logger.tool("Number of Novel Starts filter value: " + nnsCount);
+        logger.tool("Number of Mutant Reads filter value: " + mrCount);
+        logger.tool("Percentage of Mutant Reads filter value: " + mrPercentage);
+        logger.tool("Control coverage minimum value: " + controlCovCutoff);
+        logger.tool("Control coverage minimum value (for SOMATIC calls): " + controlCovCutoffForSomaticCalls);
+        logger.tool("Test coverage minimum value: " + testCovCutoff);
+        logger.tool("Mutation In Unfiltered Normal (MIUN) will be applied if the Failed Filter (FF) format field contains more than max(" + minCutoff + ", " + minPercentage + "%) occurrences of the alt in the normal (control)");
+        logger.tool("Mutation In Normal (MIN) will be applied if number of alt reads in the normal (control) are greater than or equal to " + minCutoff + " OR greater than or equal to " + minPercentage + "% of total reads");
+        logger.tool("Homopolymer cutoff (will add to filter if value is greater than or equal to cutoff): " + homopolymerCutoff);
 
-	void addAnnotation() {
-		
-		int pass = 0;
-		int fail = 0;
-		
-		final boolean percentageMode = mrPercentage > 0.0f;
-		
-		//check high, low nns...
-		for (List<VcfRecord> vcfs : positionRecordMap.values()) {
-			for(VcfRecord vcf : vcfs){
-				
-				Map<String, String[]> ffMap = vcf.getFormatFieldsAsMap();
-				
-				boolean isSomatic = VcfUtils.isRecordSomatic(vcf.getInfo(), ffMap);
-				String [] alts = vcf.getAlt().split(Constants.COMMA_STRING);
-				
-				/*
-				 * We will look at each sample in isolation
-				 * if no genotype is present, skip the sample
-				 * If we have a 0/0 genotype, and the sample FT is ., and the coverage is adequate, set it to pass
-				 * if we have any other genotype (ie, the sample is showing a mutation), check coverage, MR and NNS and existing FT fields. If within our acceptable limits, set FT to PASS
-				 */
-				
-				VcfInfoFieldRecord info = vcf.getInfoRecord();
-				int lhomo = (info.getField(VcfHeaderUtils.INFO_HOM) == null)? 1 :
-					StringUtils.string2Number(info.getField(VcfHeaderUtils.INFO_HOM).split(Constants.COMMA_STRING)[0], Integer.class);
-				String caller = info.getField(VcfHeaderUtils.INFO_MERGE_IN);
-				
-				String [] gtArray = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE);
-				String [] nnsArr = ffMap.get(VcfHeaderUtils.FILTER_NOVEL_STARTS);
-				String [] filterArr = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
-				String [] covArr = ffMap.get(VcfHeaderUtils.FORMAT_READ_DEPTH);
-				String [] ccmArr = ffMap.get(VcfHeaderUtils.FORMAT_CCM);
-				String [] oabsArr = ffMap.get(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND);
-				String [] gqArr = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE_QUALITY);
-				String [] adArr = ffMap.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS);
-				String [] infArr = ffMap.get(VcfHeaderUtils.FORMAT_INFO);
-				String [] eorArr = ffMap.get(VcfHeaderUtils.FORMAT_END_OF_READ);
-				String [] ffArr = ffMap.get(VcfHeaderUtils.FORMAT_FF);
-				if (covArr == null || covArr.length == 0) {
-					logger.warn("no coverage values for vcf record!!!: " + vcf);
-					continue;
-				}
-				if (null == filterArr || filterArr.length == 0) {
-					continue;
-				}
-				
-				for (int i = 0 ; i < gtArray.length ; i++) {
-					
-					
-					String inf = null != infArr && infArr.length > i ? infArr[i] : null;
-					/*
-					 * for No Call in GATK, set filter to PASS
-					 */
-					if (VcfHeaderUtils.FORMAT_NCIG.equals(inf)) {
-						filterArr[i] = VcfHeaderUtils.FILTER_PASS;
-						continue;
-					}
-					
-					boolean isControl =  controlCols != null && controlCols.contains((short) (i + 1));
+        minCov = Math.min(controlCovCutoff, testCovCutoff);
 
-					/*
-					 * add all failed filters to FT field
-					 */
-					StringBuilder fSb = new StringBuilder();
-					
-					
-					/*
-					 * coverage next - needs to be >= the min coverage value
-					 */
-					String covS = covArr[i];
-					boolean isGATKCall = null != gqArr && ! StringUtils.isNullOrEmptyOrMissingData(gqArr[i]);
-					int cov = StringUtils.isNullOrEmptyOrMissingData(covS) ? 0 :Integer.parseInt(covS);
-					
-					if (cov < minCov || cov < (isControl ? controlCovCutoff : testCovCutoff)) {
-						StringUtils.updateStringBuilder(fSb, VcfHeaderUtils.FILTER_COVERAGE, Constants.SEMI_COLON);
-					}
-					
-					Map<String, int[]> alleleDist = (null != oabsArr && oabsArr.length >= i) ? VcfUtils.getAllelicCoverageWithStrand(oabsArr[i]) : Collections.emptyMap();
-					/*
-					 * MIN next - only do this for control when we have a somatic call
-					 * need OABS field to be able to do this.
-					 */
-					if (isControl && isSomatic && ! isGATKCall) {
-						
-						checkMIN(alts, cov, alleleDist, fSb, minCutoff, (float) minPercentage);
-						
-						/*
-						 * look for MIUN, but only if we don't already have MIN
-						 */
-						if ( ! fSb.toString().contains(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL)) {
-							if (null != ffArr && ffArr.length > i) {
-								String failedFilter = ffArr[i];
-								// using the same values as for the MIN annotation
-								checkMIUN(alts, cov, failedFilter, fSb, minCutoff, (float) minPercentage);
-							}
-						}
-						if ( ! fSb.toString().contains(VcfHeaderUtils.FILTER_COVERAGE) && cov < controlCovCutoffForSomaticCalls) {
-							StringUtils.updateStringBuilder(fSb, VcfHeaderUtils.FILTER_COVERAGE, Constants.SEMI_COLON);
-						}
-					}
-						
-					/*
-					 * SBIASALT and SBIASCOV - do for all samples
-					 */
-					String gt = gtArray[i];
-					if ( ! StringUtils.isNullOrEmptyOrMissingData(gt)) {
-						if ( ! "0/0".equals(gt)) {
-							int index = gt.indexOf(Constants.SLASH);
-							int []  gts = new int[] {Integer.parseInt(gt.substring(0,index)), Integer.parseInt(gt.substring(index + 1))};
-							
-							if ( ! alleleDist.isEmpty() && ! isGATKCall) {
-								checkStrandBias(alts, fSb, alleleDist, gts, sBiasCovPercentage, sBiasAltPercentage);
-							}
-							
-							/*
-							 * HOM
-							 */
-							checkHOM(fSb, lhomo, IndelConfidenceMode.DEFAULT_HOMN);
-							
-							/*
-							 * check mutant read count and novel starts
-							 */
-							if ( ! isGATKCall) {
-								checkNNS(nnsArr[i], fSb, nnsCount);
-							}
-							
-							if (applyMutantReadFilter(gts, adArr[i], percentageMode ? (int)(mrPercentage * cov) : mrCount)) {
-								StringUtils.updateStringBuilder(fSb, VcfHeaderUtils.FORMAT_MUTANT_READS, Constants.SEMI_COLON);
-							}
-							
-							/*
-							 * end of read check
-							 */
-							if ( ! isGATKCall && null != eorArr) {
-								int eor = endsOfReads(alts, gt, alleleDist, eorArr[i]);
-								if (eor > 0) {
-									StringUtils.updateStringBuilder(fSb, "5BP=" + eor, Constants.SEMI_COLON);
-								}
-							}
-						}
-					}
-						
-					filterArr[i] = fSb.length() == 0 ? VcfHeaderUtils.FILTER_PASS : fSb.toString();
-					/*
-					 * deal with homozygous loss instances where we potentially have no coverage in test - still mark as a pass
-					 */
-					if (null != ccmArr) {
-						int ccm = Integer.parseInt(ccmArr[i]);
-						if (ccm == 11 || ccm == 21 || ccm == 31 || ccm == 41) {
-							filterArr[i] = VcfHeaderUtils.FILTER_PASS;
-						}
-					}
-				}
-				
-				/*
-				 * update vcf record with (possibly) updated ffs
-				 */
-				vcf.setFormatFields(VcfUtils.convertFFMapToList(ffMap));
-				
-				if (Arrays.stream(filterArr).distinct().count() == 1 && filterArr[0].equals(VcfHeaderUtils.FILTER_PASS)) {
-					pass++;
-				} else {
-					fail++;
-				}
-			}
-		}
-		
-		logger.info("Confidence breakdown, pass: " + pass + ", fail: " + fail );
- 
-		//add header line  set number to 1
-		if (null != header ) {
-			header.addInfo(VcfHeaderUtils.INFO_CONFIDENCE, "1", "String", DESCRIPTION_INFO_CONFIDENCE);
-		}
-	}
+        //get control and test sample column; here use the header from inputRecord(...)
+        meta = new VcfFileMeta(header);
+        logger.tool("meta: " + meta.getType());
+        controlCols = meta.getAllControlPositions();
+
+        addAnnotation();
+        addVcfHeaderFilters();
+        reheader(options.getCommandLine(), options.getInputFileName());
+        writeVCF(new File(options.getOutputFileName()));
+    }
+
+    public void addVcfHeaderFilters() {
+        header.addFilter(VcfHeaderUtils.FILTER_COVERAGE, VcfHeaderUtils.FILTER_COVERAGE_DESC + ", test coverage minimum value: " + testCovCutoff + ", control coverage minimum value (somatic/germline): " + controlCovCutoffForSomaticCalls + "/" + controlCovCutoff);
+        header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL, "Mutation also found in pileup of normal (>= " + minPercentage + "% of reads)");
+        header.addFilter(VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL, "Mutation also found in pileup of unfiltered normal (>= " + minCutoff + " reads, and also >= " + minPercentage + "%) of reads)");
+        header.addFilter(VcfHeaderUtils.FILTER_NOVEL_STARTS, "Less than " + nnsCount + " novel starts not considering read pair");
+        header.addFilter(VcfHeaderUtils.FILTER_MUTANT_READS, "Less than " + (mrPercentage > 0.0f ? mrPercentage + "%" : mrCount) + " mutant reads");
+        header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_ALT, "Alternate allele on only one strand (or percentage alternate allele on other strand is less than " + sBiasAltPercentage + "%)");
+        header.addFilter(VcfHeaderUtils.FILTER_STRAND_BIAS_COV, "Sequence coverage on only one strand (or percentage coverage on other strand is less than " + sBiasCovPercentage + "%)");
+        header.addFilter(VcfHeaderUtils.FILTER_END_OF_READ, VcfHeaderUtils.FILTER_END_OF_READ_DESC);
+    }
+
+    void addAnnotation() {
+
+        int passCount = 0;
+        int fail = 0;
+
+        final boolean percentageMode = mrPercentage > 0.0f;
+
+        //check high, low nns...
+        for (List<VcfRecord> vcfs : positionRecordMap.values()) {
+            for (VcfRecord vcf : vcfs) {
+
+                Map<String, String[]> ffMap = vcf.getFormatFieldsAsMap();
+
+                boolean isSomatic = VcfUtils.isRecordSomatic(vcf.getInfo(), ffMap);
+                String[] alts = vcf.getAlt().split(Constants.COMMA_STRING);
+
+                /*
+                 * We will look at each sample in isolation
+                 * if no genotype is present, skip the sample
+                 * If we have a 0/0 genotype, and the sample FT is ., and the coverage is adequate, set it to pass
+                 * if we have any other genotype (ie, the sample is showing a mutation), check coverage, MR and NNS and existing FT fields. If within our acceptable limits, set FT to PASS
+                 */
+
+                VcfInfoFieldRecord info = vcf.getInfoRecord();
+                int lhomo = (info.getField(VcfHeaderUtils.INFO_HOM) == null) ? 1 : StringUtils.string2Number(info.getField(VcfHeaderUtils.INFO_HOM).split(Constants.COMMA_STRING)[0], Integer.class);
+
+                String[] gtArray = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE);
+                String[] nnsArr = ffMap.get(VcfHeaderUtils.FILTER_NOVEL_STARTS);
+                String[] filterArr = ffMap.get(VcfHeaderUtils.FORMAT_FILTER);
+                String[] covArr = ffMap.get(VcfHeaderUtils.FORMAT_READ_DEPTH);
+                String[] ccmArr = ffMap.get(VcfHeaderUtils.FORMAT_CCM);
+                String[] oabsArr = ffMap.get(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND);
+                String[] gqArr = ffMap.get(VcfHeaderUtils.FORMAT_GENOTYPE_QUALITY);
+                String[] adArr = ffMap.get(VcfHeaderUtils.FORMAT_ALLELIC_DEPTHS);
+                String[] infArr = ffMap.get(VcfHeaderUtils.FORMAT_INFO);
+                String[] eorArr = ffMap.get(VcfHeaderUtils.FORMAT_END_OF_READ);
+                String[] ffArr = ffMap.get(VcfHeaderUtils.FORMAT_FF);
+                if (covArr == null || covArr.length == 0) {
+                    logger.warn("no coverage values for vcf record!!!: " + vcf);
+                    continue;
+                }
+                if (null == filterArr || filterArr.length == 0) {
+                    continue;
+                }
+
+                for (int i = 0; i < gtArray.length; i++) {
 
 
-	/**
-	 * @param alts
-	 * @param fSb
-	 * @param alleleDist
-	 * @param gt
-	 */
-	public static void checkStrandBias(String[] alts, StringBuilder fSb, Map<String, int[]> alleleDist, int[] gts, int sBiasCovPercentage, int sBiasAltPercentage) {
+                    String inf = null != infArr && infArr.length > i ? infArr[i] : null;
+                    /*
+                     * for No Call in GATK, set filter to PASS
+                     */
+                    if (VcfHeaderUtils.FORMAT_NCIG.equals(inf)) {
+                        filterArr[i] = VcfHeaderUtils.FILTER_PASS;
+                        continue;
+                    }
 
-		AtomicInteger fsCount = new AtomicInteger();
-		AtomicInteger rsCount = new AtomicInteger();
-		alleleDist.values().stream().forEach(a -> {fsCount.addAndGet(a[0]); rsCount.addAndGet(a[1]);});
-		boolean sbiasCov = ! AccumulatorUtils.areBothStrandsRepresented(fsCount, rsCount, sBiasCovPercentage);
-		
-		
-		for (int gtI : gts) {
-			if (gtI > 0) {
-				int [] iArray = alleleDist.get(alts[gtI - 1]);
-				int min = Math.min(iArray[0], iArray[1]);
-				
-				if ( ((double) min / (iArray[0] + iArray[1])) * 100 < sBiasAltPercentage) {
-					StringUtils.updateStringBuilder(fSb, sbiasCov ? SnpUtils.STRAND_BIAS_COVERAGE : SnpUtils.STRAND_BIAS_ALT, Constants.SEMI_COLON);
-					break;
-				}
-			}
-		}
-	}
-	
-	public static void checkNNS(String nnsString, StringBuilder sb, int nnsCount) {
-		int [] nns = getFieldOfInts(nnsString);
-		if ( ! allValuesAboveThreshold(nns, nnsCount)) {
-			StringUtils.updateStringBuilder(sb, VcfHeaderUtils.FILTER_NOVEL_STARTS, Constants.SEMI_COLON);
-		}
-	}
-	
-	public static void checkMIN(String [] alts, int coverage, Map<String, int[]> alleleDist, StringBuilder sb, int minCutoff, float minPercentage) {
-		if (null != alts && null != alleleDist) {
-			for (String alt : alts) {
-				int altCov = Arrays.stream(alleleDist.getOrDefault(alt, new int[]{0,0})).sum();
-				boolean min = VcfUtils.mutationInNormal(altCov, coverage, minPercentage, minCutoff);
-				if (min) {
-					StringUtils.updateStringBuilder(sb, VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL, Constants.SEMI_COLON);
-					break;
-				}
-			}
-		}
-	}
-	
-	/**
-	 * This checkMIUN method will use the max(percentage of alts, hard cutoff) means of determining if the MIUN annotation should be added, similar to the checkMIN method
-	 * 
-	 * THe coverage used in the percentage calculation will need to take into account failed filter reads along with regular reads.
-	 * 
-	 * @param alts
-	 * @param coverage
-	 * @param failedFilter
-	 * @param sb
-	 * @param miunCutoff
-	 * @param miunPercentage
-	 */
-	public static void checkMIUN(String [] alts, int coverage, String failedFilter, StringBuilder sb, int miunCutoff, float miunPercentage) {
-		if (null != alts && ! StringUtils.isNullOrEmptyOrMissingData(failedFilter)) {
-			
-			int totalCoverage = coverage + getCoverageFromFailedFilterString(failedFilter);
-			float cutoffToUse = Math.max(miunCutoff, (float)((miunPercentage / 100) * totalCoverage));
-			
-			
-			for (String alt : alts) {
-				int altIndex = failedFilter.indexOf(alt);
-				if (altIndex > -1) {
-					/*
-					 * bases are separated by colons
-					 */
-					int semiColonIndex = failedFilter.indexOf(Constants.SEMI_COLON, altIndex);
-					int failedFilterCount = Integer.parseInt(failedFilter.substring(altIndex + alt.length(), semiColonIndex > -1 ? semiColonIndex : failedFilter.length()));
-					if (failedFilterCount >= cutoffToUse) {
-						StringUtils.updateStringBuilder(sb, VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL, Constants.SEMI_COLON);
-						break;
-					}
-				}
-			}
-		}
-	}
-	
-	public static int endsOfReads(String [] alts, String gt, Map<String, int[]> oabsMap, String eor) {
-		if ((null == oabsMap || oabsMap.isEmpty()) 
-				|| StringUtils.isNullOrEmptyOrMissingData(eor)
-				|| (null == alts || alts.length == 0)
-				|| "0/0".equals(gt)
-				|| "./.".equals(gt)
-				) {
-			return 0;
-		}
-		
-		int i = 1;
-		int maxBP = 0;
-		Map<String, int[]> eorMap = VcfUtils.getAllelicCoverageWithStrand(eor);
-		for (String alt : alts) {
-			if (gt.contains("" + i)) {
-				int [] altCov = oabsMap.getOrDefault(alt, new int [] {0,0});
-				int [] altCovEOR = eorMap.getOrDefault(alt, new int [] {0,0});
-				int middleOfReadForwardStrand = altCov[0] - altCovEOR[0];
-				int middleOfReadReverseStrand = altCov[1] - altCovEOR[1];
-				int middleOfReadCount = middleOfReadForwardStrand + middleOfReadReverseStrand;
-				int endOfReadCount = altCovEOR[0] +  altCovEOR[1];
-				
-				if (middleOfReadCount >= 5 && (middleOfReadReverseStrand > 0 && middleOfReadForwardStrand > 0)) {
-					// all good
-				} else {
-					if ((endOfReadCount) > maxBP) {
-						maxBP = endOfReadCount;
-					}
-				}
-			}
-			i++;
-		}
-		return maxBP;
-	}
-	
-	/**
-	 * Check that if gt field contains a non-ref number that the corresponding AD value is above (or equal to) the cutoff
-	 * @param gt
-	 * @param adField
-	 * @param mrCutoff
-	 * @return
-	 */
-	public static boolean applyMutantReadFilter(int [] gts, String ad, int mrCutoff) {
-		
-		if ( null != gts && gts.length > 0 && ! StringUtils.isNullOrEmptyOrMissingData(ad)) {
-			
-			String [] adArray = ad.split(Constants.COMMA_STRING);
-			if (null != adArray && adArray.length > 1) {
-				
-				for (int i : gts) {
-					if (i > 0 && i < adArray.length && Integer.parseInt(adArray[i]) < mrCutoff) {
-						return true;
-					}
-				}
-			}
-		}
-		
-		return false;
-	}
-	
-	public static boolean allValuesAboveThreshold(int[] values, int threshold) {
-		return Arrays.stream(values).allMatch(i -> i >= threshold);
-	}
-	public static boolean allValuesAboveThreshold(int[] values, int coverage, double percentageCutoff) {
-		return Arrays.stream(values).allMatch(i -> ((double)i / coverage) * 100 >= percentageCutoff);
-	}
-	
-	public static void checkHOM(StringBuilder sb, int homCount, int acceptableHomCount) {
-		/*
-		 * HOM
-		 */
-		if (homCount > 0 && homCount >= acceptableHomCount) {
-			StringUtils.updateStringBuilder(sb, VcfHeaderUtils.INFO_HOM, Constants.SEMI_COLON);
-		}
-	}
+                    boolean isControl = controlCols != null && controlCols.contains((short) (i + 1));
 
-	 public static int [] getFieldOfInts(VcfFormatFieldRecord formatField, String key) {
-		 String value = formatField.getField(key);
-		 return getFieldOfInts(value);
-	 }
-	 
-	 /**
-	  * Takes a string containing 1 or 2 ints separated by a comma, and returns an int array representing the ints in the string.
-	  * If the string is null or empty, an int array containing a single element equal to 0 is returned.
-	  * 
-	  * This will throw an (unchecked) exception should the string contain characters that can't be coerced into a int using Interger.parseInt()
-	  * 
-	  * @param value
-	  * @return
-	  */
-	 public static int [] getFieldOfInts(String value) {
-		 if (StringUtils.isNullOrEmptyOrMissingData(value)) {
-			 return new int[]{0};
-		 }
-		 int cI = value.indexOf(Constants.COMMA);
-		 if (cI == -1) return new int[] {Integer.parseInt(value)};
-		 return new int[]{Integer.parseInt(value.substring(0, cI)), Integer.parseInt(value.substring(cI + 1))}; 
-	 }
-	 
-	 /**
-	  * Returns the number of reads present in the failed filter string.
-	  * This string must be in the following format: "<base><count>[;<base><count>]"
-	  * eg. "A3;C8"
-	  * The coverage value returned in this instance would be 11.
-	  * 
-	  * @param ff
-	  * @return
-	  */
-	 public static int getCoverageFromFailedFilterString(String ff) {
-		int cov = 0;
-		if ( ! StringUtils.isNullOrEmptyOrMissingData(ff)) {
-			 
-			 int semiColonIndex = ff.indexOf(Constants.SEMI_COLON);
-				 
-			 // could probably start this at 1....
-			 for (int i = 0 ; i < ff.length() ; ) {
-				 if (Character.isDigit(ff.charAt(i))) {
-					 cov += Integer.parseInt(ff.substring(i, semiColonIndex > -1 ? semiColonIndex : ff.length()));
-					 if (semiColonIndex == -1) {
-						 break;
-					 } else {
-						 // increment i by semi colon index
-						 i = semiColonIndex + 1;
-						 semiColonIndex = ff.indexOf(Constants.SEMI_COLON, i);
-					 }
-				 } else {
-					 i++;
-				 }
-			 }
-		}
-		return cov;
-	 }
-	 
-	 public static int [] getAltCoveragesFromADField(String ad) {
-		 if (StringUtils.isNullOrEmptyOrMissingData(ad)) {
-			 return new int[]{0};
-		 }
-		 String [] adArray = ad.split(Constants.COMMA_STRING);
-		 if (adArray.length < 2) {
-			 return new int[]{0};
-		 }
-		 int [] adIntArray = new int[adArray.length - 1];
-		 for (int i = 1 ; i < adArray.length ; i++) {
-			 adIntArray[i - 1] = Integer.parseInt(adArray[i]);
-		 }
-		 return adIntArray;
-	 }
-	 
-	@Override
-	void addAnnotation(String dbfile) throws IOException {
-		// TODO Auto-generated method stub		
-	}  
+                    /*
+                     * add all failed filters to FT field
+                     */
+                    StringBuilder failedFilterStringBuilder = new StringBuilder();
+
+
+                    /*
+                     * coverage next - needs to be >= the min coverage value
+                     */
+                    String covS = covArr[i];
+                    boolean isGATKCall = null != gqArr && !StringUtils.isNullOrEmptyOrMissingData(gqArr[i]);
+                    int cov = StringUtils.isNullOrEmptyOrMissingData(covS) ? 0 : Integer.parseInt(covS);
+
+                    if (cov < minCov || cov < (isControl ? controlCovCutoff : testCovCutoff)) {
+                        StringUtils.updateStringBuilder(failedFilterStringBuilder, VcfHeaderUtils.FILTER_COVERAGE, Constants.SEMI_COLON);
+                    }
+
+                    Map<String, int[]> alleleDist = (null != oabsArr && oabsArr.length >= i) ? VcfUtils.getAllelicCoverageWithStrand(oabsArr[i]) : Collections.emptyMap();
+                    /*
+                     * MIN next - only do this for control when we have a somatic call
+                     * need OABS field to be able to do this.
+                     */
+                    if (isControl && isSomatic && !isGATKCall) {
+
+                        checkMIN(alts, cov, alleleDist, failedFilterStringBuilder, minCutoff, (float) minPercentage);
+
+                        /*
+                         * look for MIUN, but only if we don't already have MIN
+                         */
+                        checkMIUN(failedFilterStringBuilder, ffArr, i, alts, cov);
+
+                        if (!failedFilterStringBuilder.toString().contains(VcfHeaderUtils.FILTER_COVERAGE) && cov < controlCovCutoffForSomaticCalls) {
+                            StringUtils.updateStringBuilder(failedFilterStringBuilder, VcfHeaderUtils.FILTER_COVERAGE, Constants.SEMI_COLON);
+                        }
+                    }
+
+                    /*
+                     * SBIASALT and SBIASCOV - do for all samples
+                     */
+                    String gt = gtArray[i];
+                    if ( ! StringUtils.isNullOrEmptyOrMissingData(gt) && ! "0/0".equals(gt)) {
+                        int index = gt.indexOf(Constants.SLASH);
+                        int[] gts = new int[]{Integer.parseInt(gt.substring(0, index)), Integer.parseInt(gt.substring(index + 1))};
+
+                        if (!alleleDist.isEmpty() && !isGATKCall) {
+                            checkStrandBias(alts, failedFilterStringBuilder, alleleDist, gts, sBiasCovPercentage, sBiasAltPercentage);
+                        }
+
+                        /*
+                         * HOM
+                         */
+                        checkHOM(failedFilterStringBuilder, lhomo, homopolymerCutoff);
+
+                        /*
+                         * check mutant read count and novel starts
+                         */
+                        if (!isGATKCall) {
+                            checkNNS(nnsArr[i], failedFilterStringBuilder, nnsCount);
+                        }
+
+                        if (applyMutantReadFilter(gts, adArr[i], percentageMode ? (int) (mrPercentage * cov) : mrCount)) {
+                            StringUtils.updateStringBuilder(failedFilterStringBuilder, VcfHeaderUtils.FORMAT_MUTANT_READS, Constants.SEMI_COLON);
+                        }
+
+                        /*
+                         * end of read check
+                         */
+                        endOfReadCheck(isGATKCall, eorArr, alts, gt, alleleDist, i, failedFilterStringBuilder);
+                    }
+
+                    filterArr[i] = failedFilterStringBuilder.isEmpty() ? VcfHeaderUtils.FILTER_PASS : failedFilterStringBuilder.toString();
+                    /*
+                     * deal with homozygous loss instances where we potentially have no coverage in test - still mark as a pass
+                     */
+                    if (null != ccmArr) {
+                        int ccm = Integer.parseInt(ccmArr[i]);
+                        if (ccm == 11 || ccm == 21 || ccm == 31 || ccm == 41) {
+                            filterArr[i] = VcfHeaderUtils.FILTER_PASS;
+                        }
+                    }
+                }
+
+                /*
+                 * update vcf record with (possibly) updated ffs
+                 */
+                vcf.setFormatFields(VcfUtils.convertFFMapToList(ffMap));
+
+                if (Arrays.stream(filterArr).distinct().count() == 1 && filterArr[0].equals(VcfHeaderUtils.FILTER_PASS)) {
+                    passCount++;
+                } else {
+                    fail++;
+                }
+            }
+        }
+
+        logger.info("Confidence breakdown, pass: " + passCount + ", fail: " + fail);
+
+        //add header line  set number to 1
+        if (null != header) {
+            header.addInfo(VcfHeaderUtils.INFO_CONFIDENCE, "1", "String", DESCRIPTION_INFO_CONFIDENCE);
+        }
+    }
+
+    private void checkMIUN(StringBuilder fSb, String[] ffArr, int i, String[] alts, int cov) {
+        if (!fSb.toString().contains(VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL)) {
+            if (null != ffArr && ffArr.length > i) {
+                String failedFilter = ffArr[i];
+                // using the same values as for the MIN annotation
+                checkMIUN(alts, cov, failedFilter, fSb, minCutoff, (float) minPercentage);
+            }
+        }
+    }
+
+    private static void endOfReadCheck(boolean isGATKCall, String[] eorArr, String[] alts, String gt, Map<String, int[]> alleleDist, int i, StringBuilder fSb) {
+        if (!isGATKCall && null != eorArr) {
+            int eor = endsOfReads(alts, gt, alleleDist, eorArr[i]);
+            if (eor > 0) {
+                StringUtils.updateStringBuilder(fSb, "5BP=" + eor, Constants.SEMI_COLON);
+            }
+        }
+    }
+
+
+    /**
+     * Checks for strand bias in the given allele distribution and genotype information.
+     *
+     * @param alts               Array of alternative alleles
+     * @param fSb                StringBuilder object to store the result of the check
+     * @param alleleDist         Map containing the allele distribution
+     * @param gts                Array of genotype information
+     * @param sBiasCovPercentage Coverage percentage threshold to determine strand bias
+     * @param sBiasAltPercentage Alternative allele percentage threshold to determine strand bias
+     */
+    public static void checkStrandBias(String[] alts, StringBuilder fSb, Map<String, int[]> alleleDist, int[] gts, int sBiasCovPercentage, int sBiasAltPercentage) {
+
+        AtomicInteger fsCount = new AtomicInteger();
+        AtomicInteger rsCount = new AtomicInteger();
+        alleleDist.values().forEach(a -> {
+            fsCount.addAndGet(a[0]);
+            rsCount.addAndGet(a[1]);
+        });
+        boolean sbiasCov = !AccumulatorUtils.areBothStrandsRepresented(fsCount, rsCount, sBiasCovPercentage);
+
+
+        for (int gtI : gts) {
+            if (gtI > 0) {
+                int[] iArray = alleleDist.get(alts[gtI - 1]);
+                int min = Math.min(iArray[0], iArray[1]);
+
+                if (((double) min / (iArray[0] + iArray[1])) * 100 < sBiasAltPercentage) {
+                    StringUtils.updateStringBuilder(fSb, sbiasCov ? SnpUtils.STRAND_BIAS_COVERAGE : SnpUtils.STRAND_BIAS_ALT, Constants.SEMI_COLON);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks for the number of novel starts in the given NNS string.
+     *
+     * @param nnsString NNS string
+     * @param sb        StringBuilder object to store the result of the check
+     * @param nnsCount  Number of novel starts threshold
+     */
+    public static void checkNNS(String nnsString, StringBuilder sb, int nnsCount) {
+        int[] nns = getFieldOfInts(nnsString);
+        if (!allValuesAboveThreshold(nns, nnsCount)) {
+            StringUtils.updateStringBuilder(sb, VcfHeaderUtils.FILTER_NOVEL_STARTS, Constants.SEMI_COLON);
+        }
+    }
+
+    /**
+     * Checks the minimum coverage and percentage for alternative alleles in the given allele distribution.
+     *
+     * @param alts          Array of alternative alleles
+     * @param coverage      The total coverage
+     * @param alleleDist    Map containing the allele distribution
+     * @param sb            StringBuilder object to store the result of the check
+     * @param minCutoff     The minimum coverage cutoff
+     * @param minPercentage The minimum percentage cutoff
+     */
+    public static void checkMIN(String[] alts, int coverage, Map<String, int[]> alleleDist, StringBuilder sb, int minCutoff, float minPercentage) {
+        if (null != alts && null != alleleDist) {
+            for (String alt : alts) {
+                int altCov = Arrays.stream(alleleDist.getOrDefault(alt, new int[]{0, 0})).sum();
+                boolean min = VcfUtils.mutationInNormal(altCov, coverage, minPercentage, minCutoff);
+                if (min) {
+                    StringUtils.updateStringBuilder(sb, VcfHeaderUtils.FILTER_MUTATION_IN_NORMAL, Constants.SEMI_COLON);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * This checkMIUN method will use the max(percentage of alts, hard cutoff) means of determining if the MIUN annotation should be added, similar to the checkMIN method
+     * <p>
+     * THe coverage used in the percentage calculation will need to take into account failed filter reads along with regular reads.
+     *
+     * @param alts           Array of alternative alleles
+     * @param coverage       The total coverage
+     * @param failedFilter   The failed filter string
+     * @param sb             StringBuilder object to store the result of the check
+     * @param miunCutoff     The minimum coverage cutoff for MIUN
+     * @param miunPercentage The minimum percentage cutoff for MIUN
+     */
+    public static void checkMIUN(String[] alts, int coverage, String failedFilter, StringBuilder sb, int miunCutoff, float miunPercentage) {
+        if (null != alts && !StringUtils.isNullOrEmptyOrMissingData(failedFilter)) {
+
+            int totalCoverage = coverage + getCoverageFromFailedFilterString(failedFilter);
+            float cutoffToUse = Math.max(miunCutoff, (miunPercentage / 100) * totalCoverage);
+
+
+            for (String alt : alts) {
+                int altIndex = failedFilter.indexOf(alt);
+                if (altIndex > -1) {
+                    /*
+                     * bases are separated by colons
+                     */
+                    int semiColonIndex = failedFilter.indexOf(Constants.SEMI_COLON, altIndex);
+                    int failedFilterCount = Integer.parseInt(failedFilter.substring(altIndex + alt.length(), semiColonIndex > -1 ? semiColonIndex : failedFilter.length()));
+                    if (failedFilterCount >= cutoffToUse) {
+                        StringUtils.updateStringBuilder(sb, VcfHeaderUtils.FILTER_MUTATION_IN_UNFILTERED_NORMAL, Constants.SEMI_COLON);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the maximum number of ends of reads for the given alternative alleles, genotype information,
+     * allele coverage map, and ends of reads string.
+     *
+     * @param alts    Array of alternative alleles
+     * @param gt      Genotype information
+     * @param oabsMap Map containing the allele coverage information
+     * @param eor     Ends of reads string
+     * @return The maximum number of ends of reads
+     */
+    public static int endsOfReads(String[] alts, String gt, Map<String, int[]> oabsMap, String eor) {
+        if ((null == oabsMap || oabsMap.isEmpty()) || StringUtils.isNullOrEmptyOrMissingData(eor) || (null == alts || alts.length == 0) || "0/0".equals(gt) || "./.".equals(gt)) {
+            return 0;
+        }
+
+        int i = 1;
+        int maxBP = 0;
+        Map<String, int[]> eorMap = VcfUtils.getAllelicCoverageWithStrand(eor);
+        for (String alt : alts) {
+            if (gt.contains("" + i)) {
+                int[] altCov = oabsMap.getOrDefault(alt, new int[]{0, 0});
+                int[] altCovEOR = eorMap.getOrDefault(alt, new int[]{0, 0});
+                int middleOfReadForwardStrand = altCov[0] - altCovEOR[0];
+                int middleOfReadReverseStrand = altCov[1] - altCovEOR[1];
+                int middleOfReadCount = middleOfReadForwardStrand + middleOfReadReverseStrand;
+                int endOfReadCount = altCovEOR[0] + altCovEOR[1];
+
+                if (middleOfReadCount >= 5 && (middleOfReadReverseStrand > 0 && middleOfReadForwardStrand > 0)) {
+                    // all good
+                } else {
+                    if ((endOfReadCount) > maxBP) {
+                        maxBP = endOfReadCount;
+                    }
+                }
+            }
+            i++;
+        }
+        return maxBP;
+    }
+
+    /**
+     * Applies a mutant read filter to the given genotype information and alternative allele depth.
+     *
+     * @param gts      Array of genotype information
+     * @param ad       Alternative allele depth as a string where each value is separated by a comma
+     * @param mrCutoff Minimum mutant read cutoff
+     * @return true if the mutant read filter is applied, false otherwise
+     */
+    public static boolean applyMutantReadFilter(int[] gts, String ad, int mrCutoff) {
+
+        if (null != gts && gts.length > 0 && !StringUtils.isNullOrEmptyOrMissingData(ad)) {
+
+            String[] adArray = ad.split(Constants.COMMA_STRING);
+            if (adArray.length > 1) {
+
+                for (int i : gts) {
+                    if (i > 0 && i < adArray.length && Integer.parseInt(adArray[i]) < mrCutoff) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if all the values in the given array are above the specified threshold.
+     *
+     * @param values    The array of values to check.
+     * @param threshold The threshold value.
+     * @return {@code true} if all values are above the threshold, {@code false} otherwise.
+     */
+    public static boolean allValuesAboveThreshold(int[] values, int threshold) {
+        return Arrays.stream(values).allMatch(i -> i >= threshold);
+    }
+
+    public static boolean allValuesAboveThreshold(int[] values, int coverage, double percentageCutoff) {
+        return Arrays.stream(values).allMatch(i -> ((double) i / coverage) * 100 >= percentageCutoff);
+    }
+
+    /**
+     * Checks the number of HOM calls against an acceptable threshold
+     *
+     * @param sb                 StringBuilder object to store the result of the check
+     * @param homCount           The number of HOM calls
+     * @param acceptableHomCount The acceptable threshold for HOM calls
+     */
+    public static void checkHOM(StringBuilder sb, int homCount, int acceptableHomCount) {
+        /*
+         * HOM
+         */
+        if (homCount > 0 && homCount >= acceptableHomCount) {
+            StringUtils.updateStringBuilder(sb, VcfHeaderUtils.INFO_HOM, Constants.SEMI_COLON);
+        }
+    }
+
+    public static int[] getFieldOfInts(VcfFormatFieldRecord formatField, String key) {
+        String value = formatField.getField(key);
+        return getFieldOfInts(value);
+    }
+
+    /**
+     * Takes a string containing 1 or 2 ints separated by a comma, and returns an int array representing the ints in the string.
+     * If the string is null or empty, an int array containing a single element equal to 0 is returned.
+     * <p>
+     * This will throw an (unchecked) exception should the string contain characters that can't be coerced into a int using Integer.parseInt()
+     */
+    public static int[] getFieldOfInts(String value) {
+        if (StringUtils.isNullOrEmptyOrMissingData(value)) {
+            return new int[]{0};
+        }
+        int cI = value.indexOf(Constants.COMMA);
+        if (cI == -1) return new int[]{Integer.parseInt(value)};
+        return new int[]{Integer.parseInt(value.substring(0, cI)), Integer.parseInt(value.substring(cI + 1))};
+    }
+
+    /**
+     * Returns the number of reads present in the failed filter string.
+     * This string must be in the following format: "<base><count>[;<base><count>]"
+     * eg. "A3;C8"
+     * The coverage value returned in this instance would be 11.
+     *
+     * @param ff The failed filter string.
+     * @return The coverage value extracted from the failed filter string.
+     */
+    public static int getCoverageFromFailedFilterString(String ff) {
+        int cov = 0;
+        if (!StringUtils.isNullOrEmptyOrMissingData(ff)) {
+
+            int semiColonIndex = ff.indexOf(Constants.SEMI_COLON);
+
+            // could probably start this at 1....
+            for (int i = 0; i < ff.length(); ) {
+                if (Character.isDigit(ff.charAt(i))) {
+                    cov += Integer.parseInt(ff.substring(i, semiColonIndex > -1 ? semiColonIndex : ff.length()));
+                    if (semiColonIndex == -1) {
+                        break;
+                    } else {
+                        // increment i by semi colon index
+                        i = semiColonIndex + 1;
+                        semiColonIndex = ff.indexOf(Constants.SEMI_COLON, i);
+                    }
+                } else {
+                    i++;
+                }
+            }
+        }
+        return cov;
+    }
+
+    /**
+     * Retrieves the alternative coverages from the given AD field.
+     *
+     * @param ad The AD field as a string where each value is separated by a comma.
+     *           This field represents the coverage for each alternative allele.
+     * @return An array of integers containing the alternative coverages.
+     * If the AD field is null, empty, or contains missing data, an array with a single element containing 0 is returned.
+     */
+    public static int[] getAltCoveragesFromADField(String ad) {
+        if (StringUtils.isNullOrEmptyOrMissingData(ad)) {
+            return new int[]{0};
+        }
+        String[] adArray = ad.split(Constants.COMMA_STRING);
+        if (adArray.length < 2) {
+            return new int[]{0};
+        }
+        int[] adIntArray = new int[adArray.length - 1];
+        for (int i = 1; i < adArray.length; i++) {
+            adIntArray[i - 1] = Integer.parseInt(adArray[i]);
+        }
+        return adIntArray;
+    }
+
+    @Override
+    void addAnnotation(String dbfile) throws IOException {
+        // TODO Auto-generated method stub
+    }
 }	
 	

--- a/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
+++ b/qannotate/src/au/edu/qimr/qannotate/modes/HomoplymersMode.java
@@ -1,8 +1,8 @@
 /**
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
-*/
+ */
 package au.edu.qimr.qannotate.modes;
 
 import java.io.File;
@@ -32,54 +32,54 @@ import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.util.IOUtil;
 
-public class HomoplymersMode extends AbstractMode{
-	private final static QLogger logger = QLoggerFactory.getLogger(HomoplymersMode.class);
-	private final String input;
-	private final String output;
-	private final int homopolymerWindow;
-	private final String dbfile;
-	private int reportWindow;
-	public static final int defaultWindow = 100;
-	public static final int defaultreport = 10;
-	
-	@Deprecated //for unit test
-	HomoplymersMode( int homoWindow, int reportWindow){		
-		this.input = null;
-		this.output = null;
-		this.dbfile = null;
-		this.homopolymerWindow = homoWindow;
-		this.reportWindow = reportWindow;
-	}
-		
-	public HomoplymersMode(Options options) throws IOException {
-		input = options.getInputFileName();
-		output = options.getOutputFileName();
-		dbfile = options.getDatabaseFileName();
-		homopolymerWindow =  options.getHomoplymersWindow();
-		reportWindow = options.getHomoplymersReportSize();
-		reportWindow = options.getHomoplymersReportSize();
-		logger.tool("input: " + options.getInputFileName());
+public class HomoplymersMode extends AbstractMode {
+    private final static QLogger logger = QLoggerFactory.getLogger(HomoplymersMode.class);
+    private final String input;
+    private final String output;
+    private final int homopolymerWindow;
+    private final String dbfile;
+    private final int reportWindow;
+    public static final int DEFAULT_WINDOW = 100;
+    public static final int HOMOPOLYMER_CUTOFF = 10;
+
+    @Deprecated
+        //for unit test
+    HomoplymersMode(int homoWindow, int reportWindow) {
+        this.input = null;
+        this.output = null;
+        this.dbfile = null;
+        this.homopolymerWindow = homoWindow;
+        this.reportWindow = reportWindow;
+    }
+
+    public HomoplymersMode(Options options) throws IOException {
+        input = options.getInputFileName();
+        output = options.getOutputFileName();
+        dbfile = options.getDatabaseFileName();
+        homopolymerWindow = options.getHomoplymersWindow();
+        reportWindow = options.getHomoplymersReportSize();
+        logger.tool("input: " + options.getInputFileName());
         logger.tool("reference file: " + dbfile);
         logger.tool("output for annotated vcf records: " + options.getOutputFileName());
         logger.tool("logger file " + options.getLogFileName());
-        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() :  options.getLogLevel()));
+        logger.tool("logger level " + (options.getLogLevel() == null ? QLoggerFactory.DEFAULT_LEVEL.getName() : options.getLogLevel()));
         logger.tool("window size for homoplymers: " + homopolymerWindow);
         logger.tool("number of homoplymer bases on either side of variant to report: " + reportWindow);
-        
-        reheader(options.getCommandLine(),options.getInputFileName());
- 		addAnnotation(dbfile);		
-	}
-	
-	/*
-	 * taken from htsjdk
-	 * https://github.com/samtools/htsjdk/blob/master/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
-	 */
-	protected static Path findSequenceDictionary(final Path path) {
+
+        reheader(options.getCommandLine(), options.getInputFileName());
+        addAnnotation(dbfile);
+    }
+
+    /*
+     * taken from htsjdk
+     * https://github.com/samtools/htsjdk/blob/master/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+     */
+    protected static Path findSequenceDictionary(final Path path) {
         if (path == null) {
             return null;
         }
         // Try and locate the dictionary with the default method
-        final Path dictionary = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(path); path.toAbsolutePath();
+        final Path dictionary = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(path);
         if (Files.exists(dictionary)) {
             return dictionary;
         }
@@ -87,236 +87,235 @@ public class HomoplymersMode extends AbstractMode{
         final Path dictionaryExt = path.resolveSibling(path.getFileName().toString() + IOUtil.DICT_FILE_EXTENSION);
         if (Files.exists(dictionaryExt)) {
             return dictionaryExt;
-        }
-        else return null;
+        } else return null;
     }
-	
-	
-	@Override
-	void addAnnotation(String dbfile) throws IOException {
-		//load reference data
-		Map<String, byte[]> referenceBase = getReferenceBase(new File(dbfile));
-		
-		try (VcfFileReader reader = new VcfFileReader(input);
-	            RecordWriter<VcfRecord> writer = new RecordWriter<>(new File(output))) {
-			header.addInfo(VcfHeaderUtils.INFO_HOM,  "2", "String",VcfHeaderUtils.INFO_HOM_DESC); 			
-		    for (final VcfHeaderRecord record: header) {
-		    	writer.addHeader(record.toString());
-		    }
-		    
-		    int sum = 0;
-			for (final VcfRecord re : reader) {	
-				writer.add( annotate(re, referenceBase.get(IndelUtils.getFullChromosome(re.getChromosome()))));
-				sum ++;
-			}
-			logger.info(sum + " records have been put through qannotate's homopolymer mode");
-		}
-	}
-	
-	VcfRecord annotate(VcfRecord re1, byte[] base){
-		VcfRecord re = re1; 
-		ChrRangePosition pos = new ChrRangePosition(  re.getChrPosition());
-		SVTYPE variantType = IndelUtils.getVariantType(re.getRef(), re.getAlt());
-		String motif = IndelUtils.getMotif(re.getRef(), re.getAlt(), variantType);
-		byte[][] sideBases = getReferenceBase(base, pos, variantType, homopolymerWindow);
-		
-		String str = getHomopolymerData(motif, sideBases, variantType, reportWindow);
-		re.appendInfo(VcfHeaderUtils.INFO_HOM + Constants.EQ + str);						 
-		return re; 
-	}
-	
-	/**
-	 * use default of 
-	 * @param motif
-	 * @param sideBases
-	 * @param variantType
-	 * @return
-	 */
-	public static String getHomopolymerData(String motif, byte[][] sideBases, SVTYPE variantType) {
-		return getHomopolymerData(motif, sideBases, variantType, defaultreport);
-	}
-	
-	public static String getHomopolymerData(String motif, byte[][] sideBases, SVTYPE variantType, int reportWindow ) {
-		/*
-		 * need to deal with multiple alts - find the one that gives the greatest HOM count and use that
-		 */
-		int homNo = 0;
-		if (motif.contains(Constants.COMMA_STRING)) {
-			String [] altAlleles = motif.split(Constants.COMMA_STRING);
-			int maxHomValue = 0;
-			String maxHomAlt = null;
-			for (String alt : altAlleles) {
-				if (maxHomAlt == null) {
-					maxHomAlt = alt;
-				}
-				int hNo = findHomopolymer(sideBases, alt,variantType);
-				if (hNo > maxHomValue) {
-					maxHomValue = hNo;
-					maxHomAlt = alt;
-				}
-			}
-			motif = maxHomAlt;
-			homNo = maxHomValue;
-			
-		} else {
-			homNo = findHomopolymer(sideBases,  motif,variantType);
-		}
-		return homNo + Constants.COMMA_STRING + getHomTxt(motif, sideBases, variantType, reportWindow);
-	}
-	
-	private static String getHomTxt(String variantStr, byte[][] updownReference, SVTYPE type, int reportWindow ) {	
-		
-		//at the edge of reference, the report window maybe bigger than nearby base
-		int baseNo1 = Math.min(updownReference[0].length, reportWindow) ;	
-		int baseNo2 = Math.min(updownReference[1].length, reportWindow) ;		
-		byte[] seq = new byte[baseNo1 + variantStr.length() + baseNo2]; 
-				
-		System.arraycopy(updownReference[0], (updownReference[0].length - baseNo1), seq, 0, baseNo1);  	
- 		System.arraycopy(updownReference[1], 0, seq, baseNo1 + variantStr.length(), baseNo2); 
- 				
-		if (type.equals(SVTYPE.DEL)) {			 
-			for (int i = 0; i < variantStr.length(); i++) {
-				seq[baseNo1 + i] = '_';
-			}
-		} else {  			
-			//copy INS base  or SNPs reference base
-			System.arraycopy( variantStr.toLowerCase().getBytes(), 0, seq, baseNo1 , variantStr.length());  
-		}
-		return new String(seq); 
-	}
-	
-	static byte[][] getReferenceBase(byte[]  reference, ChrRangePosition pos, SVTYPE type, int homopolymerWindow) { 	
-		//eg. INS: 21 T TC ,  DEL: 21  TCC T,  SNPs: TCC ATT
-		//T from INS or DEL  position.getPosition() is 21 but should be  referenceBase[20] which is end of upStream
-		//INS position.getEndPosition() is 21, downStream should start at referenceBase[21]
-		//DEL position.getEndPosition() is 23, downStream should start at referenceBase[23]
-	    //SNPs referenceBase[19] which is end of upStream and downStream should start at referenceBase[23]
-		
-	    //byte[] start with 0 but reference start with 1. 
-		//INDELs contain leading base from reference but SNPs not
-	    int indelStart = (type.equals(SVTYPE.INS) || type.equals(SVTYPE.DEL)) ? pos.getStartPosition() : pos.getStartPosition() - 1;
-    	int wstart =  Math.max( 0,indelStart-homopolymerWindow);
-    	if (indelStart - wstart < 0) {
-  	    	throw new IllegalArgumentException("Start of variant is before (or equal to) start of contig! variant start (+homopolymerWindow): " + wstart);
-  	    }
-    	byte[] upstreamReference = new byte[indelStart - wstart];
-	    System.arraycopy(reference, wstart, upstreamReference, 0, upstreamReference.length);
-	    
-	    int indelEnd = pos.getEndPosition();
-	    int wend = Math.min(reference.length, indelEnd + homopolymerWindow);
-	    if (wend - indelEnd < 0) {
-	    	throw new IllegalArgumentException("End of variant is past (or equal to) end of contig! contig end: " + reference.length + ", variant end (+homopolymerWindow): " + wend);
-	    }
-     	byte[] downstreamReference = new byte[wend - indelEnd];
-     	System.arraycopy(reference, indelEnd, downstreamReference, 0, downstreamReference.length);   
-     	return new byte[][]{upstreamReference, downstreamReference};
-	}
-	
-	static int findHomopolymer(byte[][] updownReference, String motif, SVTYPE indelType){
-		if (null == motif || motif.contains(Constants.COMMA_STRING)) {
-			throw new IllegalArgumentException("motif supplied to findHomopolymer is invalid: " + motif);
-		}
-		
-		int upBaseCount = 1;
-		int downBaseCount = 1;
- 		//upstream - start from end since this is the side adjacent to the indel
-		//decide if it is contiguous		
-		final int finalUpIndex = updownReference[0].length - 1;	
-		
-		//count upstream homopolymer bases
-		if (finalUpIndex >= 0) {
-			char nearBase = (char) updownReference[0][finalUpIndex];
-			for (int i = finalUpIndex - 1; i >= 0; i--) {
-				if (nearBase == updownReference[0][i]) {
-					upBaseCount++;
-				} else {
-					break;
-				}
-			}
-		}
-		
-		//count downstream homopolymer
-		if (null != updownReference[1] && updownReference[1].length > 0) {
-			char nearBase = (char) updownReference[1][0];
-			for (int i = 1; i < updownReference[1].length; i++) {
-				if (nearBase == updownReference[1][i]) {
-					downBaseCount++;
-				} else {
-					break;
-				}
-			}
-		}
-		
-		int max;
-		//reset up or down stream for deletion and SNPs reference base
-		if(indelType.equals(SVTYPE.DEL) || indelType.equals(SVTYPE.SNP) || indelType.equals(SVTYPE.DNP)  
-				|| indelType.equals(SVTYPE.ONP) || indelType.equals(SVTYPE.TNP) ){
-			byte[] mByte = motif.getBytes();
-			
-			int left = 0;
-			if (finalUpIndex >= 0) {
-				char nearBase = (char) updownReference[0][finalUpIndex];
-				for(int i = 0; i < mByte.length; i++ ) {
-					if (nearBase == mByte[i]) {
-						left ++;
-					} else {
-						break;				 
-					}
-				}
-			}
-			upBaseCount += left; 
-						
-			int right = 0;
-			if (null != updownReference[1] && updownReference[1].length > 0) {
-				char nearBase = (char) updownReference[1][0];
-				for(int i = mByte.length - 1; i >= 0; i--) { 
-					if (nearBase == mByte[i]) {
-						right++;
-					} else  {
-						break;
-					}
-				}
-			}
-			downBaseCount += right; 
-			
-			max = (left == right && left == mByte.length) ? 
-					(downBaseCount + upBaseCount - mByte.length) : Math.max(downBaseCount, upBaseCount);
-		} else {
-		    //INS don't have reference base
-			max = (updownReference[0][finalUpIndex] == updownReference[1][0]) ? 
-					(downBaseCount + upBaseCount) : Math.max(downBaseCount, upBaseCount);
-		}
-					
-		return max == 1 ? 0 : max;
-	}
-	
-   static Map<String, byte[]> getReferenceBase(File reference) throws IOException {
-	   
-	   /*
-        * check to see if the index and dict file exist for the reference
-        */
-       Path dictPath = findSequenceDictionary(reference.toPath());
-       if (null == dictPath) {
-       	throw new IllegalArgumentException("No dict file found for reference file: " + reference);
-       }
-       logger.tool("reference dictionary file: " + dictPath.toString());
-       Path indexPath = ReferenceSequenceFileFactory.getFastaIndexFileName(reference.toPath());
-       if (null == indexPath || ! indexPath.toFile().exists()) {
-       	throw new IllegalArgumentException("No index file found for reference file: " + reference);
-       }
-       logger.tool("reference index file: " + indexPath.toString());
-	   
-	   Map<String, byte[]> referenceBase = new HashMap<>();
-	   
-	   FastaSequenceIndex index = new FastaSequenceIndex(indexPath);
-	   
-	   try (IndexedFastaSequenceFile indexedFasta = new IndexedFastaSequenceFile(reference, index);) {
-		   SAMSequenceDictionary dict = indexedFasta.getSequenceDictionary();
-		   for (SAMSequenceRecord re: dict.getSequences()) {
-			   String contig = IndelUtils.getFullChromosome(re.getSequenceName());
-			   referenceBase.put(contig, indexedFasta.getSequence(contig).getBases());
-		   }
-	   }
-	   return referenceBase;
-   }
+
+
+    @Override
+    void addAnnotation(String dbfile) throws IOException {
+        //load reference data
+        Map<String, byte[]> referenceBase = getReferenceBase(new File(dbfile));
+
+        try (VcfFileReader reader = new VcfFileReader(input);
+             RecordWriter<VcfRecord> writer = new RecordWriter<>(new File(output))) {
+            header.addInfo(VcfHeaderUtils.INFO_HOM, "2", "String", VcfHeaderUtils.INFO_HOM_DESC);
+            for (final VcfHeaderRecord record : header) {
+                writer.addHeader(record.toString());
+            }
+
+            int sum = 0;
+            for (final VcfRecord re : reader) {
+                writer.add(annotate(re, referenceBase.get(IndelUtils.getFullChromosome(re.getChromosome()))));
+                sum++;
+            }
+            logger.info(sum + " records have been put through qannotate's homopolymer mode");
+        }
+    }
+
+    VcfRecord annotate(VcfRecord re1, byte[] base) {
+        VcfRecord re = re1;
+        ChrRangePosition pos = new ChrRangePosition(re.getChrPosition());
+        SVTYPE variantType = IndelUtils.getVariantType(re.getRef(), re.getAlt());
+        String motif = IndelUtils.getMotif(re.getRef(), re.getAlt(), variantType);
+        byte[][] sideBases = getReferenceBase(base, pos, variantType, homopolymerWindow);
+
+        String str = getHomopolymerData(motif, sideBases, variantType, reportWindow);
+        re.appendInfo(VcfHeaderUtils.INFO_HOM + Constants.EQ + str);
+        return re;
+    }
+
+    /**
+     * use default of
+     * @param motif
+     * @param sideBases
+     * @param variantType
+     * @return
+     */
+    public static String getHomopolymerData(String motif, byte[][] sideBases, SVTYPE variantType) {
+        return getHomopolymerData(motif, sideBases, variantType, HOMOPOLYMER_CUTOFF);
+    }
+
+    public static String getHomopolymerData(String motif, byte[][] sideBases, SVTYPE variantType, int reportWindow) {
+        /*
+         * need to deal with multiple alts - find the one that gives the greatest HOM count and use that
+         */
+        int homNo = 0;
+        if (motif.contains(Constants.COMMA_STRING)) {
+            String[] altAlleles = motif.split(Constants.COMMA_STRING);
+            int maxHomValue = 0;
+            String maxHomAlt = null;
+            for (String alt : altAlleles) {
+                if (maxHomAlt == null) {
+                    maxHomAlt = alt;
+                }
+                int hNo = findHomopolymer(sideBases, alt, variantType);
+                if (hNo > maxHomValue) {
+                    maxHomValue = hNo;
+                    maxHomAlt = alt;
+                }
+            }
+            motif = maxHomAlt;
+            homNo = maxHomValue;
+
+        } else {
+            homNo = findHomopolymer(sideBases, motif, variantType);
+        }
+        return homNo + Constants.COMMA_STRING + getHomTxt(motif, sideBases, variantType, reportWindow);
+    }
+
+    private static String getHomTxt(String variantStr, byte[][] updownReference, SVTYPE type, int reportWindow) {
+
+        //at the edge of reference, the report window maybe bigger than nearby base
+        int baseNo1 = Math.min(updownReference[0].length, reportWindow);
+        int baseNo2 = Math.min(updownReference[1].length, reportWindow);
+        byte[] seq = new byte[baseNo1 + variantStr.length() + baseNo2];
+
+        System.arraycopy(updownReference[0], (updownReference[0].length - baseNo1), seq, 0, baseNo1);
+        System.arraycopy(updownReference[1], 0, seq, baseNo1 + variantStr.length(), baseNo2);
+
+        if (type.equals(SVTYPE.DEL)) {
+            for (int i = 0; i < variantStr.length(); i++) {
+                seq[baseNo1 + i] = '_';
+            }
+        } else {
+            //copy INS base  or SNPs reference base
+            System.arraycopy(variantStr.toLowerCase().getBytes(), 0, seq, baseNo1, variantStr.length());
+        }
+        return new String(seq);
+    }
+
+    static byte[][] getReferenceBase(byte[] reference, ChrRangePosition pos, SVTYPE type, int homopolymerWindow) {
+        //eg. INS: 21 T TC ,  DEL: 21  TCC T,  SNPs: TCC ATT
+        //T from INS or DEL  position.getPosition() is 21 but should be  referenceBase[20] which is end of upStream
+        //INS position.getEndPosition() is 21, downStream should start at referenceBase[21]
+        //DEL position.getEndPosition() is 23, downStream should start at referenceBase[23]
+        //SNPs referenceBase[19] which is end of upStream and downStream should start at referenceBase[23]
+
+        //byte[] start with 0 but reference start with 1.
+        //INDELs contain leading base from reference but SNPs not
+        int indelStart = (type.equals(SVTYPE.INS) || type.equals(SVTYPE.DEL)) ? pos.getStartPosition() : pos.getStartPosition() - 1;
+        int wstart = Math.max(0, indelStart - homopolymerWindow);
+        if (indelStart - wstart < 0) {
+            throw new IllegalArgumentException("Start of variant is before (or equal to) start of contig! variant start (+homopolymerWindow): " + wstart);
+        }
+        byte[] upstreamReference = new byte[indelStart - wstart];
+        System.arraycopy(reference, wstart, upstreamReference, 0, upstreamReference.length);
+
+        int indelEnd = pos.getEndPosition();
+        int wend = Math.min(reference.length, indelEnd + homopolymerWindow);
+        if (wend - indelEnd < 0) {
+            throw new IllegalArgumentException("End of variant is past (or equal to) end of contig! contig end: " + reference.length + ", variant end (+homopolymerWindow): " + wend);
+        }
+        byte[] downstreamReference = new byte[wend - indelEnd];
+        System.arraycopy(reference, indelEnd, downstreamReference, 0, downstreamReference.length);
+        return new byte[][]{upstreamReference, downstreamReference};
+    }
+
+    static int findHomopolymer(byte[][] updownReference, String motif, SVTYPE indelType) {
+        if (null == motif || motif.contains(Constants.COMMA_STRING)) {
+            throw new IllegalArgumentException("motif supplied to findHomopolymer is invalid: " + motif);
+        }
+
+        int upBaseCount = 1;
+        int downBaseCount = 1;
+        //upstream - start from end since this is the side adjacent to the indel
+        //decide if it is contiguous
+        final int finalUpIndex = updownReference[0].length - 1;
+
+        //count upstream homopolymer bases
+        if (finalUpIndex >= 0) {
+            char nearBase = (char) updownReference[0][finalUpIndex];
+            for (int i = finalUpIndex - 1; i >= 0; i--) {
+                if (nearBase == updownReference[0][i]) {
+                    upBaseCount++;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        //count downstream homopolymer
+        if (null != updownReference[1] && updownReference[1].length > 0) {
+            char nearBase = (char) updownReference[1][0];
+            for (int i = 1; i < updownReference[1].length; i++) {
+                if (nearBase == updownReference[1][i]) {
+                    downBaseCount++;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        int max;
+        //reset up or down stream for deletion and SNPs reference base
+        if (indelType.equals(SVTYPE.DEL) || indelType.equals(SVTYPE.SNP) || indelType.equals(SVTYPE.DNP)
+                || indelType.equals(SVTYPE.ONP) || indelType.equals(SVTYPE.TNP)) {
+            byte[] mByte = motif.getBytes();
+
+            int left = 0;
+            if (finalUpIndex >= 0) {
+                char nearBase = (char) updownReference[0][finalUpIndex];
+                for (byte b : mByte) {
+                    if (nearBase == b) {
+                        left++;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            upBaseCount += left;
+
+            int right = 0;
+            if (null != updownReference[1] && updownReference[1].length > 0) {
+                char nearBase = (char) updownReference[1][0];
+                for (int i = mByte.length - 1; i >= 0; i--) {
+                    if (nearBase == mByte[i]) {
+                        right++;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            downBaseCount += right;
+
+            max = (left == right && left == mByte.length) ?
+                    (downBaseCount + upBaseCount - mByte.length) : Math.max(downBaseCount, upBaseCount);
+        } else {
+            //INS don't have reference base
+            max = (updownReference[0][finalUpIndex] == updownReference[1][0]) ?
+                    (downBaseCount + upBaseCount) : Math.max(downBaseCount, upBaseCount);
+        }
+
+        return max == 1 ? 0 : max;
+    }
+
+    static Map<String, byte[]> getReferenceBase(File reference) throws IOException {
+
+        /*
+         * check to see if the index and dict file exist for the reference
+         */
+        Path dictPath = findSequenceDictionary(reference.toPath());
+        if (null == dictPath) {
+            throw new IllegalArgumentException("No dict file found for reference file: " + reference);
+        }
+        logger.tool("reference dictionary file: " + dictPath.toString());
+        Path indexPath = ReferenceSequenceFileFactory.getFastaIndexFileName(reference.toPath());
+        if (null == indexPath || !indexPath.toFile().exists()) {
+            throw new IllegalArgumentException("No index file found for reference file: " + reference);
+        }
+        logger.tool("reference index file: " + indexPath.toString());
+
+        Map<String, byte[]> referenceBase = new HashMap<>();
+
+        FastaSequenceIndex index = new FastaSequenceIndex(indexPath);
+
+        try (IndexedFastaSequenceFile indexedFasta = new IndexedFastaSequenceFile(reference, index);) {
+            SAMSequenceDictionary dict = indexedFasta.getSequenceDictionary();
+            for (SAMSequenceRecord re : dict.getSequences()) {
+                String contig = IndelUtils.getFullChromosome(re.getSequenceName());
+                referenceBase.put(contig, indexedFasta.getSequence(contig).getBases());
+            }
+        }
+        return referenceBase;
+    }
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/ConfidenceModeTest.java
@@ -1,13 +1,11 @@
 package au.edu.qimr.qannotate.modes;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.util.ChrPositionUtils;
@@ -16,1105 +14,1222 @@ import org.qcmg.common.vcf.VcfRecord;
 import org.qcmg.common.vcf.VcfUtils;
 import org.qcmg.common.vcf.header.VcfHeaderUtils;
 
+import static org.junit.Assert.*;
+
 
 public class ConfidenceModeTest {
-	@org.junit.Rule
-	public  TemporaryFolder testFolder = new TemporaryFolder();
-	
-	public static final VcfFileMeta TWO_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createTwoSampleTwoCallerVcf());
-	public static final VcfFileMeta TWO_SAMPLE_ONE_CALLER_META = new VcfFileMeta( CCMModeTest.createTwoSampleVcf());
-	public static final VcfFileMeta SINGLE_SAMPLE_TWO_CALLER_META = new VcfFileMeta( CCMModeTest.createSingleSampleTwoCallerVcf());
-	 	 
-	 @Test
-	 public void testThresholds() {
-		 assertEquals(true, ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 9));
-		 assertEquals(true, ConfidenceMode.allValuesAboveThreshold(new int[]{10,9}, 9));
-		 assertEquals(false, ConfidenceMode.allValuesAboveThreshold(new int[]{10,9,8}, 9));
-		 assertEquals(false, ConfidenceMode.allValuesAboveThreshold(new int[]{8,9,8}, 9));
-		 assertEquals(true, ConfidenceMode.allValuesAboveThreshold(new int[]{8,9,8}, 8));
-	 }
-	 @Test
-	 public void testThresholdsPercentage() {
-		 assertEquals(true, ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 100, 9f));
-		 assertEquals(true, ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 100, 10f));
-		 assertEquals(false, ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 100, 10.1f));
-		 assertEquals(true, ConfidenceMode.allValuesAboveThreshold(new int[]{10,11,23}, 100, 10.0f));
-		 assertEquals(false, ConfidenceMode.allValuesAboveThreshold(new int[]{10,11,23}, 100, 20.1f));
-	 }
-	 
-	 @Test
-	 public void getFieldofInts() {
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getFieldOfInts(null));
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getFieldOfInts(""));
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getFieldOfInts("."));
-		 assertArrayEquals(new int[]{1}, ConfidenceMode.getFieldOfInts("1"));
-		 assertArrayEquals(new int[]{10}, ConfidenceMode.getFieldOfInts("10"));
-		 assertArrayEquals(new int[]{10}, ConfidenceMode.getFieldOfInts("010"));
-		 assertArrayEquals(new int[]{10,0}, ConfidenceMode.getFieldOfInts("010,0"));
-		 assertArrayEquals(new int[]{10,1}, ConfidenceMode.getFieldOfInts("010,001"));
-	 }
-	 
-	 @Test
-	 public void getADs() {
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField(null));
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField(""));
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField("."));
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField("A"));
-		 assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField("1234"));
-		 assertArrayEquals(new int[]{2}, ConfidenceMode.getAltCoveragesFromADField("1,2"));
-		 assertArrayEquals(new int[]{20}, ConfidenceMode.getAltCoveragesFromADField("1,20"));
-		 assertArrayEquals(new int[]{20}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20"));
-		 assertArrayEquals(new int[]{20,1}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20,1"));
-		 assertArrayEquals(new int[]{20,1,3}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20,1,3"));
-		 assertArrayEquals(new int[]{20,1,3,5}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20,1,3,5"));
-		 assertArrayEquals(new int[]{20,1,3,5}, ConfidenceMode.getAltCoveragesFromADField("100,20,1,3,5"));
-	 }
-	 
-	 @Test
-	 public void checkMin() {
-		 StringBuilder sb = null;
-		 ConfidenceMode.checkMIN(null, -1,  null,  sb, -1, -1f);
-		 assertEquals(null, sb);
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIN(null, -1,  null,  sb, -1, -1f);
-		 assertEquals("", sb.toString());
-		 Map<String, int[]> alleleDist = new HashMap<>();
-		 alleleDist.put("A", new int[]{10,10});
-		 ConfidenceMode.checkMIN(new String [] {"A"}, 20,  alleleDist,  sb, 1, 5f);
-		 assertEquals("MIN", sb.toString());
-		 
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIN(new String [] {"A"}, 2000,  alleleDist,  sb, Integer.MAX_VALUE, 5f);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIN(new String [] {"A"}, 2000,  alleleDist,  sb, 21, 5f);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIN(new String [] {"A"}, 2000,  alleleDist,  sb, 20, 5f);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIN(new String [] {"A"}, 200,  alleleDist,  sb, 2, 3f);
-		 assertEquals("MIN", sb.toString());
-		 
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIN(new String [] {"C"}, 2000,  alleleDist,  sb, 20, 5f);
-		 assertEquals("", sb.toString());
-	 }
-	 
-	 @Test
-	 public void minForCompoundSnps() {
-		 
-		 StringBuilder sb = new StringBuilder();
-		 Map<String, int[]> alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40]");
-		 ConfidenceMode.checkMIN(new String [] {"AA"}, 20,  alleleDist,  sb, 1, 5f);
-		 assertEquals("MIN", sb.toString());
-		 
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIN(new String [] {"AC"}, 20,  alleleDist,  sb, 1, 5f);
-		 assertEquals("", sb.toString());
-		 
-		 sb = new StringBuilder();
-		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]0[0]");
-		 ConfidenceMode.checkMIN(new String [] {"AC"}, 21,  alleleDist,  sb, 1, 5f);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIN(new String [] {"AC"}, 21,  alleleDist,  sb, 2, 3f);
-		 assertEquals("", sb.toString());
-		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]1[10]");
-		 ConfidenceMode.checkMIN(new String [] {"AC"}, 21,  alleleDist,  sb, 2, 3f);
-		 assertEquals("MIN", sb.toString());
-		 
-		 sb = new StringBuilder();
-		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]0[0]");
-		 ConfidenceMode.checkMIN(new String [] {"AC"}, 21,  alleleDist,  sb, 2, 5f);
-		 assertEquals("", sb.toString());
-		 
-		 sb = new StringBuilder();
-		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]10[40]");
-		 ConfidenceMode.checkMIN(new String [] {"AC"}, 32,  alleleDist,  sb, 2, 5f);
-		 assertEquals("MIN", sb.toString());
-		 
-		 sb = new StringBuilder();
-		 alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA100[40]10[40];AC1[40]10[40]");
-		 ConfidenceMode.checkMIN(new String [] {"AC"}, 122,  alleleDist,  sb, 2, 10f);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIN(new String [] {"AA"}, 122,  alleleDist,  sb, 2, 10f);
-		 assertEquals("MIN", sb.toString());
-		 
-	 }
-	 
-	 @Test
-	 public void checkMIUN() {
-		 StringBuilder sb = null;
-		 ConfidenceMode.checkMIUN(null, 0, null,  sb, -1, 3);
-		 assertEquals(null, sb);
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "", sb, -1, 3);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "C1", sb, 1, 3);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "C1;G2;T3", sb, 1, 3);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C"}, 0, "C1;G2;T3", sb, 2, 3);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, 93, "C1;G2;T3", sb, 2, 3);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","G","T"}, 93, "C1;G2;T3", sb, 2, 3);
-		 assertEquals("MIUN", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","G"}, 94, "C1;G2;T3", sb, 2, 3);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, 0, "C1;G2;T3", sb, 3, 3);
-		 assertEquals("MIUN", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A","C","T"}, 100, "C1;G2;T3", sb, 3, 3);
-		 assertEquals("", sb.toString());
-		 ConfidenceMode.checkMIUN(new String [] {"C"}, 0, "C1;G2;T3", sb, 1, 3);
-		 assertEquals("MIUN", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"G"}, 0, "C1;G2;T3", sb, 2, 3);
-		 assertEquals("MIUN", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"T"}, 0, "C1;G2;T3", sb, 3, 3);
-		 assertEquals("MIUN", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"T"}, 0, "C1;G2;T3", sb, 4, 3);
-		 assertEquals("", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, 0, "A3;C8", sb, 2, 3);
-		 assertEquals("MIUN", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkMIUN(new String [] {"A"}, 90, "A3;C8", sb, 2, 3);
-		 assertEquals("", sb.toString());
-	 }
-	 
-	 @Test
-	 public void testHOM() {
-		 StringBuilder sb = null;
-		 ConfidenceMode.checkHOM(sb, -1, -1);
-		 assertEquals(null, sb);
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkHOM(sb, -1, -1);
-		 assertEquals("", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkHOM(sb, 1, 0);
-		 assertEquals("HOM", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkHOM(sb, 1, 1);
-		 assertEquals("HOM", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkHOM(sb, 1, 2);
-		 assertEquals("", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkHOM(sb, 2, 2);
-		 assertEquals("HOM", sb.toString());
-		 sb = new StringBuilder();
-		 ConfidenceMode.checkHOM(sb, 3, 2);
-		 assertEquals("HOM", sb.toString());
-	 }
-	 
-	 @Test
-	 public void endOfReads() {
-		 /*
-		  * chr2    31044381        .       C       A       .       .       FLANK=CACCCAACAAC;BaseQRankSum=-1.769;ClippingRankSum=0.078;DP=38;FS=0.000;MQ=59.43;MQRankSum=-0.078;QD=9.20;ReadPosRankSum=-0.204;SOR=0.315;IN=1,2;HOM=2,CCCCCCACCCaACAACAGTCC GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL   0/0:28,0:Reference:13:28:C2[]2[]:C4:PASS:.:.:.:C4[34.25]24[36.67]:.     0/1:28,12:Somatic:13:40:A1[]1[];C1[]2[]:A6;C4:PASS:.:SOMATIC:12:A1[32]11[33.55];C3[31.33]25[35.04]:.    ./.:.:.:3:.:.:.:PASS:.:NCIG:.:.:.       0/1:23,14:.:3:37:.:.:PASS:99:SOMATIC:.:.:349.77
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr2","31044381",".","C","A",".",".","FLANK=CACCCAACAAC;BaseQRankSum=-1.769;ClippingRankSum=0.078;DP=38;FS=0.000;MQ=59.43;MQRankSum=-0.078;QD=9.20;ReadPosRankSum=-0.204;SOR=0.315;IN=1,2;HOM=2,CCCCCCACCCaACAACAGTCC;"
-				 ,"GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL"
-				 ,"0/0:28,0:Reference:13:28:C2[]2[]:C4:.:.:.:.:C4[34.25]24[36.67]:."
-				 ,"0/1:28,12:Somatic:13:40:A1[]1[];C1[]2[]:A6;C4:.:.:SOMATIC:12:A1[32]11[33.55];C3[31.33]25[35.04]:."
-				 ,"./.:.:.:3:.:.:.:.:.:NCIG:.:.:."
-				 ,"0/1:23,14:.:3:37:.:.:.:99:SOMATIC:.:.:349.77"});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("5BP=2", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
+    @org.junit.Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
 
-	 @Test
-	 public void realLifeMIUN() {
-		 /*
-		  * chr1	792590	.	C	A	.	.	FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT;EFF=downstream_gene_variant(MODIFIER||4458|||LINC01128|retained_intron|NON_CODING|ENST00000425657||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000416570||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000448975||1),downstream_gene_variant(MODIFIER||3584|||LINC01128|lincRNA|NON_CODING|ENST00000449005||1),non_coding_exon_variant(MODIFIER|||n.4370C>A||LINC01128|lincRNA|NON_CODING|ENST00000445118|5|1)	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:46,1:47:.:A3;C8:PASS:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.	0/1:61,7:68:C1[]2[]:A9;C3:PASS:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:62,11:73:.:.:PASS:99:SOMATIC:.:.:89.77
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","792590",".","C","A",".",".","FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT",
-				 "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
-				 "0/0:46,1:47:.:A3;C8:.:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.",
-				 "0/1:61,7:68:C1[]2[]:A9;C3:.:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.",
-				 "./.:.:.:.:.:.:.:NCIG:.:.:.",
-				 "0/1:62,11:73:.:.:.:99:SOMATIC:.:.:89.77"});
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("MIUN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void firstCallerOnly() {
-		 /*
-		  * chr1    5323163 rs7525806       C       T       .       .       BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)     GT:AD:CCC:CCM:DP:FT:GQ:INF:QL   0/1:1,2:Germline:21:3:COV;MR:37:.:35.77 ./.:.:HomozygousLoss:21:.:PASS:.:NCIG:.	./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","5323163","rs7525806","C","T",".",".","BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)","GT:AD:CCC:CCM:DP:FT:GQ:INF:QL","0/1:1,2:Germline:21:3:.:37:.:35.77","./.:.:HomozygousLoss:21:.:.:.:NCIG:.","./.:.:.:1:.:.:.:.:.","./.:.:.:1:.:.:.:.:."});
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void secondCallerOnly() {
-		 /*
-		  * chr1    5323163 rs7525806       C       T       .       .       BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)     GT:AD:CCC:CCM:DP:FT:GQ:INF:QL   ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.   0/1:1,2:Germline:21:3:COV;MR:37:.:35.77 ./.:.:HomozygousLoss:21:.:PASS:.:NCIG:.
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","5323163","rs7525806","C","T",".",".","BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)","GT:AD:CCC:CCM:DP:FT:GQ:INF:QL","./.:.:.:1:.:.:.:.:.","./.:.:.:1:.:.:.:.:.","0/1:1,2:Germline:21:3:.:37:.:35.77","./.:.:HomozygousLoss:21:.:.:.:NCIG:."});
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void compoundSnp() {
-		 /*
-		  * chr1    14221527        .       TG      CA      .       .       IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)    GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS        1/1:0,22:Germline:34:39:PASS:.:21:CA12[]10[];CG8[]9[];C_2[]0[]  1/1:0,6:Germline:34:50:PASS:.:6:CA3[]3[];CG23[]21[];_G1[]1[]    ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
-				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
-				 "1/1:0,22:Germline:34:39:.:.:21:CA12[]10[];CG8[]9[];C_2[]0[]",
-				 "1/1:0,6:Germline:34:50:.:.:6:CA3[]3[];CG23[]21[];_G1[]1[]",
-				 "./.:.:.:1:.:.:.:.:.",
-				 "./.:.:.:1:.:.:.:.:."});
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void compoundSnp2() {
-		 /*
-		  * chr1    14221527        .       TG      CA      .       .       IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)    
-		  * GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS        
-		  * 1/1:0,22:Germline:34:39:PASS:.:21:CA12[]10[];CG8[]9[];C_2[]0[]  
-		  * 1/1:0,6:Germline:34:50:PASS:.:6:CA3[]3[];CG23[]21[];_G1[]1[]    
-		  * ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
-				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
-				 "./.:.:.:1:.:.:.:.:.",
-				 "1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]",
-				 "./.:.:.:1:.:.:.:.:.",
-		 		 "./.:.:.:1:.:.:.:.:."});
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
-				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
-				 "0/0:3:.:1:.:.:.:.:TG1[]2[]",
-				 "1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]",
-				 "./.:.:.:1:.:.:.:.:.",
-		 		 "./.:.:.:1:.:.:.:.:."});
-		 cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
-				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
-				 "1/1:0,16:Germline:34:50:.:.:16:CA13[]3[];CG23[]21[];_G1[]1[]",
-		 		"./.:.:.:1:.:.:.:.:."});
-		 cm = new ConfidenceMode(SINGLE_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
-				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
-				 "1/1:0,16:Germline:34:50:.:.:16:CA13[]3[];CG23[]21[];_G1[]1[]",
-		 		  "./.:.:.:1:.:.:.:.:."});
-		 cm = new ConfidenceMode(TWO_SAMPLE_ONE_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 r = new VcfRecord(new String[]{"chr1","14221527",".","TG","CA",".",".","IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
-				 "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
-				 "./.:.:.:1:.:.:.:.:.",
-		 		"1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]"});
-		 cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 @Test
-	 public void realLifeMIN() {
-		 /*
-		  * chr1	14248	.	T	G	.	.	FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:24,1:25:T1[]0[]:G8;T42:PASS:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.	0/1:20,6:26:T2[]1[]:G11;T94:PASS:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:19,6:25:.:.:PASS:86:SOMATIC:.:.:57.77
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","14248",".","T","G",".",".","FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT",
-				 "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
-				 "0/0:24,2:26:T1[]0[]:T42:.:.:.:.:G1[41]1[10];T14[31.36]10[38.1]:.",
-				 "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
-				 "./.:.:.:.:.:.:.:NCIG:.:.:.",
-				 "0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"});
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("MIN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 /*
-		  * reduce alt coverage in control to below 3% - should change to PASS
-		  */
-		 r.setFormatFields(java.util.Arrays.asList("GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
-				 "0/0:34,1:35:T1[]0[]:T42:.:.:.:.:G1[41]0[0];T14[31.36]20[38.1]:.",
-				 "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
-				 "./.:.:.:.:.:.:.:NCIG:.:.:.",
-				 "0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 @Test
-	 public void realLifeMIN2() {
-		 /*
-		  * chr1	14248	.	T	G	.	.	FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:24,1:25:T1[]0[]:G8;T42:PASS:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.	0/1:20,6:26:T2[]1[]:G11;T94:PASS:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:19,6:25:.:.:PASS:86:SOMATIC:.:.:57.77
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","14248",".","T","G",".",".","FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT",
-				 "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
-				 "0/0:64,3:67:T1[]0[]:T42:.:.:.:.:G1[41]2[20];T14[31.36]50[38.1]:.",
-				 "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
-				 "./.:.:.:.:.:.:.:NCIG:.:.:.",
-		 		"0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"});
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("MIN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 /*
-		  * reduce alt coverage in control to below 3% - should change to PASS
-		  */
-		 r.setFormatFields(java.util.Arrays.asList(
-				 "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
-				 "0/0:64,2:67:T1[]0[]:T42:.:.:.:.:G1[41]1[20];T14[31.36]50[38.1]:.",
-				 "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
-				 "./.:.:.:.:.:.:.:NCIG:.:.:.",
-		 		"0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 @Test
-	 public void realLifeMIN3() {
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","577154",".","A","T",".",".","FLANK=GGGCATTTTCT;BaseQRankSum=-1.290;ClippingRankSum=0.000;DP=12;ExcessHet=3.0103;FS=0.000;MQ=25.90;MQRankSum=-0.765;QD=7.15;ReadPosRankSum=-0.713;SOR=0.883;IN=1,2;HOM=3,TGATGGGGCAaTTTCTGAAAA;EFF=intron_variant(MODIFIER|||n.170-33718T>A||RP5-857K21.4|lincRNA|NON_CODING|ENST00000440200|1|1)",
-				 "GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
-				 "0/0:3,2:Reference:13:5:T1[]1[]:A25;T10:.:.:.:.:A1[41]2[41];T1[37]1[37]:.",
-				 "0/1:7,6:Somatic:13:13:T1[]2[]:A50;G1;T18:.:.:SOMATIC:5:A4[32.75]3[41];T3[38.33]3[36.67]:.",
-				 "./.:.:.:3:.:.:.:.:.:NCIG:.:.:.",
-				 "0/1:7,5:.:3:12:.:.:.:99:SOMATIC:.:.:85.77"});
-		 
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("COV;MIN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("5BP=3", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 @Test
-	 public void realLifeMIN4() {
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","67978295","rs185498976","A","G",".",".","FLANK=TTACAGCCTCT;BaseQRankSum=0.391;ClippingRankSum=0.000;DP=59;ExcessHet=3.0103;FS=7.068;MQ=60.00;MQRankSum=0.000;QD=13.40;ReadPosRankSum=-0.873;SOR=0.757;IN=1,2;DB;VAF=0.005051;HOM=2,GCTCATTACAaCCTCTGCCTC;EFF=intergenic_region(MODIFIER||||||||||1)",
-				 "GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
-				 "0/0:29,1:Reference:13:30:A3[]0[]:A1:.:.:.:.:A16[33.44]13[35.31];G1[12]0[0]:.",
-				 "0/1:32,26:Somatic:13:58:A3[]0[];G0[]3[]:A2;G2:.:.:SOMATIC:25:A20[34.8]12[37.67];G11[32]15[33]:.",
-				 "./.:.:.:3:.:.:.:.:.:NCIG:.:.:.",
-				 "0/1:31,28:.:3:59:.:.:.:99:SOMATIC:.:.:790.77"});
-		 
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void newCoverageCutoffs() {
-		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr1", 4985568, 4985568), "rs10753395","A", "C");
-		 vcf.setInfo("FLANK=ACGTTCCTGCA;AC=1;AF=0.500;AN=2;BaseQRankSum=0.972;ClippingRankSum=1.139;DP=26;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=-0.472;QD=9.45;ReadPosRankSum=-0.194;SOR=0.693;IN=1,2;DB;VAF=0.4816");
-		 vcf.setFormatFields(java.util.Arrays.asList(
-				 "GT:AD:DP:FT:INF:MR:NNS", 
-				 "0/1:3,5:8:.:.:5:5",
-				 "0/1:3,5:8:.:.:5:5",
-				 "0/1:3,5:8:.:.:5:5",
-				 "0/1:3,5:8:.:.:5:5"));
-		 
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 
-		 
-		 vcf.setFormatFields(java.util.Arrays.asList(
-				 "GT:AD:DP:FT:INF:MR:NNS", 
-				 "0/1:3,5:8:.:.:5:5",
-				 "0/1:2,5:7:.:.:5:5",
-				 "0/1:3,5:8:.:.:5:5",
-				 "0/1:2,5:7:.:.:5:5"));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 vcf.setFormatFields(java.util.Arrays.asList(
-				 "GT:AD:DP:FT:INF:MR:NNS", 
-				 "0/1:2,5:7:.:.:5:5",
-				 "0/1:2,5:7:.:.:5:5",
-				 "0/1:3,5:8:.:.:5:5",
-				 "0/1:3,5:8:.:.:5:5"));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 
-		 assertEquals("COV", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void realLifeFail3() {
-		 //GL000224.1	34563	.	C	T	.	.	FLANK=TCTTTTTTTAA;BaseQRankSum=4.387;ClippingRankSum=-0.431;DP=512;FS=0.000;MQ=59.99;MQRankSum=-1.755;QD=2.17;ReadPosRankSum=1.855;SOR=0.676;IN=1,2;HOM=7,GCAATTCTTTtTTTAATGATC;EFF=upstream_gene_variant(MODIFIER||3648|||AL591856.4|miRNA|NON_CODING|ENST00000581903||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/0:.:Reference:13:240:PASS:.:.:.:.:C117[38.72]123[39.17]	0/1:.:Somatic:13:516:.:.:SOMATIC:64:60:C226[39.34]226[39.23];T33[40.76]31[40.16]	0/0:.:Reference:13:240:PASS:.:.:.:.:C117[38.72]123[39.17]	0/1:450,62:Somatic:13:512:.:99:SOMATIC:64:60:C226[39.34]226[39.23];T33[40.76]31[40.16]
-		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000224.1", 34563, 34563), ".","C", "T");
-		 vcf.setInfo("FLANK=TCTTTTTTTAA;BaseQRankSum=4.387;ClippingRankSum=-0.431;DP=512;FS=0.000;MQ=59.99;MQRankSum=-1.755;QD=2.17;ReadPosRankSum=1.855;SOR=0.676;IN=1,2;HOM=7,GCAATTCTTTtTTTAATGATC");
-		 List<String> ff =  java.util.Arrays.asList(
-				 "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
-				 "0/0:240:Reference:13:240:.:.:.:.:C117[38.72]123[39.17]	",
-				 "0/1:452,64:Somatic:13:516:.:.:SOMATIC:60:C226[39.34]226[39.23];T33[40.76]31[40.16]",
-				 "0/0:240:Reference:13:240:.:.:.:.:.",
-				 "0/1:450,62:Somatic:13:512:.:99:SOMATIC:.:.");
-		 vcf.setFormatFields(ff);
-		 ConfidenceMode cm =new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("HOM", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("HOM", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 
-		 /*
-		  * set HOM to 5, and we should be all PASSES
-		  */
-		 vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000224.1", 34563, 34563), ".","C", "T");
-		 vcf.setInfo("FLANK=TCTTTTTTTAA;BaseQRankSum=4.387;ClippingRankSum=-0.431;DP=512;FS=0.000;MQ=59.99;MQRankSum=-1.755;QD=2.17;ReadPosRankSum=1.855;SOR=0.676;IN=1,2;HOM=5,GCAATTCTTTtTTTAATGATC");
-		 ff =  java.util.Arrays.asList(
-				 "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
-				 "0/0:240:Reference:13:240:.:.:.:.:C117[38.72]123[39.17]	",
-				 "0/1:452,64:Somatic:13:516:.:.:SOMATIC:60:C226[39.34]226[39.23];T33[40.76]31[40.16]",
-				 "0/0:240:Reference:13:240:.:.:.:.:.",
-				 "0/1:450,62:Somatic:13:512:.:99:SOMATIC:.:.");
-		 vcf.setFormatFields(ff);
-		 cm =new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void realLifeFail4() {
-		 //GL000247.1	152	.	A	G	.	.	FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:27:PASS:.:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:.:Germline:23:76:SBIASALT:.:.:29:25:A43[39.23]4[41];G28[39.39]1[41]	0/1:20,7:Germline:23:27:PASS:99:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:45,20:Germline:23:65:SBIASALT:99:.:29:25:A43[39.23]4[41];G28[39.39]1[41]
-		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000247.1", 152, 152), ".","A", "G");
-		 vcf.setInfo("FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG");
-		 List<String> ff =  java.util.Arrays.asList(
-				 "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
-				 "0/1:20,7:Germline:23:27:.:.:.:7:A20[38.1]0[0];G6[40.33]1[41]",
-				 "0/1:47,29:Germline:23:76:.:.:.:25:A43[39.23]4[41];G28[39.39]1[41]",
-				 "0/1:20,7:Germline:23:27:.:99:.:.:.",
-				 "0/1:45,20:Germline:23:65:.:99:.:.:.");
+    public static final VcfFileMeta TWO_SAMPLE_TWO_CALLER_META = new VcfFileMeta(CCMModeTest.createTwoSampleTwoCallerVcf());
+    public static final VcfFileMeta TWO_SAMPLE_ONE_CALLER_META = new VcfFileMeta(CCMModeTest.createTwoSampleVcf());
+    public static final VcfFileMeta SINGLE_SAMPLE_TWO_CALLER_META = new VcfFileMeta(CCMModeTest.createSingleSampleTwoCallerVcf());
+
+    @Test
+    public void testThresholds() {
+        assertTrue(ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 9));
+        assertTrue(ConfidenceMode.allValuesAboveThreshold(new int[]{10, 9}, 9));
+        assertFalse(ConfidenceMode.allValuesAboveThreshold(new int[]{10, 9, 8}, 9));
+        assertFalse(ConfidenceMode.allValuesAboveThreshold(new int[]{8, 9, 8}, 9));
+        assertTrue(ConfidenceMode.allValuesAboveThreshold(new int[]{8, 9, 8}, 8));
+    }
+
+    @Test //gt not contain 1, should return 0
+    public void testEndsOfReadsWithGtNotContainOne() {
+
+        Map<String, int[]> oabsMap = Map.of("A", new int[]{10, 10}, "C", new int[]{0, 5});
+        String[] alts = {"A"};
+        String gt = "0/0";
+
+        int result = ConfidenceMode.endsOfReads(alts, gt, oabsMap, "A10[40]10[40];C10[40]0[0]");
+
+        assertEquals(0, result);
+    }
+
+    @Test //eor is empty, should return 0
+    public void testEndsOfReadsWithEmptyEor() {
+        String[] alts = {"A"};
+        String gt = "0/1";
+        String eor = "";
+
+        int result = ConfidenceMode.endsOfReads(alts, gt, Map.of("A", new int[]{10, 10}, "C", new int[]{0, 5}), eor);
+
+        assertEquals(0, result);
+    }
+
+    @Test //alt not found in oabsMap, should return 0
+    public void testEndsOfReadsWithAltNotFound() {
+        String[] alts = {"A"};
+        String gt = "0/1";
+
+        int result = ConfidenceMode.endsOfReads(alts, gt, Map.of("A", new int[]{10, 10}, "C", new int[]{0, 5}), "C10[40]10[40];G10[40]0[0]");
+
+        assertEquals(0, result);
+    }
+
+    @Test //middleOfReadCount is less than 5, should return max endOfReadCount
+    public void testEndsOfReadsWithMiddleOfReadCountLessThanFive() {
+        String[] alts = {"A"};
+        String gt = "1/1";
+
+        int result = ConfidenceMode.endsOfReads(alts, gt, Map.of("alt1", new int[]{10, 10}, "alt2", new int[]{0, 5}), "A10[40]10[40];C10[40]0[0]");
+
+        // Assuming max endOfReadCount will be 20
+        assertEquals(20, result);
+    }
+
+    @Test
+    public void testCheckNNS() {
+
+        // Test 1: All NNS above threshold
+        StringBuilder sb1 = new StringBuilder();
+        ConfidenceMode.checkNNS("3,5", sb1, 1);
+        assertEquals("", sb1.toString());
+
+        // Test 2: Some NNS not above threshold
+        StringBuilder sb2 = new StringBuilder();
+        ConfidenceMode.checkNNS("2,1", sb2, 3);
+        assertEquals(VcfHeaderUtils.FILTER_NOVEL_STARTS, sb2.toString());
+
+        // Test 3: All NNS equal to threshold
+        StringBuilder sb3 = new StringBuilder();
+        ConfidenceMode.checkNNS("2,2", sb3, 2);
+        assertEquals("", sb3.toString());
+
+        // Test 4: Null or empty string
+        StringBuilder sb4 = new StringBuilder();
+        ConfidenceMode.checkNNS("", sb4, 1);
+        assertEquals(VcfHeaderUtils.FILTER_NOVEL_STARTS, sb4.toString());
+
+        // Test 5: Some NNS are equals to threshold and some below threshold
+        StringBuilder sb5 = new StringBuilder();
+        ConfidenceMode.checkNNS("4,2", sb5, 3);
+        assertEquals(VcfHeaderUtils.FILTER_NOVEL_STARTS, sb5.toString());
+    }
+
+    @Test
+    public void testCheckStrandBiasWhenBothStrandsRepresented() {
+        ConfidenceMode subject = new ConfidenceMode();
+
+        Map<String, int[]> alleleDist = new HashMap<>();
+        alleleDist.put("A", new int[]{10, 10});
+
+        int[] gts = new int[]{1};
+        StringBuilder failedFilterStringBuilder = new StringBuilder();
+        int sBiasCovPercentage = 5;
+        int sBiasAltPercentage = 5;
+
+        ConfidenceMode.checkStrandBias(
+                new String[]{"A"}, failedFilterStringBuilder, alleleDist, gts,
+                sBiasCovPercentage, sBiasAltPercentage
+        );
+
+        assertEquals("", failedFilterStringBuilder.toString());
+
+        alleleDist.put("A", new int[]{10, 0});
+        failedFilterStringBuilder = new StringBuilder();
+        ConfidenceMode.checkStrandBias(
+                new String[]{"A"}, failedFilterStringBuilder, alleleDist, gts,
+                sBiasCovPercentage, sBiasAltPercentage
+        );
+        assertEquals("SBIASCOV", failedFilterStringBuilder.toString());
+
+        alleleDist.put("A", new int[]{0, 10});
+        failedFilterStringBuilder = new StringBuilder();
+        ConfidenceMode.checkStrandBias(
+                new String[]{"A"}, failedFilterStringBuilder, alleleDist, gts,
+                sBiasCovPercentage, sBiasAltPercentage
+        );
+        assertEquals("SBIASCOV", failedFilterStringBuilder.toString());
+    }
+
+    @Test
+    public void testThresholdsPercentage() {
+        assertTrue(ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 100, 9f));
+        assertTrue(ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 100, 10f));
+        assertFalse(ConfidenceMode.allValuesAboveThreshold(new int[]{10}, 100, 10.1f));
+        assertTrue(ConfidenceMode.allValuesAboveThreshold(new int[]{10, 11, 23}, 100, 10.0f));
+        assertFalse(ConfidenceMode.allValuesAboveThreshold(new int[]{10, 11, 23}, 100, 20.1f));
+    }
+
+    @Test
+    public void getFieldofInts() {
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getFieldOfInts(null));
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getFieldOfInts(""));
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getFieldOfInts("."));
+        assertArrayEquals(new int[]{1}, ConfidenceMode.getFieldOfInts("1"));
+        assertArrayEquals(new int[]{10}, ConfidenceMode.getFieldOfInts("10"));
+        assertArrayEquals(new int[]{10}, ConfidenceMode.getFieldOfInts("010"));
+        assertArrayEquals(new int[]{10, 0}, ConfidenceMode.getFieldOfInts("010,0"));
+        assertArrayEquals(new int[]{10, 1}, ConfidenceMode.getFieldOfInts("010,001"));
+    }
+
+    @Test
+    public void getADs() {
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField(null));
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField(""));
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField("."));
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField("A"));
+        assertArrayEquals(new int[]{0}, ConfidenceMode.getAltCoveragesFromADField("1234"));
+        assertArrayEquals(new int[]{2}, ConfidenceMode.getAltCoveragesFromADField("1,2"));
+        assertArrayEquals(new int[]{20}, ConfidenceMode.getAltCoveragesFromADField("1,20"));
+        assertArrayEquals(new int[]{20}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20"));
+        assertArrayEquals(new int[]{20, 1}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20,1"));
+        assertArrayEquals(new int[]{20, 1, 3}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20,1,3"));
+        assertArrayEquals(new int[]{20, 1, 3, 5}, ConfidenceMode.getAltCoveragesFromADField("XYZ,20,1,3,5"));
+        assertArrayEquals(new int[]{20, 1, 3, 5}, ConfidenceMode.getAltCoveragesFromADField("100,20,1,3,5"));
+    }
+
+    @Test
+    public void checkMin() {
+        StringBuilder sb = null;
+        ConfidenceMode.checkMIN(null, -1, null, sb, -1, -1f);
+        assertNull(sb);
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIN(null, -1, null, sb, -1, -1f);
+        assertEquals("", sb.toString());
+        Map<String, int[]> alleleDist = new HashMap<>();
+        alleleDist.put("A", new int[]{10, 10});
+        ConfidenceMode.checkMIN(new String[]{"A"}, 20, alleleDist, sb, 1, 5f);
+        assertEquals("MIN", sb.toString());
+
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIN(new String[]{"A"}, 2000, alleleDist, sb, Integer.MAX_VALUE, 5f);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIN(new String[]{"A"}, 2000, alleleDist, sb, 21, 5f);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIN(new String[]{"A"}, 2000, alleleDist, sb, 20, 5f);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIN(new String[]{"A"}, 200, alleleDist, sb, 2, 3f);
+        assertEquals("MIN", sb.toString());
+
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIN(new String[]{"C"}, 2000, alleleDist, sb, 20, 5f);
+        assertEquals("", sb.toString());
+    }
+
+    @Test
+    public void minForCompoundSnps() {
+
+        StringBuilder sb = new StringBuilder();
+        Map<String, int[]> alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40]");
+        ConfidenceMode.checkMIN(new String[]{"AA"}, 20, alleleDist, sb, 1, 5f);
+        assertEquals("MIN", sb.toString());
+
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIN(new String[]{"AC"}, 20, alleleDist, sb, 1, 5f);
+        assertEquals("", sb.toString());
+
+        sb = new StringBuilder();
+        alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]0[0]");
+        ConfidenceMode.checkMIN(new String[]{"AC"}, 21, alleleDist, sb, 1, 5f);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIN(new String[]{"AC"}, 21, alleleDist, sb, 2, 3f);
+        assertEquals("", sb.toString());
+        alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]1[10]");
+        ConfidenceMode.checkMIN(new String[]{"AC"}, 21, alleleDist, sb, 2, 3f);
+        assertEquals("MIN", sb.toString());
+
+        sb = new StringBuilder();
+        alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]0[0]");
+        ConfidenceMode.checkMIN(new String[]{"AC"}, 21, alleleDist, sb, 2, 5f);
+        assertEquals("", sb.toString());
+
+        sb = new StringBuilder();
+        alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA10[40]10[40];AC1[40]10[40]");
+        ConfidenceMode.checkMIN(new String[]{"AC"}, 32, alleleDist, sb, 2, 5f);
+        assertEquals("MIN", sb.toString());
+
+        sb = new StringBuilder();
+        alleleDist = VcfUtils.getAllelicCoverageWithStrand("AA100[40]10[40];AC1[40]10[40]");
+        ConfidenceMode.checkMIN(new String[]{"AC"}, 122, alleleDist, sb, 2, 10f);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIN(new String[]{"AA"}, 122, alleleDist, sb, 2, 10f);
+        assertEquals("MIN", sb.toString());
+
+    }
+
+    @Test
+    public void checkMIUN() {
+        StringBuilder sb = null;
+        ConfidenceMode.checkMIUN(null, 0, null, sb, -1, 3);
+        assertNull(sb);
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"A"}, 0, "", sb, -1, 3);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIUN(new String[]{"A"}, 0, "C1", sb, 1, 3);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIUN(new String[]{"A"}, 0, "C1;G2;T3", sb, 1, 3);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIUN(new String[]{"A", "C"}, 0, "C1;G2;T3", sb, 2, 3);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIUN(new String[]{"A", "C", "G"}, 93, "C1;G2;T3", sb, 2, 3);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIUN(new String[]{"A", "C", "G", "T"}, 93, "C1;G2;T3", sb, 2, 3);
+        assertEquals("MIUN", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"A", "C", "G"}, 94, "C1;G2;T3", sb, 2, 3);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIUN(new String[]{"A", "C", "T"}, 0, "C1;G2;T3", sb, 3, 3);
+        assertEquals("MIUN", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"A", "C", "T"}, 100, "C1;G2;T3", sb, 3, 3);
+        assertEquals("", sb.toString());
+        ConfidenceMode.checkMIUN(new String[]{"C"}, 0, "C1;G2;T3", sb, 1, 3);
+        assertEquals("MIUN", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"G"}, 0, "C1;G2;T3", sb, 2, 3);
+        assertEquals("MIUN", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"T"}, 0, "C1;G2;T3", sb, 3, 3);
+        assertEquals("MIUN", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"T"}, 0, "C1;G2;T3", sb, 4, 3);
+        assertEquals("", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"A"}, 0, "A3;C8", sb, 2, 3);
+        assertEquals("MIUN", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkMIUN(new String[]{"A"}, 90, "A3;C8", sb, 2, 3);
+        assertEquals("", sb.toString());
+    }
+
+    @Test
+    public void testHOM() {
+        StringBuilder sb = null;
+        ConfidenceMode.checkHOM(sb, -1, -1);
+        assertNull(sb);
+        sb = new StringBuilder();
+        ConfidenceMode.checkHOM(sb, -1, -1);
+        assertEquals("", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkHOM(sb, 1, 0);
+        assertEquals("HOM", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkHOM(sb, 1, 1);
+        assertEquals("HOM", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkHOM(sb, 1, 2);
+        assertEquals("", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkHOM(sb, 2, 2);
+        assertEquals("HOM", sb.toString());
+        sb = new StringBuilder();
+        ConfidenceMode.checkHOM(sb, 3, 2);
+        assertEquals("HOM", sb.toString());
+    }
+
+    @Test
+    public void endOfReads() {
+        /*
+         * chr2    31044381        .       C       A       .       .       FLANK=CACCCAACAAC;BaseQRankSum=-1.769;ClippingRankSum=0.078;DP=38;FS=0.000;MQ=59.43;MQRankSum=-0.078;QD=9.20;ReadPosRankSum=-0.204;SOR=0.315;IN=1,2;HOM=2,CCCCCCACCCaACAACAGTCC GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL   0/0:28,0:Reference:13:28:C2[]2[]:C4:PASS:.:.:.:C4[34.25]24[36.67]:.     0/1:28,12:Somatic:13:40:A1[]1[];C1[]2[]:A6;C4:PASS:.:SOMATIC:12:A1[32]11[33.55];C3[31.33]25[35.04]:.    ./.:.:.:3:.:.:.:PASS:.:NCIG:.:.:.       0/1:23,14:.:3:37:.:.:PASS:99:SOMATIC:.:.:349.77
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr2", "31044381", ".", "C", "A", ".", ".", "FLANK=CACCCAACAAC;BaseQRankSum=-1.769;ClippingRankSum=0.078;DP=38;FS=0.000;MQ=59.43;MQRankSum=-0.078;QD=9.20;ReadPosRankSum=-0.204;SOR=0.315;IN=1,2;HOM=2,CCCCCCACCCaACAACAGTCC;"
+                , "GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL"
+                , "0/0:28,0:Reference:13:28:C2[]2[]:C4:.:.:.:.:C4[34.25]24[36.67]:."
+                , "0/1:28,12:Somatic:13:40:A1[]1[];C1[]2[]:A6;C4:.:.:SOMATIC:12:A1[32]11[33.55];C3[31.33]25[35.04]:."
+                , "./.:.:.:3:.:.:.:.:.:NCIG:.:.:."
+                , "0/1:23,14:.:3:37:.:.:.:99:SOMATIC:.:.:349.77"});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("5BP=2", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeMIUN() {
+        /*
+         * chr1	792590	.	C	A	.	.	FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT;EFF=downstream_gene_variant(MODIFIER||4458|||LINC01128|retained_intron|NON_CODING|ENST00000425657||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000416570||1),downstream_gene_variant(MODIFIER||4444|||LINC01128|lincRNA|NON_CODING|ENST00000448975||1),downstream_gene_variant(MODIFIER||3584|||LINC01128|lincRNA|NON_CODING|ENST00000449005||1),non_coding_exon_variant(MODIFIER|||n.4370C>A||LINC01128|lincRNA|NON_CODING|ENST00000445118|5|1)	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:46,1:47:.:A3;C8:PASS:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.	0/1:61,7:68:C1[]2[]:A9;C3:PASS:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:62,11:73:.:.:PASS:99:SOMATIC:.:.:89.77
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "792590", ".", "C", "A", ".", ".", "FLANK=AATTTATTCCC;BaseQRankSum=-1.455;ClippingRankSum=0.000;DP=73;ExcessHet=3.0103;FS=1.318;MQ=55.96;MQRankSum=-6.174;QD=1.23;ReadPosRankSum=1.813;SOR=0.953;IN=1,2;GERM=A:9:0:9:0;HOM=0,TTGATAATTTaTTCCCATTCT",
+                "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+                "0/0:46,1:47:.:A3;C8:.:.:.:.:A1[37]0[0];C26[39.62]20[40.15]:.",
+                "0/1:61,7:68:C1[]2[]:A9;C3:.:.:SOMATIC:6:A6[37.83]1[41];C40[40.17]21[37.86]:.",
+                "./.:.:.:.:.:.:.:NCIG:.:.:.",
+                "0/1:62,11:73:.:.:.:99:SOMATIC:.:.:89.77"});
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("MIUN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void firstCallerOnly() {
+        /*
+         * chr1    5323163 rs7525806       C       T       .       .       BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)     GT:AD:CCC:CCM:DP:FT:GQ:INF:QL   0/1:1,2:Germline:21:3:COV;MR:37:.:35.77 ./.:.:HomozygousLoss:21:.:PASS:.:NCIG:.	./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "5323163", "rs7525806", "C", "T", ".", ".", "BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)", "GT:AD:CCC:CCM:DP:FT:GQ:INF:QL", "0/1:1,2:Germline:21:3:.:37:.:35.77", "./.:.:HomozygousLoss:21:.:.:.:NCIG:.", "./.:.:.:1:.:.:.:.:.", "./.:.:.:1:.:.:.:.:."});
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void secondCallerOnly() {
+        /*
+         * chr1    5323163 rs7525806       C       T       .       .       BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)     GT:AD:CCC:CCM:DP:FT:GQ:INF:QL   ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.   0/1:1,2:Germline:21:3:COV;MR:37:.:35.77 ./.:.:HomozygousLoss:21:.:PASS:.:NCIG:.
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "5323163", "rs7525806", "C", "T", ".", ".", "BaseQRankSum=-0.967;ClippingRankSum=0.000;DP=3;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=11.92;ReadPosRankSum=-0.431;SOR=1.179;IN=2;DB;VLD;VAF=0.2567;GERM=T:8:157:165:0;HOM=3,TGGCACTATGcTTTGCATAGA;EFF=intergenic_region(MODIFIER||||||||||1)", "GT:AD:CCC:CCM:DP:FT:GQ:INF:QL", "./.:.:.:1:.:.:.:.:.", "./.:.:.:1:.:.:.:.:.", "0/1:1,2:Germline:21:3:.:37:.:35.77", "./.:.:HomozygousLoss:21:.:.:.:NCIG:."});
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void compoundSnp() {
+        /*
+         * chr1    14221527        .       TG      CA      .       .       IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)    GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS        1/1:0,22:Germline:34:39:PASS:.:21:CA12[]10[];CG8[]9[];C_2[]0[]  1/1:0,6:Germline:34:50:PASS:.:6:CA3[]3[];CG23[]21[];_G1[]1[]    ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "14221527", ".", "TG", "CA", ".", ".", "IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+                "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+                "1/1:0,22:Germline:34:39:.:.:21:CA12[]10[];CG8[]9[];C_2[]0[]",
+                "1/1:0,6:Germline:34:50:.:.:6:CA3[]3[];CG23[]21[];_G1[]1[]",
+                "./.:.:.:1:.:.:.:.:.",
+                "./.:.:.:1:.:.:.:.:."});
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void compoundSnp2() {
+        /*
+         * chr1    14221527        .       TG      CA      .       .       IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)
+         * GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS
+         * 1/1:0,22:Germline:34:39:PASS:.:21:CA12[]10[];CG8[]9[];C_2[]0[]
+         * 1/1:0,6:Germline:34:50:PASS:.:6:CA3[]3[];CG23[]21[];_G1[]1[]
+         * ./.:.:.:1:.:COV:.:.:.   ./.:.:.:1:.:COV:.:.:.
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "14221527", ".", "TG", "CA", ".", ".", "IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+                "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+                "./.:.:.:1:.:.:.:.:.",
+                "1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]",
+                "./.:.:.:1:.:.:.:.:.",
+                "./.:.:.:1:.:.:.:.:."});
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        r = new VcfRecord(new String[]{"chr1", "14221527", ".", "TG", "CA", ".", ".", "IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+                "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+                "0/0:3:.:1:.:.:.:.:TG1[]2[]",
+                "1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]",
+                "./.:.:.:1:.:.:.:.:.",
+                "./.:.:.:1:.:.:.:.:."});
+        cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        r = new VcfRecord(new String[]{"chr1", "14221527", ".", "TG", "CA", ".", ".", "IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+                "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+                "1/1:0,16:Germline:34:50:.:.:16:CA13[]3[];CG23[]21[];_G1[]1[]",
+                "./.:.:.:1:.:.:.:.:."});
+        cm = new ConfidenceMode(SINGLE_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        r = new VcfRecord(new String[]{"chr1", "14221527", ".", "TG", "CA", ".", ".", "IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+                "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+                "1/1:0,16:Germline:34:50:.:.:16:CA13[]3[];CG23[]21[];_G1[]1[]",
+                "./.:.:.:1:.:.:.:.:."});
+        cm = new ConfidenceMode(TWO_SAMPLE_ONE_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        r = new VcfRecord(new String[]{"chr1", "14221527", ".", "TG", "CA", ".", ".", "IN=1;HOM=2,TGTAAAACGGtgCTACTAGGCA;EFF=intergenic_region(MODIFIER||||||||||1)",
+                "GT:AD:CCC:CCM:DP:FT:INF:NNS:OABS",
+                "./.:.:.:1:.:.:.:.:.",
+                "1/1:0,6:Germline:34:50:.:SOMATIC:6:CA3[]3[];CG23[]21[];_G1[]1[]"});
+        cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("COV", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeMIN() {
+        /*
+         * chr1	14248	.	T	G	.	.	FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:24,1:25:T1[]0[]:G8;T42:PASS:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.	0/1:20,6:26:T2[]1[]:G11;T94:PASS:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:19,6:25:.:.:PASS:86:SOMATIC:.:.:57.77
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "14248", ".", "T", "G", ".", ".", "FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT",
+                "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+                "0/0:24,2:26:T1[]0[]:T42:.:.:.:.:G1[41]1[10];T14[31.36]10[38.1]:.",
+                "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
+                "./.:.:.:.:.:.:.:NCIG:.:.:.",
+                "0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"});
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("MIN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        /*
+         * reduce alt coverage in control to below 3% - should change to PASS
+         */
+        r.setFormatFields(java.util.Arrays.asList("GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+                "0/0:34,1:35:T1[]0[]:T42:.:.:.:.:G1[41]0[0];T14[31.36]20[38.1]:.",
+                "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
+                "./.:.:.:.:.:.:.:NCIG:.:.:.",
+                "0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeMIN2() {
+        /*
+         * chr1	14248	.	T	G	.	.	FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	0/0:24,1:25:T1[]0[]:G8;T42:PASS:.:.:.:G1[41]0[0];T14[31.36]10[38.1]:.	0/1:20,6:26:T2[]1[]:G11;T94:PASS:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.	./.:.:.:.:.:PASS:.:NCIG:.:.:.	0/1:19,6:25:.:.:PASS:86:SOMATIC:.:.:57.77
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "14248", ".", "T", "G", ".", ".", "FLANK=CTGACGGCCCT;BaseQRankSum=-0.422;ClippingRankSum=0.000;DP=25;ExcessHet=3.0103;FS=1.906;MQ=26.71;MQRankSum=1.263;QD=2.31;ReadPosRankSum=0.769;SOR=1.282;IN=1,2;GERM=G:205:9:214:0;HOM=2,CCCTGCTGACgGCCCTTCTCT",
+                "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+                "0/0:64,3:67:T1[]0[]:T42:.:.:.:.:G1[41]2[20];T14[31.36]50[38.1]:.",
+                "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
+                "./.:.:.:.:.:.:.:NCIG:.:.:.",
+                "0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"});
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("MIN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        /*
+         * reduce alt coverage in control to below 3% - should change to PASS
+         */
+        r.setFormatFields(java.util.Arrays.asList(
+                "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+                "0/0:64,2:67:T1[]0[]:T42:.:.:.:.:G1[41]1[20];T14[31.36]50[38.1]:.",
+                "0/1:20,6:26:T2[]1[]:G11;T94:.:.:SOMATIC:6:G4[35.25]2[26.5];T11[39.09]9[37.56]:.",
+                "./.:.:.:.:.:.:.:NCIG:.:.:.",
+                "0/1:19,6:25:.:.:.:86:SOMATIC:.:.:57.77"));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeMIN3() {
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "577154", ".", "A", "T", ".", ".", "FLANK=GGGCATTTTCT;BaseQRankSum=-1.290;ClippingRankSum=0.000;DP=12;ExcessHet=3.0103;FS=0.000;MQ=25.90;MQRankSum=-0.765;QD=7.15;ReadPosRankSum=-0.713;SOR=0.883;IN=1,2;HOM=3,TGATGGGGCAaTTTCTGAAAA;EFF=intron_variant(MODIFIER|||n.170-33718T>A||RP5-857K21.4|lincRNA|NON_CODING|ENST00000440200|1|1)",
+                "GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+                "0/0:3,2:Reference:13:5:T1[]1[]:A25;T10:.:.:.:.:A1[41]2[41];T1[37]1[37]:.",
+                "0/1:7,6:Somatic:13:13:T1[]2[]:A50;G1;T18:.:.:SOMATIC:5:A4[32.75]3[41];T3[38.33]3[36.67]:.",
+                "./.:.:.:3:.:.:.:.:.:NCIG:.:.:.",
+                "0/1:7,5:.:3:12:.:.:.:99:SOMATIC:.:.:85.77"});
+
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("COV;MIN", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("5BP=3", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeMIN4() {
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "67978295", "rs185498976", "A", "G", ".", ".", "FLANK=TTACAGCCTCT;BaseQRankSum=0.391;ClippingRankSum=0.000;DP=59;ExcessHet=3.0103;FS=7.068;MQ=60.00;MQRankSum=0.000;QD=13.40;ReadPosRankSum=-0.873;SOR=0.757;IN=1,2;DB;VAF=0.005051;HOM=2,GCTCATTACAaCCTCTGCCTC;EFF=intergenic_region(MODIFIER||||||||||1)",
+                "GT:AD:CCC:CCM:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL",
+                "0/0:29,1:Reference:13:30:A3[]0[]:A1:.:.:.:.:A16[33.44]13[35.31];G1[12]0[0]:.",
+                "0/1:32,26:Somatic:13:58:A3[]0[];G0[]3[]:A2;G2:.:.:SOMATIC:25:A20[34.8]12[37.67];G11[32]15[33]:.",
+                "./.:.:.:3:.:.:.:.:.:NCIG:.:.:.",
+                "0/1:31,28:.:3:59:.:.:.:99:SOMATIC:.:.:790.77"});
+
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void newCoverageCutoffs() {
+        VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr1", 4985568, 4985568), "rs10753395", "A", "C");
+        vcf.setInfo("FLANK=ACGTTCCTGCA;AC=1;AF=0.500;AN=2;BaseQRankSum=0.972;ClippingRankSum=1.139;DP=26;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=-0.472;QD=9.45;ReadPosRankSum=-0.194;SOR=0.693;IN=1,2;DB;VAF=0.4816");
+        vcf.setFormatFields(java.util.Arrays.asList(
+                "GT:AD:DP:FT:INF:MR:NNS",
+                "0/1:3,5:8:.:.:5:5",
+                "0/1:3,5:8:.:.:5:5",
+                "0/1:3,5:8:.:.:5:5",
+                "0/1:3,5:8:.:.:5:5"));
+
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+
+        vcf.setFormatFields(java.util.Arrays.asList(
+                "GT:AD:DP:FT:INF:MR:NNS",
+                "0/1:3,5:8:.:.:5:5",
+                "0/1:2,5:7:.:.:5:5",
+                "0/1:3,5:8:.:.:5:5",
+                "0/1:2,5:7:.:.:5:5"));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        vcf.setFormatFields(java.util.Arrays.asList(
+                "GT:AD:DP:FT:INF:MR:NNS",
+                "0/1:2,5:7:.:.:5:5",
+                "0/1:2,5:7:.:.:5:5",
+                "0/1:3,5:8:.:.:5:5",
+                "0/1:3,5:8:.:.:5:5"));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+
+        assertEquals("COV", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeFail3() {
+        //GL000224.1	34563	.	C	T	.	.	FLANK=TCTTTTTTTAA;BaseQRankSum=4.387;ClippingRankSum=-0.431;DP=512;FS=0.000;MQ=59.99;MQRankSum=-1.755;QD=2.17;ReadPosRankSum=1.855;SOR=0.676;IN=1,2;HOM=7,GCAATTCTTTtTTTAATGATC;EFF=upstream_gene_variant(MODIFIER||3648|||AL591856.4|miRNA|NON_CODING|ENST00000581903||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/0:.:Reference:13:240:PASS:.:.:.:.:C117[38.72]123[39.17]	0/1:.:Somatic:13:516:.:.:SOMATIC:64:60:C226[39.34]226[39.23];T33[40.76]31[40.16]	0/0:.:Reference:13:240:PASS:.:.:.:.:C117[38.72]123[39.17]	0/1:450,62:Somatic:13:512:.:99:SOMATIC:64:60:C226[39.34]226[39.23];T33[40.76]31[40.16]
+        VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000224.1", 34563, 34563), ".", "C", "T");
+        vcf.setInfo("FLANK=TCTTTTTTTAA;BaseQRankSum=4.387;ClippingRankSum=-0.431;DP=512;FS=0.000;MQ=59.99;MQRankSum=-1.755;QD=2.17;ReadPosRankSum=1.855;SOR=0.676;IN=1,2;HOM=7,GCAATTCTTTtTTTAATGATC");
+        List<String> ff = java.util.Arrays.asList(
+                "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
+                "0/0:240:Reference:13:240:.:.:.:.:C117[38.72]123[39.17]	",
+                "0/1:452,64:Somatic:13:516:.:.:SOMATIC:60:C226[39.34]226[39.23];T33[40.76]31[40.16]",
+                "0/0:240:Reference:13:240:.:.:.:.:.",
+                "0/1:450,62:Somatic:13:512:.:99:SOMATIC:.:.");
+        vcf.setFormatFields(ff);
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("HOM", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("HOM", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+
+        /*
+         * set HOM to 5, and we should be all PASSES
+         */
+        vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000224.1", 34563, 34563), ".", "C", "T");
+        vcf.setInfo("FLANK=TCTTTTTTTAA;BaseQRankSum=4.387;ClippingRankSum=-0.431;DP=512;FS=0.000;MQ=59.99;MQRankSum=-1.755;QD=2.17;ReadPosRankSum=1.855;SOR=0.676;IN=1,2;HOM=5,GCAATTCTTTtTTTAATGATC");
+        ff = java.util.Arrays.asList(
+                "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
+                "0/0:240:Reference:13:240:.:.:.:.:C117[38.72]123[39.17]	",
+                "0/1:452,64:Somatic:13:516:.:.:SOMATIC:60:C226[39.34]226[39.23];T33[40.76]31[40.16]",
+                "0/0:240:Reference:13:240:.:.:.:.:.",
+                "0/1:450,62:Somatic:13:512:.:99:SOMATIC:.:.");
+        vcf.setFormatFields(ff);
+        cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeFail4() {
+        //GL000247.1	152	.	A	G	.	.	FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:27:PASS:.:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:.:Germline:23:76:SBIASALT:.:.:29:25:A43[39.23]4[41];G28[39.39]1[41]	0/1:20,7:Germline:23:27:PASS:99:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:45,20:Germline:23:65:SBIASALT:99:.:29:25:A43[39.23]4[41];G28[39.39]1[41]
+        VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000247.1", 152, 152), ".", "A", "G");
+        vcf.setInfo("FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG");
+        List<String> ff = java.util.Arrays.asList(
+                "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
+                "0/1:20,7:Germline:23:27:.:.:.:7:A20[38.1]0[0];G6[40.33]1[41]",
+                "0/1:47,29:Germline:23:76:.:.:.:25:A43[39.23]4[41];G28[39.39]1[41]",
+                "0/1:20,7:Germline:23:27:.:99:.:.:.",
+                "0/1:45,20:Germline:23:65:.:99:.:.:.");
 //		 "0/1:20,7:Germline:23:27:.:99:.:7:7:A20[38.1]0[0];G6[40.33]1[41]",
 //		 "0/1:45,20:Germline:23:65:.:99:.:29:25:A43[39.23]4[41];G28[39.39]1[41]");
-		 vcf.setFormatFields(ff);
-		 ConfidenceMode cm =new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("SBIASALT", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 @Test
-	 public void realLifeFail5() {
-		 //GL000247.1	152	.	A	G	.	.	FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:27:PASS:.:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:.:Germline:23:76:SBIASALT:.:.:29:25:A43[39.23]4[41];G28[39.39]1[41]	0/1:20,7:Germline:23:27:PASS:99:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:45,20:Germline:23:65:SBIASALT:99:.:29:25:A43[39.23]4[41];G28[39.39]1[41]
-		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000247.1", 152, 152), ".","A", "G");
-		 vcf.setInfo("FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG");
-		 List<String> ff =  java.util.Arrays.asList(
-				 "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
-				 "0/1:20,7:Germline:23:27:.:.:.:7:A20[38.1]0[0];G6[40.33]1[41]",
-				 "0/1:47,29:Germline:23:76:.:.:.:25:A43[39.23]4[41];G28[39.39]1[41]",
-				 "0/1:20,4:Germline:23:27:.:99:.:.:.",
-				 "0/1:45,20:Germline:23:65:.:99:.:.:.");
+        vcf.setFormatFields(ff);
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("SBIASALT", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeFail5() {
+        //GL000247.1	152	.	A	G	.	.	FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:27:PASS:.:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:.:Germline:23:76:SBIASALT:.:.:29:25:A43[39.23]4[41];G28[39.39]1[41]	0/1:20,7:Germline:23:27:PASS:99:.:7:7:A20[38.1]0[0];G6[40.33]1[41]	0/1:45,20:Germline:23:65:SBIASALT:99:.:29:25:A43[39.23]4[41];G28[39.39]1[41]
+        VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("GL000247.1", 152, 152), ".", "A", "G");
+        vcf.setInfo("FLANK=TGTAAGTTGTT;BaseQRankSum=0.083;ClippingRankSum=0.360;DP=27;FS=5.863;MQ=49.73;MQRankSum=-3.458;QD=3.44;ReadPosRankSum=0.415;SOR=0.027;IN=1,2;HOM=0,GTGAGTGTAAgTTGTTTCCAG");
+        List<String> ff = java.util.Arrays.asList(
+                "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
+                "0/1:20,7:Germline:23:27:.:.:.:7:A20[38.1]0[0];G6[40.33]1[41]",
+                "0/1:47,29:Germline:23:76:.:.:.:25:A43[39.23]4[41];G28[39.39]1[41]",
+                "0/1:20,4:Germline:23:27:.:99:.:.:.",
+                "0/1:45,20:Germline:23:65:.:99:.:.:.");
 //		 "0/1:20,7:Germline:23:27:.:99:.:7:7:A20[38.1]0[0];G6[40.33]1[41]",
 //		 "0/1:45,20:Germline:23:65:.:99:.:29:25:A43[39.23]4[41];G28[39.39]1[41]");
-		 vcf.setFormatFields(ff);
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("SBIASALT", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("MR", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void realLifeFail() {
-		 //chr1    4985568 rs10753395      A       C       .       PASS_1;PASS_2   FLANK=ACGTTCCTGCA;AC=1;AF=0.500;AN=2;BaseQRankSum=0.972;ClippingRankSum=1.139;DP=26;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=-0.472;QD=9.45;ReadPosRankSum=-0.194;SOR=0.693;IN=1,2;DB;VAF=0.4816   GT:GD:AC:MR:NNS:AD:DP:GQ:PL     0/1:A/C:A8[33.75],11[38.82],C3[42],5[40],A9[33.56],11[38.82],C3[42],5[40],G0[0],1[22],T1[11],0[0]:8:8:18,8:26:99:274,0,686      1/1:C/C:A1[37],0[0],C23[38.96],19[41.21],A1[37],0[0],C24[38.88],23[40.26]:42,47:38,42:1,44:45:94:1826,94,0
-		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr1", 4985568, 4985568), "rs10753395","A", "C");
-		 vcf.setFilter("PASS_1;PASS_2");
-		 vcf.setInfo("FLANK=ACGTTCCTGCA;AC=1;AF=0.500;AN=2;BaseQRankSum=0.972;ClippingRankSum=1.139;DP=26;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=-0.472;QD=9.45;ReadPosRankSum=-0.194;SOR=0.693;IN=1,2;DB;VAF=0.4816");
-		 List<String> ff =  java.util.Arrays.asList("GT:GD:AC:MR:NNS:AD:DP:GQ:PL", "0/1:A/C:A8[33.75],11[38.82],C3[42],5[40]:8:8:18:26:99:274,0,686","0/1:A/C:A9[33.56],11[38.82],C3[42],5[40],G0[0],1[22],T1[11],0[0]:8:8:8:26:99:274,0,686", "1/1:C/C:A1[37],0[0],C23[38.96],19[41.21]:42:38:1,44:45:94:1826,94,0", "1/1:C/C:A1[37],0[0],C24[38.88],23[40.26]:47:42:1,44:45:94:1826,94,0");
-		 vcf.setFormatFields(ff);
-		 assertEquals(8, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(1), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
-		 assertEquals(8, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(2), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
-		 assertEquals(38, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(3), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
-		 assertEquals(42, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(4), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
-	 }
-	 
-	 @Test
-	 public void realLifeFail2() {
-		 //chr1	73551390	rs12142252	T	C	.	.	FLANK=ATCAACGGTCT;BaseQRankSum=-1.162;ClippingRankSum=1.214;DP=54;FS=0.000;MQ=60.00;MQRankSum=0.330;QD=17.29;ReadPosRankSum=0.590;SOR=0.596;IN=1,2;DB;VLD;VAF=0.3462;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:22:36:PASS:.:.:7:6:C3[41]4[38.75];T17[40.29]12[35.58]	0/0:.:LOH:22:63:PASS:.:.:.:.:C1[37]1[41];T31[39.03]30[38.87]	0/1:29,25:Germline:23:54:PASS:99:.:7:6:C3[41]4[38.75];T17[40.29]12[35.58]	0/1:61,8:Germline:23:69:.:99:.:2:2:C1[37]1[41];T31[39.03]30[38.87]
-		 VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr1", 73551390, 73551390), "rs12142252","T", "C");
-		 vcf.setInfo("FLANK=ATCAACGGTCT;BaseQRankSum=-1.162;ClippingRankSum=1.214;DP=54;FS=0.000;MQ=60.00;MQRankSum=0.330;QD=17.29;ReadPosRankSum=0.590;SOR=0.596;IN=1,2;DB;VLD;VAF=0.3462;EFF=intergenic_region(MODIFIER||||||||||1)");
-		 List<String> ff =  java.util.Arrays.asList(
-				 "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
-				 "0/1:29,7:Germline:22:36:.:.:.:6:C3[41]4[38.75];T17[40.29]12[35.58]",
-				 "0/0:61:LOH:22:63:.:.:.:.:C1[37]1[41];T31[39.03]30[38.87]",
-				 "0/1:29,25:Germline:23:54:.:99:.:.:.",
-				 "0/1:61,8:Germline:23:69:.:99:.:.:.");
-		 vcf.setFormatFields(ff);
-		 ConfidenceMode cm =new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));	// fails on MR and NNS
-	 }
-	 
-	 @Test
-	 public void passHomozygosLoss() {
-		 /*
-		  * GL000225.1	6859	.	T	G	.	.	FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:24:PASS:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:.:Germline:23:14:PASS:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]	0/1:5,18:Germline:23:23:PASS:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:3,5:Germline:23:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"GL000225.1","6859",".","T","G",".",".","FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)"
-				 ,"GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS"
-				 ,"0/1:.:Germline:21:24:.:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]"
-				 ,"./.:.:HomozygousLoss:21:14:.:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]"
-				 ,"0/1:5,18:Germline:21:23:.:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]"
-				 ,"./.:3,5:HomozygousLoss:21:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]"});
-		 
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 @Test
-	 public void noCallInGATK() {
-		 /*
-		  * GL000225.1	6859	.	T	G	.	.	FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:24:PASS:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:.:Germline:23:14:PASS:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]	0/1:5,18:Germline:23:23:PASS:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:3,5:Germline:23:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","696644",".","G","A",".",".","FLANK=AAACAAAAACT;BaseQRankSum=-0.677;ClippingRankSum=-0.710;DP=49;FS=0.000;MQ=25.07;MQRankSum=-0.215;QD=21.19;ReadPosRankSum=0.974;SOR=0.446;IN=1,2;HOM=5,AACTAAAACAaAAACTCCTGA"
-		 ,"GT:AD:DP:FF:FT:GQ:INF:NNS:OABS:QL"
-		 ,"0/0:39,0:39:G17:.:.:.:.:G16[40.25]23[37.22]:."
-		 ,"0/1:5,43:48:.:.:.:SOMATIC:41:A19[39.95]24[37.83];G2[39]3[39.67]:."
-		 ,"0/0:.:.:.:.:.:NCIG:.:.:."
-		 ,"0/1:5,44:49:.:.:3:.:.:.:1038.53"});
-		 
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void  areCoverageChecksWorking(){
-		 /*
-		  * GL000225.1	6859	.	T	G	.	.	FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:24:PASS:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:.:Germline:23:14:PASS:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]	0/1:5,18:Germline:23:23:PASS:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:3,5:Germline:23:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"GL000225.1","6859",".","T","G",".",".","FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)"
-				 ,"GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS"
-				 ,"0/1:8,16:Germline:23:24:.:.:.:15:G5[38]11[38.09];T4[34.25]4[35.5]"
-				 ,"0/1:7,7:Germline:23:14:.:.:.:7:G4[34.25]3[39];T4[38.25]3[33]"
-				 ,"0/1:5,18:Germline:23:23:.:99:.:.:."
-				 ,"0/1:3,5:Germline:23:8:.:99:.:.:."});
-		 
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void areCoverageChecksWorking2() {
-		 /*
-		  * GL000231.1	21863	.	C	T	.	.	FLANK=AATCCTTTCAT;BaseQRankSum=-0.085;ClippingRankSum=-0.751;DP=90;FS=0.832;MQ=50.50;MQRankSum=-3.000;QD=11.64;ReadPosRankSum=0.564;SOR=0.554;IN=1,2;EFF=downstream_gene_variant(MODIFIER||15|||CT867977.1|miRNA|NON_CODING|ENST00000581649||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:56:PASS:.:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:.:Germline:23:38:.:.:.:4:3:C9[37.78]25[36.6];T3[40]1[41]	0/1:50,40:Germline:23:90:PASS:99:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:40,27:Germline:23:67:.:99:.:4:3:C9[37.78]25[36.6];T3[40]1[41]
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"GL000231.1","21863",".","C","T",".",".","."
-				 ,"GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS"
-				 ,"0/1:45,11:Germline:23:56:.:.:.:9:C16[37.38]29[37.34];T8[34.5]3[39.33]"
-				 ,"0/1:34,4:Germline:23:38:.:.:.:3:C9[37.78]25[36.6];T3[40]1[41]"
-				 ,"0/1:50,40:Germline:23:90:.:99:.:.:."
-				 ,"0/1:40,27:Germline:23:67:.:99:.:.:."});
-		 
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("NNS;MR", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void ifGermlineJustLookAtControl() {
-		 /*
-		  * GL000231.1	21863	.	C	T	.	.	FLANK=AATCCTTTCAT;BaseQRankSum=-0.085;ClippingRankSum=-0.751;DP=90;FS=0.832;MQ=50.50;MQRankSum=-3.000;QD=11.64;ReadPosRankSum=0.564;SOR=0.554;IN=1,2;EFF=downstream_gene_variant(MODIFIER||15|||CT867977.1|miRNA|NON_CODING|ENST00000581649||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:56:PASS:.:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:.:Germline:23:38:.:.:.:4:3:C9[37.78]25[36.6];T3[40]1[41]	0/1:50,40:Germline:23:90:PASS:99:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:40,27:Germline:23:67:.:99:.:4:3:C9[37.78]25[36.6];T3[40]1[41]
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"GL000231.1","21863",".","C","T",".",".","."
-				 ,"GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS"
-				 ,"0/1:45,11:Germline:23:56:.:.:.:9:C16[37.38]29[37.34];T8[34.5]3[39.33]"
-				 ,"0/1:34,4:Germline:23:38:.:.:.:3:C9[37.78]25[36.6];T3[40]1[41]"
-				 ,"0/1:50,40:Germline:23:90:.:99:.:.:."
-				 ,"0/1:40,27:Germline:23:67:.:99:.:.:."});
-		 
-		 ConfidenceMode cm =new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("NNS;MR", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confIsSomatic() {
-		 /*
-		  * chr1    2245570 rs2843152       C       G       .       .       FLANK=GATGCGAGGAG;DP=4;FS=0.000;MQ=60.00;MQ0=0;QD=17.76;SOR=0.693;IN=1,2;DB;VLD;VAF=0.6276;EFF=downstream_gene_variant(MODIFIER||4012||728|SKI|protein_coding|CODING|ENST00000378536||1),intergenic_region(MODIFIER||||||||||1) GT:AD:DP:FT:GQ:INF:MR:NNS:OABS  .:.:.:.:.:.:.:.:.       1/1:.:4:5BP=1;COVT:.:SOMATIC;GERM=53,185;CONF=SOMATIC;GERM=53,185;ZERO:4:4:G2[35]2[35]  .:.:.:.:.:.:.:.:.       1/1:0,4:4:5BP=1;COVT:12:SOMATIC;GERM=53,185;CONF=SOMATIC;GERM=53,185;ZERO:4:4:G2[35]2[35]
-		  */
-		 VcfRecord r = new VcfRecord(new String[]{"chr1","2245570","rs2843152","C","G",".",".","FLANK=GATGCGAGGAG;DP=4;FS=0.000;MQ=60.00;MQ0=0;QD=17.76;SOR=0.693;IN=1,2;DB;VLD;VAF=0.6276;EFF=downstream_gene_variant(MODIFIER||4012||728|SKI|protein_coding|CODING|ENST00000378536||1),intergenic_region(MODIFIER||||||||||1)"
-				 ,"GT:AD:DP:FT:GQ:INF:MR:NNS:OABS"
-				 ,".:.:.:.:.:.:.:.:."
-				 ,"1/1:0,4:4:5BP=1;COVT:.:SOMATIC;GERM=53,185:4:4:G2[35]2[35]"
-				 ,".:.:.:.:.:.:.:.:."
-				 ,"1/1:0,4:4:5BP=1;COVT:12:SOMATIC;GERM=53,185:4:4:G2[35]2[35]"});
-		 
-		 assertEquals(true, VcfUtils.isRecordSomatic(r));
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(r.getChrPosition(), java.util.Arrays.asList(r));
-		 cm.addAnnotation();
-		 r = cm.positionRecordMap.get(r.getChrPosition()).get(0);
-		 assertEquals(true, r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_INFO).contains( "SOMATIC"));
-		 assertEquals(true, r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_INFO).contains( "GERM=53,185"));
-		 assertEquals("COV;MR", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV;MR", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeSingle() {
-		 //chr8	12306635	rs28428895	C	T	.	PASS	FLANK=ACACATACATA;DB;CONF=HIGH;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)	GT:GD:AC:MR:NNS	0/1:C/T:C10[39],3[30],G1[11],0[0],T7[41.29],1[42]:8:8	0/0:C/C:C19[36.11],20[38.45],T1[42],0[0]:1:1
-		 VcfRecord vcf1 = new VcfRecord(new String[]{"chr8","12306635","rs28428895","C","T",".",".","FLANK=ACACATACATA;DB;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)","GT:AC:AD:DP:NNS:FT","0/1:C10[39],3[30],G1[11],0[0],T7[41.29],1[42]:13,8:22:8:.","0/0:C19[36.11],20[38.45],T1[42],0[0]:39,1:40:1:."});
-		 VcfRecord vcf2 = new VcfRecord(new String[]{"chr8","12306635","rs28428895","C","T","57.77",".","SOMATIC;DB;GERM=30,185;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)","GT:AD:DP:GQ:PL:GD:AC:MR:NNS:FT","0/1:17,15,1:33:.:.:C/C:C14[38.79],3[30],G1[11],0[0],T11[39.27],4[25.25]:15:15:MIN","0/1:4,3:7:86:86,0,133:C/T:C22[36.23],22[36.91],T2[26.5],1[42]:3:2:MR;NNS"});
-		 
-		 ConfidenceMode cm = new ConfidenceMode(SINGLE_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(vcf1.getChrPosition(), java.util.Arrays.asList(vcf1, vcf2));
-		 cm.addAnnotation();
-		 
-		 vcf1 = cm.positionRecordMap.get(vcf1.getChrPosition()).get(0);
-		 vcf2 = cm.positionRecordMap.get(vcf2.getChrPosition()).get(1);
-		 assertEquals("PASS", vcf1.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf1.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf2.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("COV;MR", vcf2.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void multipleADValues() {
-		 /*
-		  *chr1	63982013	rs12130694	C	G,T	.	.	FLANK=GGAAGGGGAGC;BaseQRankSum=1.437;ClippingRankSum=0.000;DP=21;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=29.74;ReadPosRankSum=-0.087;SOR=4.615;IN=1,2;DB;VAF=[.,0.359];GERM=T:32:48:80:0;HOM=4,GGAAGGGAAGgGGAGCGGGGG	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	2/2:1,0,21:22:T0[]1[]:G4;T6:MR:.:.:18:C1[12]0[0];T18[30.39]3[35]:.	1/2:0,3,8:12:T1[]0[]:A1;G9;T13:SBIASALT;NNS;MR:.:SOMATIC:3,7:A1[12]0[0];G3[12]0[0];T7[19.14]1[32]:.2/2:1,19:20:.:.:PASS:48:.:.:.:594.77	2/2:0,8:8:.:.:PASS:22:.:.:.:119.79 
-		  */
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr1	","63982013","rs12130694","C","G,T",".",".","FLANK=GGAAGGGGAGC;BaseQRankSum=1.437;ClippingRankSum=0.000;DP=21;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=29.74;ReadPosRankSum=-0.087;SOR=4.615;IN=1,2;DB;VAF=[.,0.359];GERM=T:32:48:80:0;HOM=4,GGAAGGGAAGgGGAGCGGGGG"
-				 ,"GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL"
-				 ,"2/2:1,0,21:22:T0[]1[]:G4;T6:MR:.:.:18:C1[12]0[0];T18[30.39]3[35]:."
-				 ,"1/2:0,3,8:12:T1[]0[]:A1;G9;T13:SBIASALT;NNS;MR:.:SOMATIC:3,7:A1[12]0[0];G3[12]0[0];T7[19.14]1[32]:."
-				 ,"2/2:1,19:20:.:.:PASS:48:.:.:.:594.77"
-				 ,"2/2:0,8:8:.:.:PASS:22:.:.:.:119.79"});
-		 
-		 ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
-		 cm.positionRecordMap.put(vcf.getChrPosition(), Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("SBIASALT;NNS;MR", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged() {
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr8","12306635","rs28428895","C","T",".",".","FLANK=ACACATACATA;IN=1,2;DB;GERM=30,185;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)",
-				 "GT:OABS:NNS:AD:DP:GQ:PL:FT",
-				 "0/1:C10[39]3[30]G1[11]0[0];T7[41.29]1[42]:8:13,8:22:.:.:.",
-				 "0/1:C14[38.79]3[30];G1[11]0[0];T11[39.27]4[25.25]:15:17,15:33:.:.:.",
-				 "0/0:.:.:.:40:.:.:.",
-				 "0/1:.:.:4,3:47:86:86,0,133:."});
-		 ConfidenceMode cm =new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("MR", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLife2() {
-		 //chr9	126129715	rs57014689	C	A	205.77	PASS	AC=1;AF=0.500;AN=2;BaseQRankSum=-1.408;ClippingRankSum=-1.932;DP=48;FS=3.424;MLEAC=1;MLEAF=0.500;MQ=41.89;MQ0=0;MQRankSum=0.717;QD=4.29;ReadPosRankSum=-0.717;SOR=0.120;DB	GT:AD:DP:GQ:PL:GD:AC:MR:NNS	0/1:6,5:11:99:234,0,331:A/C:A0[0],4[24.25],C243[17.06],65[18.88],G2[7],0[0]:4:4	1/1:1,18:19:46:841,46,0:A/A:A2[7],15[28.73],C179[15.92],121[14.76],G0[0],1[7]:17:16
-		 //chr9	126129715	rs57014689	C	A	.	PASS	SOMATIC;FLANK=CCCCCACACCC;DB;GERM=5,185	GT:GD:AC:MR:NNS	0/0:C/C:A0[0],4[24.25],C128[17.64],30[20.9],G2[7],0[0]:4:4	0/1:A/C:A2[7],13[28.23],C96[17.22],54[14.22]:15:15
-		 VcfRecord vcf1 = new VcfRecord(new String[]{"chr9","126129715","rs57014689","C","A","205.77",".","AC=1;AF=0.500;AN=2;BaseQRankSum=-1.408;ClippingRankSum=-1.932;DP=48;FS=3.424;MLEAC=1;MLEAF=0.500;MQ=41.89;MQ0=0;MQRankSum=0.717;QD=4.29;ReadPosRankSum=-0.717;SOR=0.120;DB",
-				 "GT:AD:DP:GQ:PL:OABS:NNS:FT",
-				 "0/1:6,5:11:99:234,0,331:A0[0]4[24.25];C243[17.06]65[18.88];G2[7]0[0]:.:.",
-				 "1/1:1,18:19:46:841,46,0:A2[7]15[28.73];C179[15.92]121[14.76];G0[0]1[7]:.:."});
-		 VcfRecord vcf2 = new VcfRecord(new String[]{"chr9","126129715","rs57014689","C","A",".",".","SOMATIC;FLANK=CCCCCACACCC;DB;GERM=5,185",
-				 "GT:AD:DP:OABS:NNS:FT",
-				 "0/0:158,4:164:A0[0]4[24.25];C128[17.64]30[20.9];G2[7]0[0]:4:.",
-				 "0/1:150,15:165:A2[7]13[28.23];C96[17.22]54[14.22]:15:."});
-		 
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf1.getChrPosition(), Arrays.asList(vcf1, vcf2));
-		 cm.addAnnotation();
-		 
-		 vcf1 = cm.positionRecordMap.get(vcf1.getChrPosition()).get(0);
-		 vcf2 = cm.positionRecordMap.get(vcf2.getChrPosition()).get(1);
-		 assertEquals("PASS", vcf1.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf1.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf2.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf2.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged2() throws Exception {
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr9","126129715","rs57014689","C","A",".",".","FLANK=CCCCCACACCC;AC=1;AF=0.500;AN=2;BaseQRankSum=-1.408;ClippingRankSum=-1.932;DP=48;FS=3.424;MLEAC=1;MLEAF=0.500;MQ=41.89;MQ0=0;MQRankSum=0.717;QD=4.29;ReadPosRankSum=-0.717;SOR=0.120;IN=1,2;DB;GERM=5,185",
-				 "GT:OABS:NNS:AD:DP:GQ:PL:FT:INF",
-				 "0/0:A0[0]4[24.25];C128[17.64]30[20.9];G2[7]0[0]:4:.:164:.:.:.:.",
-				 "0/1:A0[0]4[24.25];C243[17.06]65[18.88];G2[7]0[0]:4:6,5:300:99:234,0,331:.:SOMATIC",
-				 "0/0:.:.:.:.:.:.:.:NCIG",
-				 "1/1:.:16:1,18:319:46:841,46,0:.:."});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged3() {
-		 /*
-		  * chr17	76354679       	.      	G      	A      	.      	.      	FLANK=TAGATATAATA;BaseQRankSum=-0.735;ClippingRankSum=-0.385;DP=23;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.175;QD=20.34;ReadPosRankSum=-0.245;SOR=1.061;IN=1,2     	GT:DP:FT:INF:MR:NNS:OABS:AD:GQ 	0/0:36:.:SOMATIC:.:.:A0[0]1[34];G19[34.79]16[35.25]:.:.	0/1:22:.:SOMATIC:16:16:A9[33.11]7[33.86];G3[34.33]3[35.67]:.:. 	.:.:.:.:.:.:A0[0]1[34];G19[34.79]16[35.25]:.:. 	0/1:23:.:.:16:16:A9[33.11]7[33.86];G3[34.33]3[35.67]:6,17:99
-		  */
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr17","76354679",".","G","A",".",".","FLANK=TAGATATAATA;BaseQRankSum=-0.735;ClippingRankSum=-0.385;DP=23;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.175;QD=20.34;ReadPosRankSum=-0.245;SOR=1.061;IN=1,2"
-				 ,"GT:DP:FT:INF:NNS:OABS:AD:GQ"
-				 ,"0/0:36:.:.:.:A0[0]1[34];G19[34.79]16[35.25]:36:."
-				 ,"0/1:22:.:SOMATIC:16:A9[33.11]7[33.86];G3[34.33]3[35.67]:6,16:."
-				 ,"0/0:.:.:NCIG:.:.:.:."
-				 ,"0/1:23:.:SOMATIC:.:.:6,17:99"});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged4() {
-		 /*
-		  * chr1    	1654058	rs61777495     	C      	T      	.      	.      	FLANK=CTTCATCGAAG;DP=17;FS=0.000;MQ=46.03;MQ0=0;QD=28.60;SOR=4.294;IN=1,2;DB;VLD;VAF=0.6313	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	1/1:.:13:.:.:CONF=ZERO:13:11:T10[39.7]3[32.67] 	1/1:.:10:SBIASALT:.:.:9:8:C0[0]1[28];T9[39.67]0[0]     	1/1:0,17:17:.:57:CONF=ZERO:13:11:T10[39.7]3[32.67]     	0/1:1,10:11:SBIASALT:46:.:9:8:C0[0]1[28];T9[39.67]0[0]
-		  */
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr1","1654058","rs61777495","C","T",".",".","FLANK=CTTCATCGAAG;DP=17;FS=0.000;MQ=46.03;MQ0=0;QD=28.60;SOR=4.294;IN=1,2;DB;VLD;VAF=0.6313"
-				 ,"GT:AD:DP:FT:GQ:INF:NNS:OABS"
-				 ,"1/1:0,13:13:.:.:.:11:T10[39.7]3[32.67]"
-				 ,"1/1:1,9:10:.:.:.:8:C0[0]1[28];T9[39.67]0[0]"
-				 ,"1/1:0,17:17:.:57:.:.:."
-				 ,"0/1:1,10:11:.:46:.:.:."});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("SBIASALT", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged5() {
-		 /*
-		  * chr1   	22332008       	rs56968853     	T      	C      	.      	.      	FLANK=CCCGACTGGGT;BaseQRankSum=-2.031;ClippingRankSum=-0.750;DP=39;FS=11.226;MQ=56.26;MQ0=0;MQRankSum=-4.117;QD=1.40;ReadPosRankSum=-0.457;SOR=1.429;IN=1,2;DB;EFF=synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|121|CELA3A|protein_coding|CODING|ENST00000374663|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|5|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|2|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|7|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|8|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|6|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|4|1),sequence_feature[disulfide_bond](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),upstream_gene_variant(MODIFIER||1935||75|CELA3A|protein_coding|CODING|ENST00000400271||1|WARNING_TRANSCRIPT_NO_START_CODON),upstream_gene_variant(MODIFIER||1647|||RN7SL768P|misc_RNA|NON_CODING|ENST00000584415||1)     	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	0/1:.:64:.:.:CONF=HIGH:7:7:C2[34]5[34.8];T41[33.2]16[35.19]    	0/1:.:39:.:.:.:7:7:C2[35]5[34];T23[33.39]9[35.44]      	0/0:.:57:MIN:.:SOMATIC;GERM=49,185:.:.:C2[34]5[34.8];T41[33.2]16[35.19]	0/1:32,7:39:.:83:SOMATIC;GERM=49,185;CONF=HIGH:7:7:C2[35]5[34];T23[33.39]9[35.44]
-		  */
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr1","22332008","rs56968853","T","C",".",".","FLANK=CCCGACTGGGT;BaseQRankSum=-2.031;ClippingRankSum=-0.750;DP=39;FS=11.226;MQ=56.26;MQ0=0;MQRankSum=-4.117;QD=1.40;ReadPosRankSum=-0.457;SOR=1.429;IN=1,2;DB;EFF=synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|121|CELA3A|protein_coding|CODING|ENST00000374663|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|5|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|2|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|7|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|8|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|6|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|4|1),sequence_feature[disulfide_bond](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),upstream_gene_variant(MODIFIER||1935||75|CELA3A|protein_coding|CODING|ENST00000400271||1|WARNING_TRANSCRIPT_NO_START_CODON),upstream_gene_variant(MODIFIER||1647|||RN7SL768P|misc_RNA|NON_CODING|ENST00000584415||1)"
-				 ,"GT:AD:DP:FT:GQ:INF:NNS:OABS"
-				 ,"0/1:57,7:64:.:.:.:7:C2[34]5[34.8];T41[33.2]16[35.19]"
-				 ,"0/1:32,7:39:.:.:.:7:C2[35]5[34];T23[33.39]9[35.44]"
-				 ,"0/0:.:.:.:.:NCIG:.:."
-				 ,"0/1:32,7:39:.:83:SOMATIC;GERM=49,185:.:."});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged6() {
-		 /*
-		  * COVN12 filter in normal needs to affect the somatic confidence 
-		  * 
-		  * chr1   	176992676      	rs10798496     	C      	T      	.      	.      	FLANK=TCCAGTTGGCT;BaseQRankSum=0.851;ClippingRankSum=0.676;DP=10;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.336;QD=14.78;ReadPosRankSum=-0.336;SOR=0.250;IN=1,2;DB;VLD;VAF=0.2466	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	0/0:.:8:COVN12:.:SOMATIC;GERM=117,185:.:.:C0[0]8[39.62]	0/1:.:10:.:.:SOMATIC;GERM=117,185;CONF=HIGH:5:5:C1[32]4[35.5];T2[34]3[38]      	0/0:.:8:COVN12:.:SOMATIC;GERM=117,185:.:.:C0[0]8[39.62]	0/1:5,5:10:.:99:SOMATIC;GERM=117,185;CONF=HIGH:5:5:C1[32]4[35.5];T2[34]3[38]
-		  */
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr1","176992676","rs10798496","C","T",".",".","FLANK=TCCAGTTGGCT"
-				 ,"GT:AD:DP:FT:GQ:INF:NNS:OABS"
-				 ,"0/0:8:8:.:.:GERM=117,185:.:C0[0]8[39.62"
-				 ,"0/1:5,5:10:.:.:SOMATIC;GERM=117,185:5:C1[32]4[35.5];T2[34]3[38]"
-				 ,"0/0:.:.:.:.:NCIG:.:."
-				 ,"0/1:5,5:10:.:99:SOMATIC;GERM=117,185:.:."});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged7() {
-		 /*
-		  * SAN3 filter in normal needs to affect the somatic confidence 
-		  * chr5   	101570491      	rs4703217      	A      	G      	.      	.      	FLANK=GACAAGGAAAG;BaseQRankSum=1.262;ClippingRankSum=1.926;DP=19;FS=0.000;MQ=50.85;MQ0=0;MQRankSum=-2.192;QD=29.86;ReadPosRankSum=-0.332;SOR=1.061;IN=1,2;DB;VLD;VAF=0.1832;EFF=synonymous_variant(LOW|SILENT|aaA/aaG|p.Lys15Lys/c.45A>G|90|AC008948.1|protein_coding|CODING|ENST00000597120|1|1),3_prime_UTR_variant(MODIFIER||2071|c.*2071T>C|724|SLCO4C1|protein_coding|CODING|ENST00000310954|13|1)	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	.:.:.:.:.:SOMATIC;GERM=11,185:.:.:.    	1/1:.:19:.:.:SOMATIC;GERM=11,185;CONF=HIGH:17:17:A1[39]1[39];G7[37.43]10[38.4] 	.:.:.:SAN3:.:SOMATIC;GERM=11,185:.:.:. 	1/1:2,17:19:.:8:SOMATIC;GERM=11,185;CONF=HIGH:17:17:A1[39]1[39];G7[37.43]10[38.4]
-		  */
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr5","101570491","rs4703217","A","G",".",".","FLANK=GACAAGGAAAG;BaseQRankSum=1.262;ClippingRankSum=1.926;DP=19;FS=0.000;MQ=50.85;MQ0=0;MQRankSum=-2.192;QD=29.86;ReadPosRankSum=-0.332;SOR=1.061;IN=1,2;DB;VLD;VAF=0.1832;EFF=synonymous_variant(LOW|SILENT|aaA/aaG|p.Lys15Lys/c.45A>G|90|AC008948.1|protein_coding|CODING|ENST00000597120|1|1),3_prime_UTR_variant(MODIFIER||2071|c.*2071T>C|724|SLCO4C1|protein_coding|CODING|ENST00000310954|13|1)"
-				 ,"GT:AD:DP:FT:GQ:INF:NNS:OABS"
-				 ,"./.:.:0:.:.:SOMATIC;GERM=11,185:.:."
-				 ,"1/1:2,17:19:.:.:SOMATIC;GERM=11,185:17:A1[39]1[39];G7[37.43]10[38.4]"
-				 ,"0/0:.:.:.:.:NCIG:.:."
-				 ,"1/1:2,17:19:.:8:SOMATIC;GERM=11,185:.:."});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("COV", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged8() {
-		 /*
-		  * MIUN filter in normal needs to affect the somatic confidence 
-		  * chr11  	1016978	rs76461263     	T      	G      	.      	.      	FLANK=GTGTGGTTGGG		GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	0/0:.:63:MIUN:.:SOMATIC;GERM=40,185:.:.:G1[40]0[0];T35[33.11]27[35.33] 	0/1:.:69:.:.:SOMATIC;GERM=40,185;CONF=HIGH:7:5:G1[35]6[39.67];T32[32.12]30[36] 	0/0:.:62:.:.:SOMATIC;GERM=40,185:.:.:G1[40]0[0];T35[33.11]27[35.33]    	0/1:58,15:73:.:99:SOMATIC;GERM=40,185;CONF=HIGH:7:5:G1[35]6[39.67];T32[32.12]30[36]
-		  */
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr11","1016978","rs76461263","T","G",".",".","FLANK=GTGTGGTTGGG"
-				 ,"GT:AD:DP:FT:GQ:INF:NNS:OABS"
-				 ,"0/0:62,1:63:.:.:.;GERM=40,185:.:G1[40]0[0];T35[33.11]27[35.33]"
-				 ,"0/1:62,7:69:.:.:SOMATIC;GERM=40,185:5:G1[35]6[39.67];T32[32.12]30[36]"
-				 ,"0/0:.:.:.:.:NCIG:.:."
-				 ,"0/1:58,15:73:.:99:SOMATIC;GERM=40,185:.:."});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void confidenceRealLifeMerged9() {
-		 /*
-		  * COVN8 filter in normal needs to affect the somatic confidence 
-		  * chr17  	42254527       	rs7217858      	T      	G      	.      	.      	FLANK=AGGACGCCCCC
-		  */
-		 //now try the merged record
-		 VcfRecord vcf = new VcfRecord(new String[]{"chr17","42254527","rs7217858","T","G",".",".","FLANK=AGGACGCCCCC"
-				 ,"GT:AD:DP:FT:GQ:INF:NNS:OABS"
-				 ,"0/0:3:3:.:.:SOMATIC;GERM=30,185:.:T2[35]1[35]"
-				 ,"1/1:1,11:12:.:.:SOMATIC;GERM=30,185:10:G5[33.6]6[35.67];T0[0]1[38]"
-				 ,"0/0:.:.:.:.:NCIG:.:."
-				 ,"0/1:1,11:12:.:7:SOMATIC;GERM=30,185:.:."});
-		 ConfidenceMode cm = new ConfidenceMode();
-		 cm.positionRecordMap.put(vcf.getChrPosition(), java.util.Arrays.asList(vcf));
-		 cm.addAnnotation();
-		 
-		 vcf = cm.positionRecordMap.get(vcf.getChrPosition()).get(0);
-		 assertEquals("COV", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
-		 assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
-	 }
-	 
-	 @Test
-	 public void applyMRFilter() {
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(null, null, -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{}, "", -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,0}, ".", -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,0}, "0", -1));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,0}, "10", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "10,0", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "10,4", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "10,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{0,1}, "4,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{1,1}, "10,5", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{1,1}, "10,4", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{1,1}, "10,4,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{1,2}, "10,5,5", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{1,2}, "0,5,5", 5));
-		 assertEquals(true, ConfidenceMode.applyMutantReadFilter(new int[]{1,2}, "10,5,4", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{2,2}, "10,5,6", 5));
-		 assertEquals(false, ConfidenceMode.applyMutantReadFilter(new int[]{2,2}, "10,4,5", 5));
-	 }
-	 
-	 @Test
-	 public void covFromFF() {
-		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString(null));
-		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString(""));
-		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString("."));
-		 assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString("A0"));
-		 assertEquals(1, ConfidenceMode.getCoverageFromFailedFilterString("A1"));
-		 assertEquals(10, ConfidenceMode.getCoverageFromFailedFilterString("A10"));
-		 assertEquals(100, ConfidenceMode.getCoverageFromFailedFilterString("A100"));
-		 assertEquals(101, ConfidenceMode.getCoverageFromFailedFilterString("A100;B1"));
-		 assertEquals(110, ConfidenceMode.getCoverageFromFailedFilterString("A100;B10"));
-		 assertEquals(113, ConfidenceMode.getCoverageFromFailedFilterString("A100;B10;X3"));
-		 // alts of more than 1 base too
-		 assertEquals(1, ConfidenceMode.getCoverageFromFailedFilterString("AA1"));
-		 assertEquals(2, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1"));
-		 assertEquals(107, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1;CAB105"));
-		 assertEquals(127, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1;CAB105;H20"));
-	 }
+        vcf.setFormatFields(ff);
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("SBIASALT", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("MR", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void realLifeFail() {
+        //chr1    4985568 rs10753395      A       C       .       PASS_1;PASS_2   FLANK=ACGTTCCTGCA;AC=1;AF=0.500;AN=2;BaseQRankSum=0.972;ClippingRankSum=1.139;DP=26;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=-0.472;QD=9.45;ReadPosRankSum=-0.194;SOR=0.693;IN=1,2;DB;VAF=0.4816   GT:GD:AC:MR:NNS:AD:DP:GQ:PL     0/1:A/C:A8[33.75],11[38.82],C3[42],5[40],A9[33.56],11[38.82],C3[42],5[40],G0[0],1[22],T1[11],0[0]:8:8:18,8:26:99:274,0,686      1/1:C/C:A1[37],0[0],C23[38.96],19[41.21],A1[37],0[0],C24[38.88],23[40.26]:42,47:38,42:1,44:45:94:1826,94,0
+        VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr1", 4985568, 4985568), "rs10753395", "A", "C");
+        vcf.setFilter("PASS_1;PASS_2");
+        vcf.setInfo("FLANK=ACGTTCCTGCA;AC=1;AF=0.500;AN=2;BaseQRankSum=0.972;ClippingRankSum=1.139;DP=26;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=-0.472;QD=9.45;ReadPosRankSum=-0.194;SOR=0.693;IN=1,2;DB;VAF=0.4816");
+        List<String> ff = java.util.Arrays.asList("GT:GD:AC:MR:NNS:AD:DP:GQ:PL", "0/1:A/C:A8[33.75],11[38.82],C3[42],5[40]:8:8:18:26:99:274,0,686", "0/1:A/C:A9[33.56],11[38.82],C3[42],5[40],G0[0],1[22],T1[11],0[0]:8:8:8:26:99:274,0,686", "1/1:C/C:A1[37],0[0],C23[38.96],19[41.21]:42:38:1,44:45:94:1826,94,0", "1/1:C/C:A1[37],0[0],C24[38.88],23[40.26]:47:42:1,44:45:94:1826,94,0");
+        vcf.setFormatFields(ff);
+        assertEquals(8, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(1), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
+        assertEquals(8, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(2), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
+        assertEquals(38, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(3), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
+        assertEquals(42, ConfidenceMode.getFieldOfInts(vcf.getSampleFormatRecord(4), VcfHeaderUtils.FORMAT_NOVEL_STARTS)[0]);
+    }
+
+    @Test
+    public void realLifeFail2() {
+        //chr1	73551390	rs12142252	T	C	.	.	FLANK=ATCAACGGTCT;BaseQRankSum=-1.162;ClippingRankSum=1.214;DP=54;FS=0.000;MQ=60.00;MQRankSum=0.330;QD=17.29;ReadPosRankSum=0.590;SOR=0.596;IN=1,2;DB;VLD;VAF=0.3462;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:22:36:PASS:.:.:7:6:C3[41]4[38.75];T17[40.29]12[35.58]	0/0:.:LOH:22:63:PASS:.:.:.:.:C1[37]1[41];T31[39.03]30[38.87]	0/1:29,25:Germline:23:54:PASS:99:.:7:6:C3[41]4[38.75];T17[40.29]12[35.58]	0/1:61,8:Germline:23:69:.:99:.:2:2:C1[37]1[41];T31[39.03]30[38.87]
+        VcfRecord vcf = VcfUtils.createVcfRecord(ChrPositionUtils.getChrPosition("chr1", 73551390, 73551390), "rs12142252", "T", "C");
+        vcf.setInfo("FLANK=ATCAACGGTCT;BaseQRankSum=-1.162;ClippingRankSum=1.214;DP=54;FS=0.000;MQ=60.00;MQRankSum=0.330;QD=17.29;ReadPosRankSum=0.590;SOR=0.596;IN=1,2;DB;VLD;VAF=0.3462;EFF=intergenic_region(MODIFIER||||||||||1)");
+        List<String> ff = java.util.Arrays.asList(
+                "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS",
+                "0/1:29,7:Germline:22:36:.:.:.:6:C3[41]4[38.75];T17[40.29]12[35.58]",
+                "0/0:61:LOH:22:63:.:.:.:.:C1[37]1[41];T31[39.03]30[38.87]",
+                "0/1:29,25:Germline:23:54:.:99:.:.:.",
+                "0/1:61,8:Germline:23:69:.:99:.:.:.");
+        vcf.setFormatFields(ff);
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));    // fails on MR and NNS
+    }
+
+    @Test
+    public void passHomozygosLoss() {
+        /*
+         * GL000225.1	6859	.	T	G	.	.	FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:24:PASS:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:.:Germline:23:14:PASS:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]	0/1:5,18:Germline:23:23:PASS:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:3,5:Germline:23:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]
+         */
+        VcfRecord r = new VcfRecord(new String[]{"GL000225.1", "6859", ".", "T", "G", ".", ".", "FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)"
+                , "GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS"
+                , "0/1:.:Germline:21:24:.:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]"
+                , "./.:.:HomozygousLoss:21:14:.:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]"
+                , "0/1:5,18:Germline:21:23:.:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]"
+                , "./.:3,5:HomozygousLoss:21:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]"});
+
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void noCallInGATK() {
+        /*
+         * GL000225.1	6859	.	T	G	.	.	FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:24:PASS:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:.:Germline:23:14:PASS:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]	0/1:5,18:Germline:23:23:PASS:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:3,5:Germline:23:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "696644", ".", "G", "A", ".", ".", "FLANK=AAACAAAAACT;BaseQRankSum=-0.677;ClippingRankSum=-0.710;DP=49;FS=0.000;MQ=25.07;MQRankSum=-0.215;QD=21.19;ReadPosRankSum=0.974;SOR=0.446;IN=1,2;HOM=5,AACTAAAACAaAAACTCCTGA"
+                , "GT:AD:DP:FF:FT:GQ:INF:NNS:OABS:QL"
+                , "0/0:39,0:39:G17:.:.:.:.:G16[40.25]23[37.22]:."
+                , "0/1:5,43:48:.:.:.:SOMATIC:41:A19[39.95]24[37.83];G2[39]3[39.67]:."
+                , "0/0:.:.:.:.:.:NCIG:.:.:."
+                , "0/1:5,44:49:.:.:3:.:.:.:1038.53"});
+
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void areCoverageChecksWorking() {
+        /*
+         * GL000225.1	6859	.	T	G	.	.	FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:24:PASS:.:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:.:Germline:23:14:PASS:.:.:7:7:G4[34.25]3[39];T4[38.25]3[33]	0/1:5,18:Germline:23:23:PASS:99:.:16:15:G5[38]11[38.09];T4[34.25]4[35.5]	0/1:3,5:Germline:23:8:.:99:.:7:7:G4[34.25]3[39];T4[38.25]3[33]
+         */
+        VcfRecord r = new VcfRecord(new String[]{"GL000225.1", "6859", ".", "T", "G", ".", ".", "FLANK=CCCTTGAAGCA;BaseQRankSum=1.006;ClippingRankSum=-0.335;DP=23;FS=4.649;MQ=27.53;MQRankSum=-0.186;QD=29.47;ReadPosRankSum=1.304;SOR=1.389;IN=1,2;EFF=intergenic_region(MODIFIER||||||||||1)"
+                , "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS"
+                , "0/1:8,16:Germline:23:24:.:.:.:15:G5[38]11[38.09];T4[34.25]4[35.5]"
+                , "0/1:7,7:Germline:23:14:.:.:.:7:G4[34.25]3[39];T4[38.25]3[33]"
+                , "0/1:5,18:Germline:23:23:.:99:.:.:."
+                , "0/1:3,5:Germline:23:8:.:99:.:.:."});
+
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void areCoverageChecksWorking2() {
+        /*
+         * GL000231.1	21863	.	C	T	.	.	FLANK=AATCCTTTCAT;BaseQRankSum=-0.085;ClippingRankSum=-0.751;DP=90;FS=0.832;MQ=50.50;MQRankSum=-3.000;QD=11.64;ReadPosRankSum=0.564;SOR=0.554;IN=1,2;EFF=downstream_gene_variant(MODIFIER||15|||CT867977.1|miRNA|NON_CODING|ENST00000581649||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:56:PASS:.:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:.:Germline:23:38:.:.:.:4:3:C9[37.78]25[36.6];T3[40]1[41]	0/1:50,40:Germline:23:90:PASS:99:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:40,27:Germline:23:67:.:99:.:4:3:C9[37.78]25[36.6];T3[40]1[41]
+         */
+        VcfRecord r = new VcfRecord(new String[]{"GL000231.1", "21863", ".", "C", "T", ".", ".", "."
+                , "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS"
+                , "0/1:45,11:Germline:23:56:.:.:.:9:C16[37.38]29[37.34];T8[34.5]3[39.33]"
+                , "0/1:34,4:Germline:23:38:.:.:.:3:C9[37.78]25[36.6];T3[40]1[41]"
+                , "0/1:50,40:Germline:23:90:.:99:.:.:."
+                , "0/1:40,27:Germline:23:67:.:99:.:.:."});
+
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("NNS;MR", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void ifGermlineJustLookAtControl() {
+        /*
+         * GL000231.1	21863	.	C	T	.	.	FLANK=AATCCTTTCAT;BaseQRankSum=-0.085;ClippingRankSum=-0.751;DP=90;FS=0.832;MQ=50.50;MQRankSum=-3.000;QD=11.64;ReadPosRankSum=0.564;SOR=0.554;IN=1,2;EFF=downstream_gene_variant(MODIFIER||15|||CT867977.1|miRNA|NON_CODING|ENST00000581649||1),intergenic_region(MODIFIER||||||||||1)	GT:AD:CCC:CCM:DP:FT:GQ:INF:MR:NNS:OABS	0/1:.:Germline:23:56:PASS:.:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:.:Germline:23:38:.:.:.:4:3:C9[37.78]25[36.6];T3[40]1[41]	0/1:50,40:Germline:23:90:PASS:99:.:11:9:C16[37.38]29[37.34];T8[34.5]3[39.33]	0/1:40,27:Germline:23:67:.:99:.:4:3:C9[37.78]25[36.6];T3[40]1[41]
+         */
+        VcfRecord r = new VcfRecord(new String[]{"GL000231.1", "21863", ".", "C", "T", ".", ".", "."
+                , "GT:AD:CCC:CCM:DP:FT:GQ:INF:NNS:OABS"
+                , "0/1:45,11:Germline:23:56:.:.:.:9:C16[37.38]29[37.34];T8[34.5]3[39.33]"
+                , "0/1:34,4:Germline:23:38:.:.:.:3:C9[37.78]25[36.6];T3[40]1[41]"
+                , "0/1:50,40:Germline:23:90:.:99:.:.:."
+                , "0/1:40,27:Germline:23:67:.:99:.:.:."});
+
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertEquals("PASS", r.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("NNS;MR", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confIsSomatic() {
+        /*
+         * chr1    2245570 rs2843152       C       G       .       .       FLANK=GATGCGAGGAG;DP=4;FS=0.000;MQ=60.00;MQ0=0;QD=17.76;SOR=0.693;IN=1,2;DB;VLD;VAF=0.6276;EFF=downstream_gene_variant(MODIFIER||4012||728|SKI|protein_coding|CODING|ENST00000378536||1),intergenic_region(MODIFIER||||||||||1) GT:AD:DP:FT:GQ:INF:MR:NNS:OABS  .:.:.:.:.:.:.:.:.       1/1:.:4:5BP=1;COVT:.:SOMATIC;GERM=53,185;CONF=SOMATIC;GERM=53,185;ZERO:4:4:G2[35]2[35]  .:.:.:.:.:.:.:.:.       1/1:0,4:4:5BP=1;COVT:12:SOMATIC;GERM=53,185;CONF=SOMATIC;GERM=53,185;ZERO:4:4:G2[35]2[35]
+         */
+        VcfRecord r = new VcfRecord(new String[]{"chr1", "2245570", "rs2843152", "C", "G", ".", ".", "FLANK=GATGCGAGGAG;DP=4;FS=0.000;MQ=60.00;MQ0=0;QD=17.76;SOR=0.693;IN=1,2;DB;VLD;VAF=0.6276;EFF=downstream_gene_variant(MODIFIER||4012||728|SKI|protein_coding|CODING|ENST00000378536||1),intergenic_region(MODIFIER||||||||||1)"
+                , "GT:AD:DP:FT:GQ:INF:MR:NNS:OABS"
+                , ".:.:.:.:.:.:.:.:."
+                , "1/1:0,4:4:5BP=1;COVT:.:SOMATIC;GERM=53,185:4:4:G2[35]2[35]"
+                , ".:.:.:.:.:.:.:.:."
+                , "1/1:0,4:4:5BP=1;COVT:12:SOMATIC;GERM=53,185:4:4:G2[35]2[35]"});
+
+        assertTrue(VcfUtils.isRecordSomatic(r));
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(r.getChrPosition(), List.of(r));
+        cm.addAnnotation();
+        r = cm.positionRecordMap.get(r.getChrPosition()).getFirst();
+        assertTrue(r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_INFO).contains("SOMATIC"));
+        assertTrue(r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_INFO).contains("GERM=53,185"));
+        assertEquals("COV;MR", r.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV;MR", r.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeSingle() {
+        //chr8	12306635	rs28428895	C	T	.	PASS	FLANK=ACACATACATA;DB;CONF=HIGH;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)	GT:GD:AC:MR:NNS	0/1:C/T:C10[39],3[30],G1[11],0[0],T7[41.29],1[42]:8:8	0/0:C/C:C19[36.11],20[38.45],T1[42],0[0]:1:1
+        VcfRecord vcf1 = new VcfRecord(new String[]{"chr8", "12306635", "rs28428895", "C", "T", ".", ".", "FLANK=ACACATACATA;DB;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)", "GT:AC:AD:DP:NNS:FT", "0/1:C10[39],3[30],G1[11],0[0],T7[41.29],1[42]:13,8:22:8:.", "0/0:C19[36.11],20[38.45],T1[42],0[0]:39,1:40:1:."});
+        VcfRecord vcf2 = new VcfRecord(new String[]{"chr8", "12306635", "rs28428895", "C", "T", "57.77", ".", "SOMATIC;DB;GERM=30,185;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)", "GT:AD:DP:GQ:PL:GD:AC:MR:NNS:FT", "0/1:17,15,1:33:.:.:C/C:C14[38.79],3[30],G1[11],0[0],T11[39.27],4[25.25]:15:15:MIN", "0/1:4,3:7:86:86,0,133:C/T:C22[36.23],22[36.91],T2[26.5],1[42]:3:2:MR;NNS"});
+
+        ConfidenceMode cm = new ConfidenceMode(SINGLE_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(vcf1.getChrPosition(), java.util.Arrays.asList(vcf1, vcf2));
+        cm.addAnnotation();
+
+        vcf1 = cm.positionRecordMap.get(vcf1.getChrPosition()).getFirst();
+        vcf2 = cm.positionRecordMap.get(vcf2.getChrPosition()).get(1);
+        assertEquals("PASS", vcf1.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf1.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf2.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("COV;MR", vcf2.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void multipleADValues() {
+        /*
+         *chr1	63982013	rs12130694	C	G,T	.	.	FLANK=GGAAGGGGAGC;BaseQRankSum=1.437;ClippingRankSum=0.000;DP=21;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=29.74;ReadPosRankSum=-0.087;SOR=4.615;IN=1,2;DB;VAF=[.,0.359];GERM=T:32:48:80:0;HOM=4,GGAAGGGAAGgGGAGCGGGGG	GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL	2/2:1,0,21:22:T0[]1[]:G4;T6:MR:.:.:18:C1[12]0[0];T18[30.39]3[35]:.	1/2:0,3,8:12:T1[]0[]:A1;G9;T13:SBIASALT;NNS;MR:.:SOMATIC:3,7:A1[12]0[0];G3[12]0[0];T7[19.14]1[32]:.2/2:1,19:20:.:.:PASS:48:.:.:.:594.77	2/2:0,8:8:.:.:PASS:22:.:.:.:119.79
+         */
+        VcfRecord vcf = new VcfRecord(new String[]{"chr1	", "63982013", "rs12130694", "C", "G,T", ".", ".", "FLANK=GGAAGGGGAGC;BaseQRankSum=1.437;ClippingRankSum=0.000;DP=21;ExcessHet=3.0103;FS=0.000;MQ=60.00;MQRankSum=0.000;QD=29.74;ReadPosRankSum=-0.087;SOR=4.615;IN=1,2;DB;VAF=[.,0.359];GERM=T:32:48:80:0;HOM=4,GGAAGGGAAGgGGAGCGGGGG"
+                , "GT:AD:DP:EOR:FF:FT:GQ:INF:NNS:OABS:QL"
+                , "2/2:1,0,21:22:T0[]1[]:G4;T6:MR:.:.:18:C1[12]0[0];T18[30.39]3[35]:."
+                , "1/2:0,3,8:12:T1[]0[]:A1;G9;T13:SBIASALT;NNS;MR:.:SOMATIC:3,7:A1[12]0[0];G3[12]0[0];T7[19.14]1[32]:."
+                , "2/2:1,19:20:.:.:PASS:48:.:.:.:594.77"
+                , "2/2:0,8:8:.:.:PASS:22:.:.:.:119.79"});
+
+        ConfidenceMode cm = new ConfidenceMode(TWO_SAMPLE_TWO_CALLER_META);
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("SBIASALT;NNS;MR", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged() {
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr8", "12306635", "rs28428895", "C", "T", ".", ".", "FLANK=ACACATACATA;IN=1,2;DB;GERM=30,185;EFF=intron_variant(MODIFIER|||n.304-488G>A||ENPP7P6|unprocessed_pseudogene|NON_CODING|ENST00000529817|2|1)",
+                "GT:OABS:NNS:AD:DP:GQ:PL:FT",
+                "0/1:C10[39]3[30]G1[11]0[0];T7[41.29]1[42]:8:13,8:22:.:.:.",
+                "0/1:C14[38.79]3[30];G1[11]0[0];T11[39.27]4[25.25]:15:17,15:33:.:.:.",
+                "0/0:.:.:.:40:.:.:.",
+                "0/1:.:.:4,3:47:86:86,0,133:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("MR", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLife2() {
+        //chr9	126129715	rs57014689	C	A	205.77	PASS	AC=1;AF=0.500;AN=2;BaseQRankSum=-1.408;ClippingRankSum=-1.932;DP=48;FS=3.424;MLEAC=1;MLEAF=0.500;MQ=41.89;MQ0=0;MQRankSum=0.717;QD=4.29;ReadPosRankSum=-0.717;SOR=0.120;DB	GT:AD:DP:GQ:PL:GD:AC:MR:NNS	0/1:6,5:11:99:234,0,331:A/C:A0[0],4[24.25],C243[17.06],65[18.88],G2[7],0[0]:4:4	1/1:1,18:19:46:841,46,0:A/A:A2[7],15[28.73],C179[15.92],121[14.76],G0[0],1[7]:17:16
+        //chr9	126129715	rs57014689	C	A	.	PASS	SOMATIC;FLANK=CCCCCACACCC;DB;GERM=5,185	GT:GD:AC:MR:NNS	0/0:C/C:A0[0],4[24.25],C128[17.64],30[20.9],G2[7],0[0]:4:4	0/1:A/C:A2[7],13[28.23],C96[17.22],54[14.22]:15:15
+        VcfRecord vcf1 = new VcfRecord(new String[]{"chr9", "126129715", "rs57014689", "C", "A", "205.77", ".", "AC=1;AF=0.500;AN=2;BaseQRankSum=-1.408;ClippingRankSum=-1.932;DP=48;FS=3.424;MLEAC=1;MLEAF=0.500;MQ=41.89;MQ0=0;MQRankSum=0.717;QD=4.29;ReadPosRankSum=-0.717;SOR=0.120;DB",
+                "GT:AD:DP:GQ:PL:OABS:NNS:FT",
+                "0/1:6,5:11:99:234,0,331:A0[0]4[24.25];C243[17.06]65[18.88];G2[7]0[0]:.:.",
+                "1/1:1,18:19:46:841,46,0:A2[7]15[28.73];C179[15.92]121[14.76];G0[0]1[7]:.:."});
+        VcfRecord vcf2 = new VcfRecord(new String[]{"chr9", "126129715", "rs57014689", "C", "A", ".", ".", "SOMATIC;FLANK=CCCCCACACCC;DB;GERM=5,185",
+                "GT:AD:DP:OABS:NNS:FT",
+                "0/0:158,4:164:A0[0]4[24.25];C128[17.64]30[20.9];G2[7]0[0]:4:.",
+                "0/1:150,15:165:A2[7]13[28.23];C96[17.22]54[14.22]:15:."});
+
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf1.getChrPosition(), Arrays.asList(vcf1, vcf2));
+        cm.addAnnotation();
+
+        vcf1 = cm.positionRecordMap.get(vcf1.getChrPosition()).getFirst();
+        vcf2 = cm.positionRecordMap.get(vcf2.getChrPosition()).get(1);
+        assertEquals("PASS", vcf1.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf1.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf2.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf2.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged2() {
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr9", "126129715", "rs57014689", "C", "A", ".", ".", "FLANK=CCCCCACACCC;AC=1;AF=0.500;AN=2;BaseQRankSum=-1.408;ClippingRankSum=-1.932;DP=48;FS=3.424;MLEAC=1;MLEAF=0.500;MQ=41.89;MQ0=0;MQRankSum=0.717;QD=4.29;ReadPosRankSum=-0.717;SOR=0.120;IN=1,2;DB;GERM=5,185",
+                "GT:OABS:NNS:AD:DP:GQ:PL:FT:INF",
+                "0/0:A0[0]4[24.25];C128[17.64]30[20.9];G2[7]0[0]:4:.:164:.:.:.:.",
+                "0/1:A0[0]4[24.25];C243[17.06]65[18.88];G2[7]0[0]:4:6,5:300:99:234,0,331:.:SOMATIC",
+                "0/0:.:.:.:.:.:.:.:NCIG",
+                "1/1:.:16:1,18:319:46:841,46,0:.:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged3() {
+        /*
+         * chr17	76354679       	.      	G      	A      	.      	.      	FLANK=TAGATATAATA;BaseQRankSum=-0.735;ClippingRankSum=-0.385;DP=23;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.175;QD=20.34;ReadPosRankSum=-0.245;SOR=1.061;IN=1,2     	GT:DP:FT:INF:MR:NNS:OABS:AD:GQ 	0/0:36:.:SOMATIC:.:.:A0[0]1[34];G19[34.79]16[35.25]:.:.	0/1:22:.:SOMATIC:16:16:A9[33.11]7[33.86];G3[34.33]3[35.67]:.:. 	.:.:.:.:.:.:A0[0]1[34];G19[34.79]16[35.25]:.:. 	0/1:23:.:.:16:16:A9[33.11]7[33.86];G3[34.33]3[35.67]:6,17:99
+         */
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr17", "76354679", ".", "G", "A", ".", ".", "FLANK=TAGATATAATA;BaseQRankSum=-0.735;ClippingRankSum=-0.385;DP=23;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.175;QD=20.34;ReadPosRankSum=-0.245;SOR=1.061;IN=1,2"
+                , "GT:DP:FT:INF:NNS:OABS:AD:GQ"
+                , "0/0:36:.:.:.:A0[0]1[34];G19[34.79]16[35.25]:36:."
+                , "0/1:22:.:SOMATIC:16:A9[33.11]7[33.86];G3[34.33]3[35.67]:6,16:."
+                , "0/0:.:.:NCIG:.:.:.:."
+                , "0/1:23:.:SOMATIC:.:.:6,17:99"});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged4() {
+        /*
+         * chr1    	1654058	rs61777495     	C      	T      	.      	.      	FLANK=CTTCATCGAAG;DP=17;FS=0.000;MQ=46.03;MQ0=0;QD=28.60;SOR=4.294;IN=1,2;DB;VLD;VAF=0.6313	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	1/1:.:13:.:.:CONF=ZERO:13:11:T10[39.7]3[32.67] 	1/1:.:10:SBIASALT:.:.:9:8:C0[0]1[28];T9[39.67]0[0]     	1/1:0,17:17:.:57:CONF=ZERO:13:11:T10[39.7]3[32.67]     	0/1:1,10:11:SBIASALT:46:.:9:8:C0[0]1[28];T9[39.67]0[0]
+         */
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr1", "1654058", "rs61777495", "C", "T", ".", ".", "FLANK=CTTCATCGAAG;DP=17;FS=0.000;MQ=46.03;MQ0=0;QD=28.60;SOR=4.294;IN=1,2;DB;VLD;VAF=0.6313"
+                , "GT:AD:DP:FT:GQ:INF:NNS:OABS"
+                , "1/1:0,13:13:.:.:.:11:T10[39.7]3[32.67]"
+                , "1/1:1,9:10:.:.:.:8:C0[0]1[28];T9[39.67]0[0]"
+                , "1/1:0,17:17:.:57:.:.:."
+                , "0/1:1,10:11:.:46:.:.:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("SBIASALT", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged5() {
+        /*
+         * chr1   	22332008       	rs56968853     	T      	C      	.      	.      	FLANK=CCCGACTGGGT;BaseQRankSum=-2.031;ClippingRankSum=-0.750;DP=39;FS=11.226;MQ=56.26;MQ0=0;MQRankSum=-4.117;QD=1.40;ReadPosRankSum=-0.457;SOR=1.429;IN=1,2;DB;EFF=synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|121|CELA3A|protein_coding|CODING|ENST00000374663|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|5|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|2|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|7|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|8|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|6|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|4|1),sequence_feature[disulfide_bond](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),upstream_gene_variant(MODIFIER||1935||75|CELA3A|protein_coding|CODING|ENST00000400271||1|WARNING_TRANSCRIPT_NO_START_CODON),upstream_gene_variant(MODIFIER||1647|||RN7SL768P|misc_RNA|NON_CODING|ENST00000584415||1)     	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	0/1:.:64:.:.:CONF=HIGH:7:7:C2[34]5[34.8];T41[33.2]16[35.19]    	0/1:.:39:.:.:.:7:7:C2[35]5[34];T23[33.39]9[35.44]      	0/0:.:57:MIN:.:SOMATIC;GERM=49,185:.:.:C2[34]5[34.8];T41[33.2]16[35.19]	0/1:32,7:39:.:83:SOMATIC;GERM=49,185;CONF=HIGH:7:7:C2[35]5[34];T23[33.39]9[35.44]
+         */
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr1", "22332008", "rs56968853", "T", "C", ".", ".", "FLANK=CCCGACTGGGT;BaseQRankSum=-2.031;ClippingRankSum=-0.750;DP=39;FS=11.226;MQ=56.26;MQ0=0;MQRankSum=-4.117;QD=1.40;ReadPosRankSum=-0.457;SOR=1.429;IN=1,2;DB;EFF=synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),synonymous_variant(LOW|SILENT|gaT/gaC|p.Asp66Asp/c.198T>C|121|CELA3A|protein_coding|CODING|ENST00000374663|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|5|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|2|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|7|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|8|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|6|1),sequence_feature[domain:Peptidase_S1](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|4|1),sequence_feature[disulfide_bond](LOW|||c.198T>C|270|CELA3A|protein_coding|CODING|ENST00000290122|3|1),upstream_gene_variant(MODIFIER||1935||75|CELA3A|protein_coding|CODING|ENST00000400271||1|WARNING_TRANSCRIPT_NO_START_CODON),upstream_gene_variant(MODIFIER||1647|||RN7SL768P|misc_RNA|NON_CODING|ENST00000584415||1)"
+                , "GT:AD:DP:FT:GQ:INF:NNS:OABS"
+                , "0/1:57,7:64:.:.:.:7:C2[34]5[34.8];T41[33.2]16[35.19]"
+                , "0/1:32,7:39:.:.:.:7:C2[35]5[34];T23[33.39]9[35.44]"
+                , "0/0:.:.:.:.:NCIG:.:."
+                , "0/1:32,7:39:.:83:SOMATIC;GERM=49,185:.:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged6() {
+        /*
+         * COVN12 filter in normal needs to affect the somatic confidence
+         *
+         * chr1   	176992676      	rs10798496     	C      	T      	.      	.      	FLANK=TCCAGTTGGCT;BaseQRankSum=0.851;ClippingRankSum=0.676;DP=10;FS=0.000;MQ=60.00;MQ0=0;MQRankSum=0.336;QD=14.78;ReadPosRankSum=-0.336;SOR=0.250;IN=1,2;DB;VLD;VAF=0.2466	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	0/0:.:8:COVN12:.:SOMATIC;GERM=117,185:.:.:C0[0]8[39.62]	0/1:.:10:.:.:SOMATIC;GERM=117,185;CONF=HIGH:5:5:C1[32]4[35.5];T2[34]3[38]      	0/0:.:8:COVN12:.:SOMATIC;GERM=117,185:.:.:C0[0]8[39.62]	0/1:5,5:10:.:99:SOMATIC;GERM=117,185;CONF=HIGH:5:5:C1[32]4[35.5];T2[34]3[38]
+         */
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr1", "176992676", "rs10798496", "C", "T", ".", ".", "FLANK=TCCAGTTGGCT"
+                , "GT:AD:DP:FT:GQ:INF:NNS:OABS"
+                , "0/0:8:8:.:.:GERM=117,185:.:C0[0]8[39.62"
+                , "0/1:5,5:10:.:.:SOMATIC;GERM=117,185:5:C1[32]4[35.5];T2[34]3[38]"
+                , "0/0:.:.:.:.:NCIG:.:."
+                , "0/1:5,5:10:.:99:SOMATIC;GERM=117,185:.:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged7() {
+        /*
+         * SAN3 filter in normal needs to affect the somatic confidence
+         * chr5   	101570491      	rs4703217      	A      	G      	.      	.      	FLANK=GACAAGGAAAG;BaseQRankSum=1.262;ClippingRankSum=1.926;DP=19;FS=0.000;MQ=50.85;MQ0=0;MQRankSum=-2.192;QD=29.86;ReadPosRankSum=-0.332;SOR=1.061;IN=1,2;DB;VLD;VAF=0.1832;EFF=synonymous_variant(LOW|SILENT|aaA/aaG|p.Lys15Lys/c.45A>G|90|AC008948.1|protein_coding|CODING|ENST00000597120|1|1),3_prime_UTR_variant(MODIFIER||2071|c.*2071T>C|724|SLCO4C1|protein_coding|CODING|ENST00000310954|13|1)	GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	.:.:.:.:.:SOMATIC;GERM=11,185:.:.:.    	1/1:.:19:.:.:SOMATIC;GERM=11,185;CONF=HIGH:17:17:A1[39]1[39];G7[37.43]10[38.4] 	.:.:.:SAN3:.:SOMATIC;GERM=11,185:.:.:. 	1/1:2,17:19:.:8:SOMATIC;GERM=11,185;CONF=HIGH:17:17:A1[39]1[39];G7[37.43]10[38.4]
+         */
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr5", "101570491", "rs4703217", "A", "G", ".", ".", "FLANK=GACAAGGAAAG;BaseQRankSum=1.262;ClippingRankSum=1.926;DP=19;FS=0.000;MQ=50.85;MQ0=0;MQRankSum=-2.192;QD=29.86;ReadPosRankSum=-0.332;SOR=1.061;IN=1,2;DB;VLD;VAF=0.1832;EFF=synonymous_variant(LOW|SILENT|aaA/aaG|p.Lys15Lys/c.45A>G|90|AC008948.1|protein_coding|CODING|ENST00000597120|1|1),3_prime_UTR_variant(MODIFIER||2071|c.*2071T>C|724|SLCO4C1|protein_coding|CODING|ENST00000310954|13|1)"
+                , "GT:AD:DP:FT:GQ:INF:NNS:OABS"
+                , "./.:.:0:.:.:SOMATIC;GERM=11,185:.:."
+                , "1/1:2,17:19:.:.:SOMATIC;GERM=11,185:17:A1[39]1[39];G7[37.43]10[38.4]"
+                , "0/0:.:.:.:.:NCIG:.:."
+                , "1/1:2,17:19:.:8:SOMATIC;GERM=11,185:.:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("COV", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged8() {
+        /*
+         * MIUN filter in normal needs to affect the somatic confidence
+         * chr11  	1016978	rs76461263     	T      	G      	.      	.      	FLANK=GTGTGGTTGGG		GT:AD:DP:FT:GQ:INF:MR:NNS:OABS 	0/0:.:63:MIUN:.:SOMATIC;GERM=40,185:.:.:G1[40]0[0];T35[33.11]27[35.33] 	0/1:.:69:.:.:SOMATIC;GERM=40,185;CONF=HIGH:7:5:G1[35]6[39.67];T32[32.12]30[36] 	0/0:.:62:.:.:SOMATIC;GERM=40,185:.:.:G1[40]0[0];T35[33.11]27[35.33]    	0/1:58,15:73:.:99:SOMATIC;GERM=40,185;CONF=HIGH:7:5:G1[35]6[39.67];T32[32.12]30[36]
+         */
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr11", "1016978", "rs76461263", "T", "G", ".", ".", "FLANK=GTGTGGTTGGG"
+                , "GT:AD:DP:FT:GQ:INF:NNS:OABS"
+                , "0/0:62,1:63:.:.:.;GERM=40,185:.:G1[40]0[0];T35[33.11]27[35.33]"
+                , "0/1:62,7:69:.:.:SOMATIC;GERM=40,185:5:G1[35]6[39.67];T32[32.12]30[36]"
+                , "0/0:.:.:.:.:NCIG:.:."
+                , "0/1:58,15:73:.:99:SOMATIC;GERM=40,185:.:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("PASS", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void confidenceRealLifeMerged9() {
+        /*
+         * COVN8 filter in normal needs to affect the somatic confidence
+         * chr17  	42254527       	rs7217858      	T      	G      	.      	.      	FLANK=AGGACGCCCCC
+         */
+        //now try the merged record
+        VcfRecord vcf = new VcfRecord(new String[]{"chr17", "42254527", "rs7217858", "T", "G", ".", ".", "FLANK=AGGACGCCCCC"
+                , "GT:AD:DP:FT:GQ:INF:NNS:OABS"
+                , "0/0:3:3:.:.:SOMATIC;GERM=30,185:.:T2[35]1[35]"
+                , "1/1:1,11:12:.:.:SOMATIC;GERM=30,185:10:G5[33.6]6[35.67];T0[0]1[38]"
+                , "0/0:.:.:.:.:NCIG:.:."
+                , "0/1:1,11:12:.:7:SOMATIC;GERM=30,185:.:."});
+        ConfidenceMode cm = new ConfidenceMode();
+        cm.positionRecordMap.put(vcf.getChrPosition(), List.of(vcf));
+        cm.addAnnotation();
+
+        vcf = cm.positionRecordMap.get(vcf.getChrPosition()).getFirst();
+        assertEquals("COV", vcf.getSampleFormatRecord(1).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(2).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(3).getField(VcfHeaderUtils.FORMAT_FILTER));
+        assertEquals("PASS", vcf.getSampleFormatRecord(4).getField(VcfHeaderUtils.FORMAT_FILTER));
+    }
+
+    @Test
+    public void applyMRFilter() {
+        assertFalse(ConfidenceMode.applyMutantReadFilter(null, null, -1));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{}, "", -1));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{0, 0}, ".", -1));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{0, 0}, "0", -1));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{0, 0}, "10", 5));
+        assertTrue(ConfidenceMode.applyMutantReadFilter(new int[]{0, 1}, "10,0", 5));
+        assertTrue(ConfidenceMode.applyMutantReadFilter(new int[]{0, 1}, "10,4", 5));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{0, 1}, "10,5", 5));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{0, 1}, "4,5", 5));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{1, 1}, "10,5", 5));
+        assertTrue(ConfidenceMode.applyMutantReadFilter(new int[]{1, 1}, "10,4", 5));
+        assertTrue(ConfidenceMode.applyMutantReadFilter(new int[]{1, 1}, "10,4,5", 5));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{1, 2}, "10,5,5", 5));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{1, 2}, "0,5,5", 5));
+        assertTrue(ConfidenceMode.applyMutantReadFilter(new int[]{1, 2}, "10,5,4", 5));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{2, 2}, "10,5,6", 5));
+        assertFalse(ConfidenceMode.applyMutantReadFilter(new int[]{2, 2}, "10,4,5", 5));
+    }
+
+    @Test
+    public void covFromFF() {
+        assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString(null));
+        assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString(""));
+        assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString("."));
+        assertEquals(0, ConfidenceMode.getCoverageFromFailedFilterString("A0"));
+        assertEquals(1, ConfidenceMode.getCoverageFromFailedFilterString("A1"));
+        assertEquals(10, ConfidenceMode.getCoverageFromFailedFilterString("A10"));
+        assertEquals(100, ConfidenceMode.getCoverageFromFailedFilterString("A100"));
+        assertEquals(101, ConfidenceMode.getCoverageFromFailedFilterString("A100;B1"));
+        assertEquals(110, ConfidenceMode.getCoverageFromFailedFilterString("A100;B10"));
+        assertEquals(113, ConfidenceMode.getCoverageFromFailedFilterString("A100;B10;X3"));
+        // alts of more than 1 base too
+        assertEquals(1, ConfidenceMode.getCoverageFromFailedFilterString("AA1"));
+        assertEquals(2, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1"));
+        assertEquals(107, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1;CAB105"));
+        assertEquals(127, ConfidenceMode.getCoverageFromFailedFilterString("AA1;B1;CAB105;H20"));
+    }
 }

--- a/qannotate/test/au/edu/qimr/qannotate/modes/HomopolymersModeTest.java
+++ b/qannotate/test/au/edu/qimr/qannotate/modes/HomopolymersModeTest.java
@@ -39,7 +39,7 @@ public class HomopolymersModeTest {
 		byte[][] actualResult = HomopolymersMode.getReferenceBase(reference, pos, type, homopolymerWindow);
 
 		// Create our expected result
-		byte[][] expectedResult = new byte[][] {"ATTA".getBytes(), "CA".getBytes()};
+		byte[][] expectedResult = new byte[][] {"G".getBytes(), "TT".getBytes()};
 
 		// Assertion
 		assertArrayEquals(expectedResult, actualResult);


### PR DESCRIPTION
# Description

`qannotate's` `ConfidenceMode` was using a hard-coded value to determine if the `HOM` annotation should be applied to the filter field.
This PR allows the user to specify the homopolymer cutoff (via the `homCutoff` option), with the default value being the same as the previous hard-coded value.
This should mean that if you run the code as you would normally, then you will get identical results as before.
If you run with the `homCutoff` value set to something other than the default, you will get different results.

Some formatting has also been performed, and removal of user specific details from `qannotate's` `build.gradle` file.



## Type of change


- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Unit tests pass. Code has been run against vcf file, and results verified.

# Are WDL Updates Required?

No, assuming that the current defaults are acceptable, yes otherwise

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
