### PR TITLE
fix(qsv): qsv can now write CRAM files internally

### DIFF
--- a/q3tiledaligner/src/au/edu/qimr/tiledaligner/ReadTiledAligerFile.java
+++ b/q3tiledaligner/src/au/edu/qimr/tiledaligner/ReadTiledAligerFile.java
@@ -26,13 +26,13 @@ import gnu.trove.map.hash.TIntObjectHashMap;
 
 public class ReadTiledAligerFile {
 	
-	private static TIntObjectMap<int[]> map = TCollections.synchronizedMap(new TIntObjectHashMap<>(1024 * 8));
+	private static final TIntObjectMap<int[]> map = TCollections.synchronizedMap(new TIntObjectHashMap<>(1024 * 8));
 	
 	public static void getTiledDataInMap(String tiledAlignerFile, int bufferSize) throws IOException {
 		getTiledDataInMap(tiledAlignerFile, bufferSize, 1);
 	}
 	
-	public static void getTiledDataInMap(String tiledAlignerFile, int bufferSize, int threadPoolSize) throws IOException {
+	public static void getTiledDataInMap(String tiledAlignerFile, int bufferSize, int threadPoolSize) {
 		
 		AbstractQueue<String> queue = new LinkedBlockingQueue<>();
 		AtomicBoolean hasReaderFinished = new AtomicBoolean(false);
@@ -68,7 +68,7 @@ public class ReadTiledAligerFile {
 	}
 	
 	static class Worker implements Runnable {
-		private AbstractQueue<String> queue;
+		private final AbstractQueue<String> queue;
 		AtomicBoolean hasReaderFinished;
 		public Worker(AbstractQueue<String> queue, AtomicBoolean hasReaderFinished) {
 			this.queue = queue;
@@ -83,7 +83,7 @@ public class ReadTiledAligerFile {
 				e.printStackTrace();
 			}
 			System.out.println("Worker started...");
-			String s = null;
+			String s;
 			int invalidCount = 0;
 			while ( ! ((s = queue.poll()) == null && hasReaderFinished.get())) {
 				if (null != s) {
@@ -104,11 +104,7 @@ public class ReadTiledAligerFile {
 			System.out.println("Worker has finished! invalidCount: " + invalidCount + ", map size: " + map.size());
 		}
 	}
-	
-	public static TIntObjectMap<int[]> getCache(String tiledAlignerFile, int bufferSize) throws IOException {
-		return getCache(tiledAlignerFile, bufferSize, 1);
-	}
-	
+
 	public static TIntObjectMap<int[]> getCache(String tiledAlignerFile, int bufferSize, int threadCount) throws IOException {
 		if (map.isEmpty()) {
 			getTiledDataInMap(tiledAlignerFile, bufferSize, threadCount);

--- a/qpicard/src/org/qcmg/picard/SAMFileReaderFactory.java
+++ b/qpicard/src/org/qcmg/picard/SAMFileReaderFactory.java
@@ -74,7 +74,7 @@ public class SAMFileReaderFactory {
 				logger.info("setup index: " + index.getAbsolutePath());
 			}
 			//set reference file for cram. default reference set by java option "-Dsamjdk.REFERENCE_FASTA" 
-			if(reference != null && reference.exists()) {
+			if (reference != null && reference.exists()) {
 				factory.referenceSequence(reference); 
 				logger.info("setup reference: " + reference.getAbsolutePath());
 			}			

--- a/qsv/src/org/qcmg/qsv/QSVPipeline.java
+++ b/qsv/src/org/qcmg/qsv/QSVPipeline.java
@@ -274,7 +274,7 @@ public class QSVPipeline {
 			 */
 			logger.info("waiting for tiled aligner");
 			TILED_ALIGNER_CACHE = future.get();
-			logger.info("waiting for tiled aligner - DONE");
+			logger.info("waiting for tiled aligner - DONE, size: " + TILED_ALIGNER_CACHE.size());
 			
 			findSoftClips(); 
 			logger.info(QSVUtil.writeTime("Soft clip clustering time: ", pairsDate, new Date()));

--- a/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
+++ b/qsv/src/org/qcmg/qsv/annotate/AnnotateFilterMT.java
@@ -1,7 +1,7 @@
 /**
  * © Copyright The University of Queensland 2010-2014.
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
  */
 package org.qcmg.qsv.annotate;
@@ -12,6 +12,7 @@ import java.io.FileWriter;
 import java.util.AbstractQueue;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -20,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import htsjdk.samtools.*;
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.ReferenceNameComparator;
@@ -27,6 +29,7 @@ import org.qcmg.common.string.StringUtils;
 import org.qcmg.common.util.Constants;
 import org.qcmg.picard.HeaderUtils;
 import org.qcmg.picard.SAMFileReaderFactory;
+import org.qcmg.picard.SAMWriterFactory;
 import org.qcmg.qbamfilter.query.QueryExecutor;
 import org.qcmg.qsv.Chromosome;
 import org.qcmg.qsv.Messages;
@@ -39,576 +42,578 @@ import org.qcmg.qsv.util.CustomThreadPoolExecutor;
 import org.qcmg.qsv.util.QSVConstants;
 import org.qcmg.qsv.util.QSVUtil;
 
-import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
-import htsjdk.samtools.SAMFileWriter;
-import htsjdk.samtools.SAMFileWriterFactory;
-import htsjdk.samtools.SAMReadGroupRecord;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMRecordIterator;
-import htsjdk.samtools.SamReader;
 
 /**
- * Class to annotate discordant read pairs and filter 
- * for high quality discordant pairs, clips and unmapped reads 
- *
+ * Class to annotate discordant read pairs and filter
+ * for high quality discordant pairs, clips and unmapped reads
  */
 public class AnnotateFilterMT implements Runnable {
-	
-	private static final int noOfThreads = 2;
-	private static final int maxRecords = 500000;
-	private static final int checkPoint = 100000;
 
-	private final QLogger logger = QLoggerFactory.getLogger(getClass());
-	private final int sleepUnit = 10;
-	private final File input;
-	private final File output;
-	private final String query;
-	private final QSVParameters parameters;
-	private final CountDownLatch mainLatch;
-	private final AtomicLong badRecordCount;
-	private final AtomicLong goodPairRecordCount = new AtomicLong(); 
-	private final AtomicInteger exitStatus;
-	private final File clippedFile;
-	private final SAMFileHeader queryNameHeader;
-	private final SAMFileHeader coordinateHeader;
-	private final String softClipDir;
-	private final String clipQuery;
-	private boolean runPair;
-	private boolean runClip;
-	private final boolean isSplitRead;
-	private final Collection<String> readGroupIds;
-	private final AtomicLong goodClipCount = new AtomicLong(); 
-	private final AtomicLong unmappedCount = new AtomicLong();
-	private final boolean translocationsOnly; 
+    private static final int noOfThreads = 2;
+    private static final int maxRecords = 500000;
+    private static final int checkPoint = 100000;
 
-
-
-	public AnnotateFilterMT(Thread mainThread, CountDownLatch countDownLatch, QSVParameters parameters, AtomicInteger exitStatus, String softclipDir, Options options) {
-		this.softClipDir = softclipDir;
-		this.query = options.getPairQuery();
-		this.clipQuery = options.getClipQuery();
-		logger.info("Mapper: " + parameters.getMapper());   
-		logger.info("Type of Annotation: " + parameters.getPairingType());
-		logger.info("QBamFilter Query to use is: " + this.query);
-
-		this.parameters = parameters;
-		this.input = parameters.getInputBamFile();
-		this.output = parameters.getFilteredBamFile();
-		this.queryNameHeader = parameters.getHeader().clone();
-		this.queryNameHeader.setSortOrder(SortOrder.queryname);
-		this.coordinateHeader = parameters.getHeader().clone();
-		this.coordinateHeader.setSortOrder(SortOrder.coordinate);     
-		this.readGroupIds = parameters.getReadGroupIds();
-		this.translocationsOnly = options.getIncludeTranslocations();         
-		this.mainLatch = countDownLatch;
-		this.badRecordCount = new AtomicLong();
-		this.exitStatus = exitStatus;
-		this.clippedFile = parameters.getClippedBamFile();
-		this.isSplitRead = options.isSplitRead();
-
-		if (options.getPreprocessMode().equals("both")) {
-			this.runClip = true;
-			this.runPair = true;
-		} else if (options.getPreprocessMode().equals("clip")) {
-			this.runClip = true;
-			this.runPair = false;
-		} else if (options.getPreprocessMode().equals("pair")) {
-			this.runClip = false;
-			this.runPair = true;
-		} else {
-			this.runClip = false;
-			this.runPair = false;
-		}
-	}
-
-	/**
-	 * Class entry point. Sets up read, write and annotating/filtering threads
-	 */
-	@Override
-	public void run() {
-
-		// create sorted queue to get the chromosomes to reads
-		final AbstractQueue<List<Chromosome>> readQueue = new ConcurrentLinkedQueue<>(parameters.getChromosomes()
-				.entrySet()
-				.stream()
-				.sorted((e1, e2) -> new ReferenceNameComparator().compare(e1.getKey(), e2.getKey()))
-				.map(e -> e.getValue())
-				.collect(Collectors.toList()));
-		
-		logger.info("readQueue setup with " + readQueue.size() + " lists of chromosomes");
-
-		// create queue to store the satisfied BAM records for discordant pairs
-		final AbstractQueue<SAMRecord> writeQueue = new ConcurrentLinkedQueue<SAMRecord>();
-
-		// create queue to store the satisfied BAM records for clips and unmapped reads
-		final AbstractQueue<SAMRecord> writeClipQueue = new ConcurrentLinkedQueue<SAMRecord>();
-
-		final CountDownLatch filterLatch = new CountDownLatch(noOfThreads); // annotating filtering threads
-		final CountDownLatch writeLatch = new CountDownLatch(2); // writing thread for satisfied records
-
-		// set up executor services
-		final ExecutorService filterThreads = new CustomThreadPoolExecutor(noOfThreads, exitStatus, logger);
-		final ExecutorService writeThreads = new CustomThreadPoolExecutor(2, exitStatus, logger);
-
-		try {
+    private final QLogger logger = QLoggerFactory.getLogger(getClass());
+    private final int sleepUnit = 10;
+    private final File input;
+    private final File output;
+    private final String query;
+    private final QSVParameters parameters;
+    private final CountDownLatch mainLatch;
+    private final AtomicLong badRecordCount;
+    private final AtomicLong goodPairRecordCount = new AtomicLong();
+    private final AtomicInteger exitStatus;
+    private final File clippedFile;
+    private final SAMFileHeader queryNameHeader;
+    private final SAMFileHeader coordinateHeader;
+    private final String softClipDir;
+    private final String clipQuery;
+    private final boolean runPair;
+    private final boolean runClip;
+    private final boolean isSplitRead;
+    private final Collection<String> readGroupIds;
+    private final AtomicLong goodClipCount = new AtomicLong();
+    private final AtomicLong unmappedCount = new AtomicLong();
+    private final boolean translocationsOnly;
 
 
-			// kick-off filtering thread
-			for (int i = 0; i < noOfThreads; i++) {
-				filterThreads.execute(new AnnotationFiltering(readQueue,
-						writeQueue, writeClipQueue, Thread.currentThread(),
-						filterLatch, writeLatch));
-			}
-			filterThreads.shutdown();
+    public AnnotateFilterMT(Thread mainThread, CountDownLatch countDownLatch, QSVParameters parameters, AtomicInteger exitStatus, String softclipDir, Options options) {
+        this.softClipDir = softclipDir;
+        this.query = options.getPairQuery();
+        this.clipQuery = options.getClipQuery();
+        logger.info("Mapper: " + parameters.getMapper());
+        logger.info("Type of Annotation: " + parameters.getPairingType());
+        logger.info("QBamFilter Query to use is: " + this.query);
 
-			//paired reads
-			writeThreads.execute(new Writing(writeQueue, output, Thread.currentThread(), filterLatch, writeLatch, queryNameHeader));
+        this.parameters = parameters;
+        this.input = parameters.getInputBamFile();
+        this.output = parameters.getFilteredBamFile();
+        this.queryNameHeader = parameters.getHeader().clone();
+        this.queryNameHeader.setSortOrder(SortOrder.queryname);
+        this.coordinateHeader = parameters.getHeader().clone();
+        this.coordinateHeader.setSortOrder(SortOrder.coordinate);
+        this.readGroupIds = parameters.getReadGroupIds();
+        this.translocationsOnly = options.getIncludeTranslocations();
+        this.mainLatch = countDownLatch;
+        this.badRecordCount = new AtomicLong();
+        this.exitStatus = exitStatus;
+        this.clippedFile = parameters.getClippedBamFile();
+        this.isSplitRead = options.isSplitRead();
 
-			//soft clips                
-			writeThreads.execute(new Writing(writeClipQueue, clippedFile, Thread.currentThread(), filterLatch, writeLatch, coordinateHeader));
-			writeThreads.shutdown();
+        switch (options.getPreprocessMode()) {
+            case "both" -> {
+                this.runClip = true;
+                this.runPair = true;
+            }
+            case "clip" -> {
+                this.runClip = true;
+                this.runPair = false;
+            }
+            case "pair" -> {
+                this.runClip = false;
+                this.runPair = true;
+            }
+            default -> {
+                this.runClip = false;
+                this.runPair = false;
+            }
+        }
+    }
 
-			logger.info("waiting for  threads to finish (max wait will be 100 hours)");
-			filterThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
-			writeThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+    /**
+     * Class entry point. Sets up read, write and annotating/filtering threads
+     */
+    @Override
+    public void run() {
 
-			if (readQueue.size() != 0 || writeQueue.size() != 0 || writeClipQueue.size() != 0) {
-				throw new Exception(
-						" threads have completed but queue isn't empty  (readQueue, writeQueue, writeClipQueue ):  "
-								+ readQueue.size() + ", " + writeQueue.size() +  "," + writeClipQueue.size());
-			}
-			logger.info("All threads finished");
+        // create sorted queue to get the chromosomes to reads
+        final AbstractQueue<List<Chromosome>> readQueue = parameters.getChromosomes()
+                .entrySet()
+                .stream()
+                .sorted((e1, e2) -> new ReferenceNameComparator().compare(e1.getKey(), e2.getKey()))
+                .map(Map.Entry::getValue).collect(Collectors.toCollection(ConcurrentLinkedQueue::new));
 
-			if (runPair && goodPairRecordCount.longValue() == 0) {
-				throw new QSVException("LOW_FILTER_COUNT", "discordant pair");
-			}
-			if (runClip && goodClipCount.longValue() == 0) {
-				throw new QSVException("LOW_FILTER_COUNT", "clip");
-			}
-			logger.info("Finished filtering file: " + input.getAbsolutePath() + " .Discordant Pair records: " + 
-					goodPairRecordCount.longValue() + "; Soft clip records: " + goodClipCount.longValue() + "; Unmapped records: " + unmappedCount.intValue() );
+        logger.info("readQueue setup with " + readQueue.size() + " lists of chromosomes");
 
-		} catch (final Exception e) {
+        // create queue to store the satisfied BAM records for discordant pairs
+        final AbstractQueue<SAMRecord> writeQueue = new ConcurrentLinkedQueue<>();
 
-			logger.error(QSVUtil.getStrackTrace(e));
-			if (exitStatus.intValue() == 0) {
-				exitStatus.incrementAndGet();
-			}
-		} finally {
-			// kill off any remaining threads            	
-			writeThreads.shutdownNow();
-			filterThreads.shutdownNow();
-			mainLatch.countDown();
-		}
-	}
+        // create queue to store the satisfied BAM records for clips and unmapped reads
+        final AbstractQueue<SAMRecord> writeClipQueue = new ConcurrentLinkedQueue<>();
 
-	public AtomicLong getClipCount() {
-		return goodClipCount;
-	}
+        final CountDownLatch filterLatch = new CountDownLatch(noOfThreads); // annotating filtering threads
+        final CountDownLatch writeLatch = new CountDownLatch(2); // writing thread for satisfied records
 
+        // set up executor services
+        final ExecutorService filterThreads = new CustomThreadPoolExecutor(noOfThreads, exitStatus, logger);
+        final ExecutorService writeThreads = new CustomThreadPoolExecutor(2, exitStatus, logger);
 
-	/**
-	 * Class to annotate and filter discordant pairs, clips and unmapped readsS
-	 *
-	 */
-	class AnnotationFiltering implements Runnable {
-
-		private final AbstractQueue<List<Chromosome>> queueIn;
-		private final AbstractQueue<SAMRecord> queueOutPair;
-		private final Thread mainThread;
-		private final CountDownLatch filterLatch;
-		private final CountDownLatch writeLatch;
-		private int countOutputSleep;
-		private final AbstractQueue<SAMRecord> queueOutClip;
-		QueryExecutor pairQueryEx ;
-		QueryExecutor lifescopeQueryEx;		
-		QueryExecutor clipQueryEx;
-
-
-		public AnnotationFiltering(AbstractQueue<List<Chromosome>> readQueue,
-				AbstractQueue<SAMRecord> writeQueue, AbstractQueue<SAMRecord> writeClipQueue, Thread mainThread,
-				CountDownLatch fLatch, CountDownLatch wGoodLatch) throws Exception {
-			this.queueIn = readQueue;
-			this.queueOutPair = writeQueue;
-			this.queueOutClip = writeClipQueue;
-			this.mainThread = mainThread;
-			this.filterLatch = fLatch;
-			this.writeLatch = wGoodLatch;
-			if (runPair && ! StringUtils.isNullOrEmpty(query)) {
-				pairQueryEx = new QueryExecutor(query);
-			}
-			if (runClip && ! StringUtils.isNullOrEmpty(clipQuery)) {
-			    clipQueryEx = new QueryExecutor(clipQuery);
-			}
-			if (parameters.getPairingType().equals("lmp") && parameters.getMapper().equals("bioscope")) {
-				lifescopeQueryEx = new QueryExecutor("and(Cigar_M > 35, MD_mismatch < 3, MAPQ > 0, flag_DuplicateRead == false)");
-			}
-		}
-
-		@Override
-		public void run() {
-
-			int sleepcount = 0;
-			countOutputSleep = 0;
-			boolean run = true;
-
-			try {
-
-				List<Chromosome> chromosomes = null;
-				while (run) {
-					chromosomes = queueIn.poll();               
-
-					if (chromosomes == null) {
-						run = false;
-					} else {
-						// pass the record to filter and then to output queue                    	
-						for (final Chromosome chromosome: chromosomes) {
-							logger.info("Reading records from chromosome: " + chromosome.getName() + " in sample " + parameters.getFindType());
-
-							BufferedWriter writer = null;
-
-							//set up writer to write clips to txt file
-							if (runClip) {
-								writer = new BufferedWriter(new FileWriter(new File(SoftClipStaticMethods.getSoftClipFile(chromosome.getName(), parameters.getFindType(), softClipDir)), true));
-							}
-
-							//write reads
-							run = readAndWriteData(writer, chromosome, chromosome.getStartPosition(), chromosome.getEndPosition());	
-
-							if (runClip) {
-								writer.close();
-							}
-						}
-					} // end else
-				}// end while
-				logger.info("Completed filtering thread: " + Thread.currentThread().getName());
-
-			} catch (final Exception e) {
-				logger.error("Setting exit status in annotation thread to 1 as exception caught: " + QSVUtil.getStrackTrace(e));
-				if (exitStatus.intValue() == 0) {
-					exitStatus.incrementAndGet();
-				}
-				mainThread.interrupt();
-			} finally {
-
-				logger.debug(String
-						.format(" total slept %d times since input queue is empty and %d time since either output queue is full. each sleep take %d mill-second. queue size for qIn, qOutGood and qOutBad are %d, %d",
-								sleepcount, countOutputSleep, sleepUnit,
-								queueIn.size(), queueOutPair.size()));
-				filterLatch.countDown();
-			}
-		}
-
-		private boolean readAndWriteData(BufferedWriter writer, Chromosome chromosome, int startPos, int endPos) throws Exception {        	
-
-			boolean result = true;
-			
-			try ( SamReader reader = SAMFileReaderFactory.createSAMFileReader(input, "silent");) {
-				int queryStart = startPos - 100;
-				if (queryStart <= 0) {
-					queryStart = 1;
-				}
-				final int queryEnd = endPos + 100;
-				//get reads from bam
-				final SAMRecordIterator iter = reader.queryOverlapping(chromosome.getName(), queryStart, queryEnd);
-	
-				int count = 0;
-				int shortReadCount = 0;
-	
-				while (iter.hasNext()) {
-					final SAMRecord record = iter.next();
-					count++;
-					boolean writersResult = true;
-					boolean pileupResult = true;
-					
-					/*
-					 * only proceed with records that have sequence > QSVAssemble_SEED_LENGTH
-					 */
-					if (record.getReadLength() > QSVAssemble.SEED_LENGTH) {
-	
-						final SAMReadGroupRecord srgr = record.getReadGroup();
-						if (null != srgr 
-								&& null != srgr.getId() 
-								&& readGroupIds.contains(srgr.getId())) {
-		
-							//discordant pairs
-							if (runPair && record.getAlignmentStart() >= startPos && record.getAlignmentStart() <= endPos) {
-								writersResult = addToPairWriter(record, srgr.getId(), count);
-							}
-		
-							if (runClip) {
-								//soft clips
-								if (( ! record.getReadUnmappedFlag() && ! record.getDuplicateReadFlag() && record.getCigarString().contains("S"))
-										|| (isSplitRead && record.getReadUnmappedFlag()) ) {
-									
-									pileupResult = pileupSoftClips(writer, record, srgr.getId(), startPos, endPos, chromosome, count);
-								}
-							}
-		
-							//check to make sure there aren't any errors
-							if ( ! pileupResult || ! writersResult) {
-								if ( ! pileupResult) {	            		
-									logger.error("Error finding soft clip records in " + chromosome.toString());
-								}
-								if ( ! writersResult) {
-									logger.error("Error finding discordant read records in " + chromosome.toString());
-								}
-		
-								if (exitStatus.intValue() == 0) {
-									exitStatus.incrementAndGet();
-								}
-								result =  false;
-							}
-						} else {
-							logger.warn("SAMReadGroupRecord : " + srgr + ":" + record.getSAMString());
-							logger.warn("SAMReadGroupRecord was null, or id was not in collection: " + (null != srgr ? srgr.getId() : null) + ":" + record.getSAMString());
-							throw new Exception("Null SAMReadGroupRecord");
-						}
-					} else {
-						shortReadCount++;
-					}
-				}
-				if (shortReadCount > 0) {
-					logger.warn("Ignored " + shortReadCount + " reads that had read length < " + QSVAssemble.SEED_LENGTH);
-				}
-			}
-
-			return result; 
-		}        
-
-		/*
-		 * write soft clips and unmapped reads
-		 */
-		private boolean pileupSoftClips(BufferedWriter writer, SAMRecord record, String rgId, int start, int end, Chromosome chromosome, int count) throws Exception {
-			if (record.getReadUnmappedFlag()) {
-				unmappedCount.incrementAndGet();
-				QSVUtil.writeUnmappedRecord(writer, record, rgId, start, end, parameters.isTumor());						
-				return add2queue(record, queueOutClip, count);
-			}
+        try {
 
 
-			//see if clips pass the filter
-			if (clipQueryEx.Execute(record)) {
-				goodClipCount.incrementAndGet();
-				SoftClipStaticMethods.writeSoftClipRecord(writer, record, rgId, start, end, chromosome.getName());    			
-				return add2queue(record, queueOutClip, count);
-			} else {
-				return true;
-			}			
-		}
+            // kick-off filtering thread
+            for (int i = 0; i < noOfThreads; i++) {
+                filterThreads.execute(new AnnotationFiltering(readQueue,
+                        writeQueue, writeClipQueue, Thread.currentThread(),
+                        filterLatch, writeLatch));
+            }
+            filterThreads.shutdown();
 
-		/*
-		 * Write discordant pairs to bam
-		 */
-		private boolean addToPairWriter(SAMRecord record, String rgId, int count) throws Exception {
+            //paired reads
+            writeThreads.execute(new Writing(writeQueue, output, Thread.currentThread(), filterLatch, writeLatch, queryNameHeader));
 
-			if ( ! record.getReadUnmappedFlag()) {
-				
-				if ( ! translocationsOnly || QSVUtil.isTranslocationPair(record)) {
+            //soft clips
+            writeThreads.execute(new Writing(writeClipQueue, clippedFile, Thread.currentThread(), filterLatch, writeLatch, coordinateHeader));
+            writeThreads.shutdown();
 
-					//annotate the read
-					parameters.getAnnotator().annotate(record, rgId);
-					final String zp = (String) record.getAttribute(QSVConstants.ZP_SHORT);
+            logger.info("waiting for  threads to finish (max wait will be 100 hours)");
+            filterThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
+            writeThreads.awaitTermination(Constants.EXECUTOR_SERVICE_AWAIT_TERMINATION, TimeUnit.HOURS);
 
-					//make sure it is discordant
-					if (zp.contains("A") || zp.equals("C**") || zp.contains("B")) {
-						if ( ! zp.equals(QSVConstants.AAA)) {
-							//check if it passes the filter
-							if (pairQueryEx.Execute(record)) {
-								goodPairRecordCount.incrementAndGet();                 		    
-								return add2queue(record, queueOutPair, count, writeLatch);			                                
-							} else {
-								Object xc = record.getAttribute("XC");
-								if (lifescopeQueryEx != null && record.getAttribute("SM") == null && xc != null) {
-									//try to filter lifescope reads
-									if (lifescopeQueryEx.Execute(record)) {
-										goodPairRecordCount.incrementAndGet();
-										return add2queue(record, queueOutPair, count, writeLatch);
-									} else {
-										record.setAttribute(QSVConstants.ZP, xc);
-										if (lifescopeQueryEx.Execute(record)) {
-											return add2queue(record, queueOutPair, count, writeLatch);
-										}
-									}
-									badRecordCount.incrementAndGet();
-								} else {
-									badRecordCount.incrementAndGet();
-								}
-							}
-						} 	               	
-					}
-				}
-			}
-			return true;
-		}
-		
-		private boolean add2queue(SAMRecord re, AbstractQueue<SAMRecord> queue, int count) {
-			return add2queue(re, queue, count, null);
-		}
+            if (!readQueue.isEmpty() || !writeQueue.isEmpty() || !writeClipQueue.isEmpty()) {
+                throw new Exception(
+                        " threads have completed but queue isn't empty  (readQueue, writeQueue, writeClipQueue ):  "
+                                + readQueue.size() + ", " + writeQueue.size() + "," + writeClipQueue.size());
+            }
+            logger.info("All threads finished");
 
-		//add to write queue
-		private boolean add2queue(SAMRecord re, AbstractQueue<SAMRecord> queue,	int count, CountDownLatch latch) {
-			// check queue size in each checkPoint number
-			if (count % checkPoint == 0) {
-				// check mainThread
-				if ( ! mainThread.isAlive()) {
-					logger.error("mainThread died: " + mainThread.getName());
-					return false;
-				}
-				// check queue size
-				while (queue.size() >= maxRecords) {
-					try {
-						Thread.sleep(sleepUnit);
-						countOutputSleep++;
-					} catch (final InterruptedException e) {
-						logger.info(Thread.currentThread().getName() + " "
-								+ QSVUtil.getStrackTrace(e) + " (queue size full) ");
-					}
-					if (null != latch && latch.getCount() == 0) {
-						logger.error("output queue is not empty but writing thread are completed");
-						return false;
-					}
-				} // end while
-			}
+            if (runPair && goodPairRecordCount.longValue() == 0) {
+                throw new QSVException("LOW_FILTER_COUNT", "discordant pair");
+            }
+            if (runClip && goodClipCount.longValue() == 0) {
+                throw new QSVException("LOW_FILTER_COUNT", "clip");
+            }
+            logger.info("Finished filtering file: " + input.getAbsolutePath() + " .Discordant Pair records: " +
+                    goodPairRecordCount.longValue() + "; Soft clip records: " + goodClipCount.longValue() + "; Unmapped records: " + unmappedCount.intValue());
 
-			return queue.add(re);
-		}
-	}
+        } catch (final Exception e) {
 
-	/**
-	 * Class to write discordant pairs, clips and unmapped reads to file
-	 */
-	private class Writing implements Runnable {
-		private final File file;
-		private final AbstractQueue<SAMRecord> queue;
-		private final Thread mainThread;
-		private final CountDownLatch filterLatch;
-		private final CountDownLatch writeLatch;
-		private final SAMFileHeader header;
+            logger.error(QSVUtil.getStrackTrace(e));
+            if (exitStatus.intValue() == 0) {
+                exitStatus.incrementAndGet();
+            }
+        } finally {
+            // kill off any remaining threads
+            writeThreads.shutdownNow();
+            filterThreads.shutdownNow();
+            mainLatch.countDown();
+        }
+    }
 
-		public Writing(AbstractQueue<SAMRecord> q, File f, Thread mainThread,
-				CountDownLatch fLatch, CountDownLatch wLatch,SAMFileHeader header) {
-			queue = q;
-			file = f;
-			this.mainThread = mainThread;
-			this.filterLatch = fLatch;
-			this.writeLatch = wLatch;
-			this.header = header;
-		}
-
-		@Override
-		public void run() {        	
-			int countSleep = 0;
-			boolean run = true;
-			logger.info("Started Writing thread with output file: " + file);
-			try {
-				int count = 0;
-				if (file != null) {
-					final String commandLine = query;
-					HeaderUtils.addProgramRecord(header, "qsv",	Messages.getVersionMessage(), commandLine);
-					final SAMFileWriterFactory writeFactory = new SAMFileWriterFactory();
-					if (header.getSortOrder().equals(SortOrder.coordinate)) {
-						writeFactory.setCreateIndex(true);
-					}
-					// there is a bug at current version, cause an exception but we
-					// can use below static method
-					htsjdk.samtools.SAMFileWriterImpl.setDefaultMaxRecordsInRam(maxRecords);
+    public AtomicLong getClipCount() {
+        return goodClipCount;
+    }
 
 
-					// debug
-					
-					/*
-					 * We want the temp bam files to go to our temp folder rather than the default
-					 * Set this at the factory level before creating writers
-					 */
-					writeFactory.setTempDirectory(file.getParentFile());
-					
-					
-					final SAMFileWriter writer = writeFactory.makeBAMWriter(header, false, file, 1);
-					
-					logger.info("all tmp BAMs are located on " + file.getParentFile().getCanonicalPath());
-					logger.info("default maxRecordsInRam " + htsjdk.samtools.SAMFileWriterImpl.getDefaultMaxRecordsInRam());
+    /**
+     * Class to annotate and filter discordant pairs, clips and unmapped readsS
+     */
+    class AnnotationFiltering implements Runnable {
 
-					SAMRecord record;
-					try {
-						while (run) {
-							// when queue is empty,maybe filtering is done
-							if ((record = queue.poll()) == null) {
-	
-								try {
-									Thread.sleep(sleepUnit);
-									countSleep++;
-								} catch (final Exception e) {
-									logger.info(Thread.currentThread().getName() + " "
-											+ QSVUtil.getStrackTrace(e));
-								}
-	
-								if ((count % checkPoint == 0) && (!mainThread.isAlive())) {
-									throw new Exception("Writing thread failed since parent thread died.");
-								}
-	
-								while (queue.size() >= maxRecords) {
-									try {
-										Thread.sleep(sleepUnit);
-										countSleep++;
-									} catch (final Exception e) {
-										logger.info(Thread.currentThread().getName() + " " + QSVUtil.getStrackTrace(e));
-									}
-								}
-	
-								if (filterLatch.getCount() == 0) {
-									/*
-									 * the queue could have been added to since our last check (we did have a quick sleep after all
-									 * Check size again before pulling the plug
-									 */
-									if (queue.isEmpty()) {
-										run = false;
-									}
-								}
-	
-							} else {
-	
-								writer.addAlignment(record);
-								count++;
-								
-								if (count % 1000000 == 0) {
-									logger.info("have written " + count + " SAMRecords to file, queue size: " + queue.size());
-								}
-							}
-						}
-					} catch (Exception e) {
-						logger.error("Exception caught whilst writing SAMRecords to bam file: " + file.getAbsolutePath() + " : " + QSVUtil.getStrackTrace(e));
-						throw e;
-					} finally {
-						writer.close();
-					}
-				}
-				if (!mainThread.isAlive()) {
-					throw new Exception(
-							"Writing thread failed since parent thread died.");
-				} else {
-					if (file != null) {
-						logger.info("Completed writing thread, added " + count
-								+ " records to the output: "
-								+ file.getAbsolutePath());
-						logger.info("Record count not passing filter for the "
-								+ parameters.getFindType() + " sample is "
-								+ badRecordCount.longValue());
-					}
-				}
-			} catch (final Exception e) {
-				logger.error("Setting exit status to 1 as exception caught in writing thread: " + QSVUtil.getStrackTrace(e));
-				if (exitStatus.intValue() == 0) {
-					exitStatus.incrementAndGet();
-				}
-				mainThread.interrupt();
-			} finally {
-				writeLatch.countDown();
-				logger.info("Exit Writing thread, total " + countSleep
-						+ " times get null from writing queue.");
-			}
-		}
-	}
+        private final AbstractQueue<List<Chromosome>> queueIn;
+        private final AbstractQueue<SAMRecord> queueOutPair;
+        private final Thread mainThread;
+        private final CountDownLatch filterLatch;
+        private final CountDownLatch writeLatch;
+        private int countOutputSleep;
+        private final AbstractQueue<SAMRecord> queueOutClip;
+        QueryExecutor pairQueryEx;
+        QueryExecutor lifescopeQueryEx;
+        QueryExecutor clipQueryEx;
+
+
+        public AnnotationFiltering(AbstractQueue<List<Chromosome>> readQueue,
+                                   AbstractQueue<SAMRecord> writeQueue, AbstractQueue<SAMRecord> writeClipQueue, Thread mainThread,
+                                   CountDownLatch fLatch, CountDownLatch wGoodLatch) throws Exception {
+            this.queueIn = readQueue;
+            this.queueOutPair = writeQueue;
+            this.queueOutClip = writeClipQueue;
+            this.mainThread = mainThread;
+            this.filterLatch = fLatch;
+            this.writeLatch = wGoodLatch;
+            if (runPair && !StringUtils.isNullOrEmpty(query)) {
+                pairQueryEx = new QueryExecutor(query);
+            }
+            if (runClip && !StringUtils.isNullOrEmpty(clipQuery)) {
+                clipQueryEx = new QueryExecutor(clipQuery);
+            }
+            if (parameters.getPairingType().equals("lmp") && parameters.getMapper().equals("bioscope")) {
+                lifescopeQueryEx = new QueryExecutor("and(Cigar_M > 35, MD_mismatch < 3, MAPQ > 0, flag_DuplicateRead == false)");
+            }
+        }
+
+        @Override
+        public void run() {
+
+            int sleepcount = 0;
+            countOutputSleep = 0;
+            boolean run = true;
+
+            try (SamReader reader = SAMFileReaderFactory.createSAMFileReader(input, "silent")){
+
+                List<Chromosome> chromosomes;
+                while (run) {
+                    chromosomes = queueIn.poll();
+
+                    if (chromosomes == null) {
+                        run = false;
+                    } else {
+                        // pass the record to filter and then to output queue
+                        for (final Chromosome chromosome : chromosomes) {
+                            logger.info("Reading records from chromosome: " + chromosome.getName() + " in sample " + parameters.getFindType());
+
+                            BufferedWriter writer = null;
+
+                            //set up writer to write clips to txt file
+                            if (runClip) {
+                                writer = new BufferedWriter(new FileWriter(SoftClipStaticMethods.getSoftClipFile(chromosome.getName(), parameters.getFindType(), softClipDir), true));
+                            }
+
+                            //write reads
+                            run = readAndWriteData(reader, writer, chromosome, chromosome.getStartPosition(), chromosome.getEndPosition());
+
+                            if (runClip) {
+                                writer.close();
+                            }
+                        }
+                    } // end else
+                }// end while
+                logger.info("Completed filtering thread: " + Thread.currentThread().getName());
+
+            } catch (final Exception e) {
+                logger.error("Setting exit status in annotation thread to 1 as exception caught: " + QSVUtil.getStrackTrace(e));
+                if (exitStatus.intValue() == 0) {
+                    exitStatus.incrementAndGet();
+                }
+                mainThread.interrupt();
+            } finally {
+
+                logger.debug(String
+                        .format(" total slept %d times since input queue is empty and %d time since either output queue is full. each sleep take %d mill-second. queue size for qIn, qOutGood and qOutBad are %d, %d",
+                                sleepcount, countOutputSleep, sleepUnit,
+                                queueIn.size(), queueOutPair.size()));
+                filterLatch.countDown();
+            }
+        }
+
+        private boolean readAndWriteData(SamReader reader, BufferedWriter writer, Chromosome chromosome, int startPos, int endPos) throws Exception {
+
+            boolean result = true;
+
+//            try (SamReader reader = SAMFileReaderFactory.createSAMFileReader(input, "silent")) {
+            SAMRecordIterator iter = null;
+            try {
+                int queryStart = startPos - 100;
+                if (queryStart <= 0) {
+                    queryStart = 1;
+                }
+                final int queryEnd = endPos + 100;
+                //get reads from bam
+                iter = reader.queryOverlapping(chromosome.getName(), queryStart, queryEnd);
+
+                int count = 0;
+                int shortReadCount = 0;
+
+                while (iter.hasNext()) {
+                    final SAMRecord record = iter.next();
+                    count++;
+                    boolean writersResult = true;
+                    boolean pileupResult = true;
+
+                    /*
+                     * only proceed with records that have sequence > QSVAssemble_SEED_LENGTH
+                     */
+                    if (record.getReadLength() > QSVAssemble.SEED_LENGTH) {
+
+                        final SAMReadGroupRecord srgr = record.getReadGroup();
+                        if (null != srgr
+                                && null != srgr.getId()
+                                && readGroupIds.contains(srgr.getId())) {
+
+                            //discordant pairs
+                            if (runPair && record.getAlignmentStart() >= startPos && record.getAlignmentStart() <= endPos) {
+                                writersResult = addToPairWriter(record, srgr.getId(), count);
+                            }
+
+                            if (runClip) {
+                                //soft clips
+                                if ((!record.getReadUnmappedFlag() && !record.getDuplicateReadFlag() && record.getCigarString().contains("S"))
+                                        || (isSplitRead && record.getReadUnmappedFlag())) {
+
+                                    pileupResult = pileupSoftClips(writer, record, srgr.getId(), startPos, endPos, chromosome, count);
+                                }
+                            }
+
+                            //check to make sure there aren't any errors
+                            if (!pileupResult || !writersResult) {
+                                if (!pileupResult) {
+                                    logger.error("Error finding soft clip records in " + chromosome);
+                                }
+                                if (!writersResult) {
+                                    logger.error("Error finding discordant read records in " + chromosome);
+                                }
+
+                                if (exitStatus.intValue() == 0) {
+                                    exitStatus.incrementAndGet();
+                                }
+                                result = false;
+                            }
+                        } else {
+                            logger.warn("SAMReadGroupRecord : " + srgr + ":" + record.getSAMString());
+                            logger.warn("SAMReadGroupRecord was null, or id was not in collection: " + (null != srgr ? srgr.getId() : null) + ":" + record.getSAMString());
+                            throw new Exception("Null SAMReadGroupRecord");
+                        }
+                    } else {
+                        shortReadCount++;
+                    }
+                }
+                if (shortReadCount > 0) {
+                    logger.warn("Ignored " + shortReadCount + " reads that had read length < " + QSVAssemble.SEED_LENGTH);
+                }
+            } finally {
+                if (null != iter) {
+                    iter.close();
+                }
+            }
+            return result;
+        }
+
+        /*
+         * write soft clips and unmapped reads
+         */
+        private boolean pileupSoftClips(BufferedWriter writer, SAMRecord record, String rgId, int start, int end, Chromosome chromosome, int count) throws Exception {
+            if (record.getReadUnmappedFlag()) {
+                unmappedCount.incrementAndGet();
+                QSVUtil.writeUnmappedRecord(writer, record, rgId, start, end, parameters.isTumor());
+                return add2queue(record, queueOutClip, count);
+            }
+
+
+            //see if clips pass the filter
+            if (clipQueryEx.Execute(record)) {
+                goodClipCount.incrementAndGet();
+                SoftClipStaticMethods.writeSoftClipRecord(writer, record, rgId, start, end, chromosome.getName());
+                return add2queue(record, queueOutClip, count);
+            } else {
+                return true;
+            }
+        }
+
+        /*
+         * Write discordant pairs to bam
+         */
+        private boolean addToPairWriter(SAMRecord record, String rgId, int count) throws Exception {
+
+            if (!record.getReadUnmappedFlag()) {
+
+                if (!translocationsOnly || QSVUtil.isTranslocationPair(record)) {
+
+                    //annotate the read
+                    parameters.getAnnotator().annotate(record, rgId);
+                    final String zp = (String) record.getAttribute(QSVConstants.ZP_SHORT);
+
+                    //make sure it is discordant
+                    if (zp.contains("A") || zp.equals("C**") || zp.contains("B")) {
+                        if (!zp.equals(QSVConstants.AAA)) {
+                            //check if it passes the filter
+                            if (pairQueryEx.Execute(record)) {
+                                goodPairRecordCount.incrementAndGet();
+                                return add2queue(record, queueOutPair, count, writeLatch);
+                            } else {
+                                Object xc = record.getAttribute("XC");
+                                if (lifescopeQueryEx != null && record.getAttribute("SM") == null && xc != null) {
+                                    //try to filter lifescope reads
+                                    if (lifescopeQueryEx.Execute(record)) {
+                                        goodPairRecordCount.incrementAndGet();
+                                        return add2queue(record, queueOutPair, count, writeLatch);
+                                    } else {
+                                        record.setAttribute(QSVConstants.ZP, xc);
+                                        if (lifescopeQueryEx.Execute(record)) {
+                                            return add2queue(record, queueOutPair, count, writeLatch);
+                                        }
+                                    }
+                                    badRecordCount.incrementAndGet();
+                                } else {
+                                    badRecordCount.incrementAndGet();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        private boolean add2queue(SAMRecord re, AbstractQueue<SAMRecord> queue, int count) {
+            return add2queue(re, queue, count, null);
+        }
+
+        //add to write queue
+        private boolean add2queue(SAMRecord re, AbstractQueue<SAMRecord> queue, int count, CountDownLatch latch) {
+            // check queue size in each checkPoint number
+            if (count % checkPoint == 0) {
+                // check mainThread
+                if (!mainThread.isAlive()) {
+                    logger.error("mainThread died: " + mainThread.getName());
+                    return false;
+                }
+                // check queue size
+                while (queue.size() >= maxRecords) {
+                    try {
+                        Thread.sleep(sleepUnit);
+                        countOutputSleep++;
+                    } catch (final InterruptedException e) {
+                        logger.info(Thread.currentThread().getName() + " "
+                                + QSVUtil.getStrackTrace(e) + " (queue size full) ");
+                    }
+                    if (null != latch && latch.getCount() == 0) {
+                        logger.error("output queue is not empty but writing thread are completed");
+                        return false;
+                    }
+                } // end while
+            }
+
+            return queue.add(re);
+        }
+    }
+
+    /**
+     * Class to write discordant pairs, clips and unmapped reads to file
+     */
+    private class Writing implements Runnable {
+        private final File file;
+        private final AbstractQueue<SAMRecord> queue;
+        private final Thread mainThread;
+        private final CountDownLatch filterLatch;
+        private final CountDownLatch writeLatch;
+        private final SAMFileHeader header;
+
+        public Writing(AbstractQueue<SAMRecord> q, File f, Thread mainThread,
+                       CountDownLatch fLatch, CountDownLatch wLatch, SAMFileHeader header) {
+            queue = q;
+            file = f;
+            this.mainThread = mainThread;
+            this.filterLatch = fLatch;
+            this.writeLatch = wLatch;
+            this.header = header;
+        }
+
+        @Override
+        public void run() {
+            int countSleep = 0;
+            boolean run = true;
+            logger.info("Started Writing thread with output file: " + file);
+            try {
+                int count = 0;
+                if (file != null) {
+                    HeaderUtils.addProgramRecord(header, "qsv", Messages.getVersionMessage(), query);
+                    final SAMFileWriterFactory writeFactory = new SAMFileWriterFactory();
+                    if (header.getSortOrder().equals(SortOrder.coordinate)) {
+                        writeFactory.setCreateIndex(true);
+                    }
+                    // there is a bug at current version, cause an exception but we
+                    // can use below static method
+                    SAMFileWriterImpl.setDefaultMaxRecordsInRam(maxRecords);
+
+                    /*
+                     * We want the temp bam files to go to our temp folder rather than the default
+                     * Set this at the factory level before creating writers
+                     */
+                    writeFactory.setTempDirectory(file.getParentFile());
+
+                    /*
+                    * try using the qpicard writer to see if that will handle CRAM files
+                     */
+//                    try (SAMFileWriter writer = writeFactory.makeBAMWriter(header, false, file, 1)) {
+                    SAMFileWriter writer = null;
+                    try {
+                        SAMWriterFactory factory = new SAMWriterFactory(header, false, file, file.getParentFile(), maxRecords, true, false, -1, new File(parameters.getReference()));
+                        writer = factory.getWriter();
+                        logger.info("all tmp BAMs are located on " + file.getParentFile().getCanonicalPath());
+                        logger.info("default maxRecordsInRam " + SAMFileWriterImpl.getDefaultMaxRecordsInRam());
+                        SAMRecord record;
+                        while (run) {
+                            // when queue is empty,maybe filtering is done
+                            if ((record = queue.poll()) == null) {
+
+                                try {
+                                    Thread.sleep(sleepUnit);
+                                    countSleep++;
+                                } catch (final Exception e) {
+                                    logger.info(Thread.currentThread().getName() + " "
+                                            + QSVUtil.getStrackTrace(e));
+                                }
+
+                                if ((count % checkPoint == 0) && (!mainThread.isAlive())) {
+                                    throw new Exception("Writing thread failed since parent thread died.");
+                                }
+
+                                while (queue.size() >= maxRecords) {
+                                    try {
+                                        Thread.sleep(sleepUnit);
+                                        countSleep++;
+                                    } catch (final Exception e) {
+                                        logger.info(Thread.currentThread().getName() + " " + QSVUtil.getStrackTrace(e));
+                                    }
+                                }
+
+                                if (filterLatch.getCount() == 0) {
+                                    /*
+                                     * the queue could have been added to since our last check (we did have a quick sleep after all
+                                     * Check size again before pulling the plug
+                                     */
+                                    if (queue.isEmpty()) {
+                                        run = false;
+                                    }
+                                }
+
+                            } else {
+
+                                writer.addAlignment(record);
+                                count++;
+
+                                if (count % 1000000 == 0) {
+                                    logger.info("have written " + count + " SAMRecords to file, queue size: " + queue.size());
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        logger.error("Exception caught whilst writing SAMRecords to bam file: " + file.getAbsolutePath() + " : " + QSVUtil.getStrackTrace(e));
+                        throw e;
+                    } finally {
+                        if (writer != null) {
+                            logger.info("About to close writer for file: " + file.getAbsolutePath());
+                            writer.close();
+                        }
+
+                    }
+                }
+                if (!mainThread.isAlive()) {
+                    throw new Exception(
+                            "Writing thread failed since parent thread died.");
+                } else {
+                    if (file != null) {
+                        logger.info("Completed writing thread, added " + count
+                                + " records to the output: "
+                                + file.getAbsolutePath());
+                        logger.info("Record count not passing filter for the "
+                                + parameters.getFindType() + " sample is "
+                                + badRecordCount.longValue());
+                    }
+                }
+            } catch (final Exception e) {
+                logger.error("Setting exit status to 1 as exception caught in writing thread: " + QSVUtil.getStrackTrace(e));
+                if (exitStatus.intValue() == 0) {
+                    exitStatus.incrementAndGet();
+                }
+                mainThread.interrupt();
+            } finally {
+                writeLatch.countDown();
+                logger.info("Exit Writing thread, total " + countSleep
+                        + " times get null from writing queue.");
+            }
+        }
+    }
 }
 

--- a/qsv/src/org/qcmg/qsv/blat/BLAT.java
+++ b/qsv/src/org/qcmg/qsv/blat/BLAT.java
@@ -41,7 +41,7 @@ public class BLAT {
 
 	public BLAT(String server, String port, String path) {
 		this.commands = new ArrayList<>(6);
-		commands.add(path + QSVParameters.FILE_SEPERATOR +  "gfClient");
+		commands.add(path + QSVParameters.FILE_SEPARATOR +  "gfClient");
 	    commands.add(server);
 	    commands.add(port);
 	    commands.add("/");

--- a/qsv/src/org/qcmg/qsv/isize/CalculateISize.java
+++ b/qsv/src/org/qcmg/qsv/isize/CalculateISize.java
@@ -20,15 +20,14 @@ public class CalculateISize {
 	private final TreeMap<Integer, Double> leftMap = new TreeMap<>();
 	private final TreeMap<Integer, Double> rightMap = new TreeMap<>();
 	private final TreeMap<Integer, Integer> totalMap = new TreeMap<>();
-	private double[] leftDyDx;
-	private double[] rightDyDx;
+    private double[] rightDyDx;
 	private int isizeMin;
 	private int isizeMax;
 	
 	public CalculateISize(ConcurrentMap<Integer, AtomicInteger> isizeMap) {
 		
 		for (Entry<Integer, AtomicInteger> entry: isizeMap.entrySet()) {
-			totalMap.put(new Integer(entry.getKey().intValue()), new Integer(entry.getValue().intValue()));
+			totalMap.put(entry.getKey(), entry.getValue().intValue());
 		}		
 	}
 	
@@ -55,7 +54,7 @@ public class CalculateISize {
 		getLogMaps();
 		
 		//find derivatives		
-		leftDyDx = findFirstDerivative(leftMap);		
+        double[] leftDyDx = findFirstDerivative(leftMap);
 		rightDyDx = findFirstDerivative(rightMap);
 		
 		//left side of curve
@@ -109,7 +108,7 @@ public class CalculateISize {
 		//convert the map to arrays for x/y values
 		for (Entry<Integer, Double> entry: map.entrySet()) {
 			if (count == newRightMinIndex) {
-				isizeMax = entry.getKey().intValue() + 5;
+				isizeMax = entry.getKey() + 5;
 				break;
 			}
 			count++;				
@@ -148,7 +147,7 @@ public class CalculateISize {
 		int index = 0;
 		for (Entry<Integer, Double> entry: xyMap.entrySet()) {
 			x[index] = entry.getKey().doubleValue();
-			y[index] = entry.getValue().doubleValue();
+			y[index] = entry.getValue();
 			index++;
 		}
 		
@@ -177,7 +176,7 @@ public class CalculateISize {
 				maxCount = entry.getValue();
 				maxKey = entry.getValue();
 			}
-			if (entry.getValue().intValue() > maxCount) {
+			if (entry.getValue() > maxCount) {
 				maxCount = entry.getValue();
 				maxKey = entry.getKey();
 			}
@@ -188,12 +187,12 @@ public class CalculateISize {
 		
 		//get log of counts for left side
 		for (Entry<Integer, Integer> entry: left.entrySet()) {
-			leftMap.put(entry.getKey(), new Double(Math.log10(entry.getValue().doubleValue())));			
+			leftMap.put(entry.getKey(), Math.log10(entry.getValue().doubleValue()));
 		}
 		
 		//get log of counts for right side
 		for (Entry<Integer, Integer> entry: right.entrySet()) {
-			rightMap.put(entry.getKey(), new Double(Math.log10(entry.getValue().doubleValue())));
+			rightMap.put(entry.getKey(), Math.log10(entry.getValue().doubleValue()));
 		}		
 		
 	}

--- a/qsv/src/org/qcmg/qsv/softclip/SoftClipCluster.java
+++ b/qsv/src/org/qcmg/qsv/softclip/SoftClipCluster.java
@@ -1,29 +1,17 @@
 /**
  * © Copyright The University of Queensland 2010-2014.
  * © Copyright QIMR Berghofer Medical Research Institute 2014-2016.
- *
+ * <p>
  * This code is released under the terms outlined in the included LICENSE file.
  */
 
 package org.qcmg.qsv.softclip;
-
-import static org.qcmg.common.util.Constants.TAB;
 
 import gnu.trove.map.TIntObjectMap;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.ValidationStringency;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qsv.QSVParameters;
 import org.qcmg.qsv.assemble.QSVAssemble;
@@ -31,805 +19,800 @@ import org.qcmg.qsv.splitread.UnmappedRead;
 import org.qcmg.qsv.util.QSVConstants;
 import org.qcmg.qsv.util.QSVUtil;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
 public class SoftClipCluster implements Comparable<SoftClipCluster> {
-	
-	final String name;
-	Breakpoint leftBreakpointObject;
-	Breakpoint rightBreakpointObject;
-	private String mutationType;
-	private String leftReference;
-	private String rightReference;
-	private char leftStrand;
-	private char rightStrand;
-	private Integer leftBreakpoint;
-	private Integer rightBreakpoint;
-	private boolean hasClusterMatch = false;
-	private boolean hasMatchingBreakpoints;
-	private char rightMateStrand;
-	private char leftMateStrand;
-	private boolean hasClipMatch;
-	private boolean oneSide;
-	private boolean rescuedClips;
-	private boolean alreadyMatched;
-	private String orientationCategory = "";
+
+    final String name;
+    Breakpoint leftBreakpointObject;
+    Breakpoint rightBreakpointObject;
+    private String mutationType;
+    private String leftReference;
+    private String rightReference;
+    private char leftStrand;
+    private char rightStrand;
+    private Integer leftBreakpoint;
+    private Integer rightBreakpoint;
+    private boolean hasClusterMatch = false;
+    private boolean hasMatchingBreakpoints;
+    private boolean hasClipMatch;
+    private boolean oneSide;
+    private boolean alreadyMatched;
+    private String orientationCategory = "";
 
 
-	public SoftClipCluster(Breakpoint leftBreakpoint) {
-		this.name = leftBreakpoint.getName();
-		this.leftBreakpointObject = leftBreakpoint;		
-		setStartAndEnd();		
-		this.rightBreakpointObject = null;	
-		this.oneSide = true;
-		this.mutationType = defineMutationType();
-	}
-	
-	public SoftClipCluster(Breakpoint leftBreakpoint, Breakpoint rightBreakpoint) {
-		this.name = (leftBreakpoint.getName().compareTo(rightBreakpoint.getName()) > 0) 
-				? rightBreakpoint.getName() + ":" + leftBreakpoint.getName() : leftBreakpoint.getName() + ":" + rightBreakpoint.getName(); 
-		this.leftBreakpointObject = leftBreakpoint;
-		this.rightBreakpointObject = rightBreakpoint;
-		this.hasMatchingBreakpoints = true;
-		
-		this.oneSide = leftBreakpoint.getClipsSize() == 0 || rightBreakpoint.getClipsSize() == 0;
-		setStartAndEnd();
-		this.mutationType = defineMutationType();
-	}
+    public SoftClipCluster(Breakpoint leftBreakpoint) {
+        this.name = leftBreakpoint.getName();
+        this.leftBreakpointObject = leftBreakpoint;
+        setStartAndEnd();
+        this.rightBreakpointObject = null;
+        this.oneSide = true;
+        this.mutationType = defineMutationType();
+    }
 
-	private void setStartAndEnd() {
-		if (this.leftBreakpointObject == null) {
-			this.leftBreakpoint = rightBreakpointObject.getMateBreakpoint();
-			this.leftReference = rightBreakpointObject.getMateReference();
-			this.leftStrand = rightBreakpointObject.getMateStrand();
-			this.rightBreakpoint = rightBreakpointObject.getBreakpoint();			
-			this.rightReference = rightBreakpointObject.getReference();
-			this.rightStrand = rightBreakpointObject.getStrand();	
-			this.rightMateStrand = rightBreakpointObject.getMateStrand();
-			this.leftMateStrand = rightBreakpointObject.getStrand();
-		} else {
-			this.leftBreakpoint = leftBreakpointObject.getBreakpoint();
-			this.leftReference = leftBreakpointObject.getReference();
-			this.leftStrand = leftBreakpointObject.getStrand();
-			this.leftMateStrand = leftBreakpointObject.getMateStrand();
-			if (rightBreakpointObject == null) {
-				this.rightBreakpoint = leftBreakpointObject.getMateBreakpoint();			
-				this.rightReference = leftBreakpointObject.getMateReference();
-				this.rightStrand = leftBreakpointObject.getMateStrand();
-				this.rightMateStrand = leftBreakpointObject.getStrand();				
-			} else {
-				this.rightBreakpoint = rightBreakpointObject.getBreakpoint();		
-				this.rightReference = rightBreakpointObject.getReference();
-				this.rightStrand = rightBreakpointObject.getStrand();	
-				this.rightMateStrand = rightBreakpointObject.getMateStrand();
-			}
-		}		
-	}	
+    public SoftClipCluster(Breakpoint leftBreakpoint, Breakpoint rightBreakpoint) {
+        this.name = (leftBreakpoint.getName().compareTo(rightBreakpoint.getName()) > 0)
+                ? rightBreakpoint.getName() + ":" + leftBreakpoint.getName() : leftBreakpoint.getName() + ":" + rightBreakpoint.getName();
+        this.leftBreakpointObject = leftBreakpoint;
+        this.rightBreakpointObject = rightBreakpoint;
+        this.hasMatchingBreakpoints = true;
 
-	public String defineMutationType() {
-		
-		if (oneSide) {
-			if ( ! leftReference.equals(rightReference)) {
-				checkOrder();
-				return "CTX";
-			} else {
-				String mut = findSingleSideMutationType();
-				orientationCategory = "";
-				checkOrder();
-				return mut;
-			}
-			
-		} else {
-			checkOrder();
-			return findTwoSidedMutationType();	
-			
-		}
-	}
+        this.oneSide = leftBreakpoint.getClipsSize() == 0 || rightBreakpoint.getClipsSize() == 0;
+        setStartAndEnd();
+        this.mutationType = defineMutationType();
+    }
 
-	public String findTwoSidedMutationType() {
-		if ( ! leftBreakpointObject.isLeft() && rightBreakpointObject.isLeft()) {
-			
-			if (leftBreakpointObject.getStrand() == leftBreakpointObject.getMateStrand() && rightBreakpointObject.getStrand() == rightBreakpointObject.getMateStrand()) {
-				orientationCategory = "1";	
-				
-				return leftReference.equals(rightReference) ? "DEL/ITX" : "CTX";
-			} 				
-			
-		} else if (leftBreakpointObject.isLeft() && !rightBreakpointObject.isLeft()) {
-			if (leftBreakpointObject.getStrand() == leftBreakpointObject.getMateStrand() && rightBreakpointObject.getStrand() == rightBreakpointObject.getMateStrand()) {
-				orientationCategory = QSVConstants.ORIENTATION_2;				
-				return leftReference.equals(rightReference) ? "DUP/INS/ITX" : "CTX";
-			}			
-		} else if ((leftBreakpointObject.isLeft() && rightBreakpointObject.isLeft()) 
-				|| ( ! leftBreakpointObject.isLeft() && !rightBreakpointObject.isLeft())) {
-			if (leftBreakpointObject.getStrand() != leftBreakpointObject.getMateStrand() 
-					&& rightBreakpointObject.getStrand() != rightBreakpointObject.getMateStrand()) {
-				if (leftBreakpointObject.isLeft() && rightBreakpointObject.isLeft()) {
-					orientationCategory = QSVConstants.ORIENTATION_4;
-				}
-				if ( ! leftBreakpointObject.isLeft() && ! rightBreakpointObject.isLeft()) {
-					orientationCategory = QSVConstants.ORIENTATION_3;
-				}
-				return leftReference.equals(rightReference) ? "INV/ITX" : "CTX";
-			}			
-		}
-		
-		return "ITX";	
-	}
-
-	public String findSingleSideMutationType() {
-		Breakpoint bpObject = getSingleBreakpoint();
-		
-		if ( ! bpObject.getMatchingStrands()) {
-			return "ITX";
-		}
-
-		if (bpObject.isLeft()) {
-			if (bpObject.getBreakpoint().intValue() < bpObject.getMateBreakpoint()) {
-				return  "DUP/INS/ITX" ;
-			} else {
-				return "DEL/ITX" ;
-			}
-		} else {
-			if (bpObject.getBreakpoint() < bpObject.getMateBreakpoint()) {
-				return "DEL/ITX";
-			} else {
-				return "DUP/INS/ITX";
-			}
-		}
-	}
-
-	public void checkOrder() {
-		if (leftReference.equals(rightReference)) {
-			// wrong order: swap the records
-            if (leftBreakpoint.intValue() > rightBreakpoint.intValue()) {
-	            	swapBreakpoints();
-            }
-
-          // on different chromosomes
+    private void setStartAndEnd() {
+//        char rightMateStrand;
+//        char leftMateStrand;
+        if (this.leftBreakpointObject == null) {
+            this.leftBreakpoint = rightBreakpointObject.getMateBreakpoint();
+            this.leftReference = rightBreakpointObject.getMateReference();
+            this.leftStrand = rightBreakpointObject.getMateStrand();
+            this.rightBreakpoint = rightBreakpointObject.getBreakpoint();
+            this.rightReference = rightBreakpointObject.getReference();
+            this.rightStrand = rightBreakpointObject.getStrand();
+//            rightMateStrand = rightBreakpointObject.getMateStrand();
+//            leftMateStrand = rightBreakpointObject.getStrand();
         } else {
-            if ( QSVUtil.reorderByChromosomes(leftReference, rightReference)) {
-	            	swapBreakpoints();
+            this.leftBreakpoint = leftBreakpointObject.getBreakpoint();
+            this.leftReference = leftBreakpointObject.getReference();
+            this.leftStrand = leftBreakpointObject.getStrand();
+//            leftMateStrand = leftBreakpointObject.getMateStrand();
+            if (rightBreakpointObject == null) {
+                this.rightBreakpoint = leftBreakpointObject.getMateBreakpoint();
+                this.rightReference = leftBreakpointObject.getMateReference();
+                this.rightStrand = leftBreakpointObject.getMateStrand();
+//                rightMateStrand = leftBreakpointObject.getStrand();
+            } else {
+                this.rightBreakpoint = rightBreakpointObject.getBreakpoint();
+                this.rightReference = rightBreakpointObject.getReference();
+                this.rightStrand = rightBreakpointObject.getStrand();
+//                rightMateStrand = rightBreakpointObject.getMateStrand();
             }
         }
-	}
-	
-	public void swapBreakpoints() {
-		if (rightBreakpointObject != null) {
-			Breakpoint temp = leftBreakpointObject;			
-			leftBreakpointObject = rightBreakpointObject;
-			rightBreakpointObject = temp;			
-		} else {
-			this.rightBreakpointObject = this.leftBreakpointObject;
-			this.leftBreakpointObject = null;
-		}
-		setStartAndEnd();
-	}
+    }
 
-	@Override
-	public int compareTo(SoftClipCluster o) {
-		return this.name.compareTo(o.getName());
-	}
-	
-	public String getName() {
-		return name;
-	}
+    public String defineMutationType() {
 
-	public boolean isRescuedClips() {
-		return rescuedClips;
-	}
-	
-	public boolean isOneSide() {
-		return oneSide;
-	}
+        if (oneSide) {
+            if (!leftReference.equals(rightReference)) {
+                checkOrder();
+                return "CTX";
+            } else {
+                String mut = findSingleSideMutationType();
+                orientationCategory = "";
+                checkOrder();
+                return mut;
+            }
 
-	public Breakpoint getLeftBreakpointObject() {
-		return leftBreakpointObject;
-	}
-	
-	public Breakpoint getRightBreakpointObject() {
-		return rightBreakpointObject;
-	}
+        } else {
+            checkOrder();
+            return findTwoSidedMutationType();
 
-	public Integer getLeftBreakpoint() {
-		return leftBreakpoint;
-	}
+        }
+    }
 
-	public Integer getRightBreakpoint() {
-		return rightBreakpoint;
-	}
+    public String findTwoSidedMutationType() {
+        if (!leftBreakpointObject.isLeft() && rightBreakpointObject.isLeft()) {
 
-	public String getRightReference() {
-		return rightReference;
-	}
+            if (leftBreakpointObject.getStrand() == leftBreakpointObject.getMateStrand() && rightBreakpointObject.getStrand() == rightBreakpointObject.getMateStrand()) {
+                orientationCategory = "1";
 
-	public String getLeftReference() {
-		return leftReference;
-	}
+                return leftReference.equals(rightReference) ? "DEL/ITX" : "CTX";
+            }
 
-	public String getMutationType() {
-		return this.mutationType;
-	}
-	
-	public void setHasClusterMatch(boolean b) {
-		this.hasClusterMatch = b;		
-	}
+        } else if (leftBreakpointObject.isLeft() && !rightBreakpointObject.isLeft()) {
+            if (leftBreakpointObject.getStrand() == leftBreakpointObject.getMateStrand() && rightBreakpointObject.getStrand() == rightBreakpointObject.getMateStrand()) {
+                orientationCategory = QSVConstants.ORIENTATION_2;
+                return leftReference.equals(rightReference) ? "DUP/INS/ITX" : "CTX";
+            }
+        } else if ((leftBreakpointObject.isLeft() && rightBreakpointObject.isLeft())
+                || (!leftBreakpointObject.isLeft() && !rightBreakpointObject.isLeft())) {
+            if (leftBreakpointObject.getStrand() != leftBreakpointObject.getMateStrand()
+                    && rightBreakpointObject.getStrand() != rightBreakpointObject.getMateStrand()) {
+                if (leftBreakpointObject.isLeft() && rightBreakpointObject.isLeft()) {
+                    orientationCategory = QSVConstants.ORIENTATION_4;
+                }
+                if (!leftBreakpointObject.isLeft() && !rightBreakpointObject.isLeft()) {
+                    orientationCategory = QSVConstants.ORIENTATION_3;
+                }
+                return leftReference.equals(rightReference) ? "INV/ITX" : "CTX";
+            }
+        }
 
-	public boolean hasClusterMatch() {
-		return hasClusterMatch;
-	}
+        return "ITX";
+    }
 
-	public boolean hasMatchingBreakpoints() {
-		return hasMatchingBreakpoints;
-	}
-	
-	public boolean findMatchingBreakpoints() {
-		return getLeftBreakpointObject() != null 
-				&& getRightBreakpointObject() != null 
-				&& getRightBreakpointObject().getClipsSize() > 0 
-				&& getLeftBreakpointObject().getClipsSize() > 0;
-	}
+    public String findSingleSideMutationType() {
+        Breakpoint bpObject = getSingleBreakpoint();
 
-	public boolean hasClipMatch() {
-		return this.hasClipMatch;
-	}
+        if (!bpObject.getMatchingStrands()) {
+            return "ITX";
+        }
 
-	public void setHasClipMatch(boolean clipMatch) {
-		this.hasClipMatch = clipMatch;	
-	}	
-	
-	public String getOrientationCategory() {
-		return orientationCategory;
-	}
+        if (bpObject.isLeft()) {
+            if (bpObject.getBreakpoint() < bpObject.getMateBreakpoint()) {
+                return "DUP/INS/ITX";
+            } else {
+                return "DEL/ITX";
+            }
+        } else {
+            if (bpObject.getBreakpoint() < bpObject.getMateBreakpoint()) {
+                return "DEL/ITX";
+            } else {
+                return "DUP/INS/ITX";
+            }
+        }
+    }
 
-	public boolean findMatchingBreakpoints(SoftClipCluster compare) {
-		
-		Breakpoint left = getSingleBreakpoint();
-		Breakpoint right = compare.getSingleBreakpoint();
-		
-		if (left != null && right != null) {
-			if (left.getReference().equals(right.getMateReference()) && right.getReference().equals(left.getMateReference())) {
-				
-				Integer leftBPPosition = left.compare(right.getReference(), right.getBreakpoint());
-				Integer rightBPPosition = right.compare(left.getReference(), left.getBreakpoint());			
-	
-				if (leftBPPosition != null && rightBPPosition != null) {
-					this.hasMatchingBreakpoints = true;
-					return true;
-				}
-			}
-		}
-		
-		return false;
-	}	
-	
-	public boolean isGermline() {
-		return (leftBreakpointObject != null && leftBreakpointObject.isGermline())
-				|| (rightBreakpointObject != null && rightBreakpointObject.isGermline());
-		
-	}
+    public void checkOrder() {
+        if (leftReference.equals(rightReference)) {
+            // wrong order: swap the records
+            if (leftBreakpoint > rightBreakpoint) {
+                swapBreakpoints();
+            }
 
-	public int getRealRightBreakpoint() {
-		return this.rightBreakpointObject != null ?  rightBreakpointObject.getBreakpoint().intValue()
-				: rightBreakpoint.intValue();
-	}
-	
-	public int getRealLeftBreakpoint() {
-		return this.leftBreakpointObject != null ? leftBreakpointObject.getBreakpoint().intValue() 
-				: rightBreakpointObject.getMateBreakpoint();
-	}
+            // on different chromosomes
+        } else {
+            if (QSVUtil.reorderByChromosomes(leftReference, rightReference)) {
+                swapBreakpoints();
+            }
+        }
+    }
 
-	public int getClipCount(boolean isTumour, boolean leftPos) {		
-		
-		if (leftBreakpointObject != null) {
-				if (leftPos && !orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
-					return getLeftClipCount(isTumour);								
-				} else if (!leftPos && orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
-					return getRightClipCount(isTumour);	
-				}
-		}
-		if (rightBreakpointObject != null) {
-			if (!leftPos && !orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
-				return getRightClipCount(isTumour);								
-			} else {
-				if (leftPos && orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
-					return getLeftClipCount(isTumour);		
-				}
-			}
-		}
-		return 0;
-	}
+    public void swapBreakpoints() {
+        if (rightBreakpointObject != null) {
+            Breakpoint temp = leftBreakpointObject;
+            leftBreakpointObject = rightBreakpointObject;
+            rightBreakpointObject = temp;
+        } else {
+            this.rightBreakpointObject = this.leftBreakpointObject;
+            this.leftBreakpointObject = null;
+        }
+        setStartAndEnd();
+    }
 
-	private int getLeftClipCount(boolean isTumour) {
-		return isTumour ? leftBreakpointObject.getTumourClips().size() : leftBreakpointObject.getNormalClips().size();
-	}
-	
-	private int getRightClipCount(boolean isTumour) {
-		return isTumour ? rightBreakpointObject.getTumourClips().size() :  rightBreakpointObject.getNormalClips().size();
-	}
+    @Override
+    public int compareTo(SoftClipCluster o) {
+        return this.name.compareTo(o.getName());
+    }
 
-	public String getStrand() {
-		return this.leftStrand + "|" + this.rightStrand;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public Breakpoint getSingleBreakpoint() {
-		if (leftBreakpointObject != null && rightBreakpointObject != null) {
-			return null;
-		} else if (leftBreakpointObject != null ) {
-			return this.leftBreakpointObject;
-		} else {
-			return this.rightBreakpointObject;
-		}
-	}
+//    public boolean isRescuedClips() {
+//        return rescuedClips;
+//    }
 
-	public String getClips(boolean isLeft, boolean isTumour) {
-		if (isLeft) {
-			if (leftBreakpointObject != null && ! leftBreakpointObject.isRescued()) {
-				return isTumour ? leftBreakpointObject.getTumourClipString() : leftBreakpointObject.getNormalClipString();
-			}
-		} else {
-			if (rightBreakpointObject != null && ! rightBreakpointObject.isRescued()) {
-				return isTumour ? rightBreakpointObject.getTumourClipString() :  rightBreakpointObject.getNormalClipString();
-			}
-		}
-		return "";
-	}
-	
-	public String getLowConfClips(boolean isLeft, boolean isTumour) {
-		if (isLeft) {
-			if (leftBreakpointObject != null) {
-				if (leftBreakpointObject.isRescued()) {
-					if (isTumour) {
-						return leftBreakpointObject.getTumourClipString();
-					} else {
-						return leftBreakpointObject.getNormalClipString();
-					}
-				}
-			}
-		} else {
-			if (rightBreakpointObject != null) {
-				if (rightBreakpointObject.isRescued()) {
-					if (isTumour) {
-						return rightBreakpointObject.getTumourClipString();
-					} else {
-						return rightBreakpointObject.getNormalClipString();
-					}
-				}
-			}
-		}
-		return "";
-	}
-	
-	public String getFullName() {
-		return this.name + TAB + leftReference + TAB + leftBreakpoint + TAB + leftStrand + TAB + rightReference + TAB + rightBreakpoint + TAB + leftMateStrand + TAB;
-	}
+//    public boolean isOneSide() {
+//        return oneSide;
+//    }
 
-	public String getLeftInfo() {
-		int size = 0;
-		if (leftBreakpointObject != null) {
-			size = leftBreakpointObject.getClipsSize(); 
-		}
-		return this.name + TAB + leftBreakpoint + TAB + leftStrand + TAB + rightBreakpoint + TAB + leftMateStrand + TAB + size;
-	}
-	
-	public String getRightInfo() {
-		int size = 0;
-		if (rightBreakpointObject != null) {
-			size = rightBreakpointObject.getClipsSize(); 
-		}
-		return this.name + TAB + rightBreakpoint + TAB + rightStrand + TAB + rightMateStrand + TAB + size; 
-	}
+    public Breakpoint getLeftBreakpointObject() {
+        return leftBreakpointObject;
+    }
 
-	public void rescueClips(QSVParameters p, TIntObjectMap<int[]> cache, File tumourFile, File normalFile, String softclipDir, int consensusLength, int chrBuffer, Integer minInsertSize) throws Exception {
-		
-		Map<Integer, Breakpoint> leftMap = new HashMap<>();
-		Map<Integer, Breakpoint> rightMap = new HashMap<>();
-		TreeMap<Integer, List<UnmappedRead>> splitReads = new TreeMap<>();
-		Integer bp = getOrphanBreakpoint();
-		String ref = getOrphanReference();
-			
-		
-		if (bp != null) {
-			readRescuedClips(tumourFile, true, ref, bp, leftMap, rightMap, splitReads, consensusLength, chrBuffer, minInsertSize, p.getReadGroupIds(), p.getPairingType());
-			readRescuedClips(normalFile, false, ref, bp, leftMap, rightMap, splitReads, consensusLength, chrBuffer, minInsertSize, p.getReadGroupIds(), p.getPairingType());
-		}		
-		findMaxRescueBreakpoint(p, cache, leftMap, rightMap, splitReads, softclipDir);
-	}
-	public void findMaxRescueBreakpoint(QSVParameters p, TIntObjectMap<int[]> cache,
-			Map<Integer, Breakpoint> leftMap,
-			Map<Integer, Breakpoint> rightMap, TreeMap<Integer, List<UnmappedRead>> splitReads, String softclipDir) throws Exception {
+    public Breakpoint getRightBreakpointObject() {
+        return rightBreakpointObject;
+    }
 
-		//find maximum breakpoint
-		Breakpoint maxLengthBp = null;
-		int maxLength = 0;
-		int buffer = p.getUpperInsertSize() + 100;		
+    public Integer getLeftBreakpoint() {
+        return leftBreakpoint;
+    }
 
-		for (Breakpoint b : leftMap.values()) {
-			
-			if (b.getMaxBreakpoint(buffer, splitReads, maxLength)) {
-				if (b.getBreakpoint().intValue() != this.getSingleBreakpoint().getBreakpoint().intValue()) {
-					
-					maxLengthBp = b;
-					maxLength = b.getMateConsensus().length();
-				}
-			}
-		}
-		
-		for (Breakpoint b: rightMap.values()) {
-			
-			if (b.getMaxBreakpoint(buffer, splitReads, maxLength)) {
-				if (b.getBreakpoint().intValue() != this.getSingleBreakpoint().getBreakpoint().intValue()) {
-					maxLengthBp = b;
-					maxLength = b.getMateConsensus().length();
-				}
-			}
-		}
+    public Integer getRightBreakpoint() {
+        return rightBreakpoint;
+    }
 
-		if (maxLengthBp != null) {
-			
-			if (maxLengthBp.getMateConsensus().length() > 20) {
-				boolean match = maxLengthBp.findRescuedMateBreakpoint(cache, p, softclipDir);
-				
-				if (match) {
-					if (this.getSingleBreakpoint() != null) {
-						if (this.findMatchingBreakpoints(new SoftClipCluster(maxLengthBp))) {
-							maxLengthBp.setRescued(false);
-							
-							if (leftBreakpointObject == null) {
-								leftBreakpointObject = maxLengthBp;								
-							} else {
-								rightBreakpointObject = maxLengthBp;	
-							}
-							
-							rescuedClips = true;
-							oneSide = false;
-							setStartAndEnd();
-							this.mutationType = defineMutationType();
-							hasMatchingBreakpoints = true;
-						}
-					}
-				}
-			} 
-		}
-	}	
+    public String getRightReference() {
+        return rightReference;
+    }
 
-	String getOrphanReference() {
-		if (leftBreakpointObject == null) {
-			//find potential matches for breakpoint
-		    return leftReference;
-		}    
-	
-		if (rightBreakpointObject == null) {
-			return rightReference;
-		}
-		return null;
-	}
+    public String getLeftReference() {
+        return leftReference;
+    }
 
-	private void readRescuedClips(File file, boolean isTumour, String reference, int bp, Map<Integer, Breakpoint> leftMap, Map<Integer, Breakpoint> rightMap, TreeMap<Integer, 
-			List<UnmappedRead>> splitReads, int consensusLength, int chrBuffer, Integer minInsertSize, Collection<String> readGroupIds, String pairingType) throws IOException {
-		int bpStart = bp - chrBuffer;
-		int bpEnd = bp + chrBuffer;
-		
-		int referenceStart = bpStart - 120;
-		int referenceEnd = bpEnd + 120;
-		int count = 0;
-		
-		try (SamReader reader = SAMFileReaderFactory.createSAMFileReader(file, null, ValidationStringency.SILENT)) {
-        
-    		SAMRecordIterator iter = reader.queryOverlapping(reference, referenceStart, referenceEnd);
-    
-    		while (iter.hasNext()) {
-	        	SAMRecord r = iter.next();	
-	        	String readGroupId = r.getReadGroup().getId();
-	        	
-        		if (readGroupIds.contains(readGroupId)) {
-	        		if (r.getReadUnmappedFlag()) {
-		        		count++;
-		        		if (count > 5000) {
-	    	        		break;
-		    	        }
-		        		UnmappedRead splitRead = new UnmappedRead(r, readGroupId, isTumour);
-		        		List<UnmappedRead> reads = splitReads.get(splitRead.getBpPos());
-		        		if (null == reads) {
-		        			reads = new ArrayList<>();
-		        			splitReads.put(splitRead.getBpPos(), reads);
-		        		}
-		        		reads.add(splitRead);
-		        		
-		        	} else {
-			        	if ( ! r.getDuplicateReadFlag() && r.getCigarString().contains("S")) {
-			        		count++;
-			        		if (count > 5000) {
-			        			break;
-			    	        }
-			        		Clip c = SoftClipStaticMethods.createSoftClipRecord(r, readGroupId, bpStart, bpEnd, reference);
-			        		if (c != null) {     			
-		        				if (c.isLeft()) {
-		        					Breakpoint b = leftMap.get(c.getBpPos());
-		        					if (null == b) {
-		        						b = new Breakpoint(c.getBpPos(), reference, true, consensusLength, minInsertSize);
-		        						b.addTumourClip(c);
-		        						leftMap.put(c.getBpPos(), b);
-		        					} else {
-		        					
-			        					if (isTumour) {
-			        						b.addTumourClip(c);
-			        					} else {
-			        						b.addNormalClip(c);
-			        					}
-		        					}
-		        				} else {
-		        					Breakpoint b = rightMap.get(c.getBpPos());
-		        					if (null == b) {
-		        						b = new Breakpoint(c.getBpPos(), reference, false, consensusLength, minInsertSize);
-		        						b.addTumourClip(c);
-		        						rightMap.put(c.getBpPos(), b);
-		        					} else {
-		        						if (isTumour) {
-		        							b.addTumourClip(c);
-		        						} else {
-		        							b.addNormalClip(c);
-		        						}
-			        				}
-		        				}
-			        		}
-			        	}
-		        	}
-        		}
-	        }
-		}
-	}
+    public String getMutationType() {
+        return this.mutationType;
+    }
 
-	public Integer getOrphanBreakpoint() throws Exception {
-		if (leftBreakpointObject == null) {
-			//find potential matches for breakpoint
-		    return leftBreakpoint;
-		} else if (rightBreakpointObject == null) {
-			return rightBreakpoint;
-		} else {
-			throw new Exception("Null breakpoint");
-		}
-	}
+    public void setHasClusterMatch(boolean b) {
+        this.hasClusterMatch = b;
+    }
 
-	public boolean alreadyMatched() {
-		return this.alreadyMatched;
-	}
-	
-	public void setAlreadyMatched(boolean b) {
-		this.alreadyMatched = b;
-	}
+    public boolean hasClusterMatch() {
+        return hasClusterMatch;
+    }
 
-	public String getSoftClipConsensusString(String svId) {
-		String tab = "\t";
-		return svId + tab + leftReference + tab + leftBreakpoint + tab + getLeftSoftClipConsensus() 
-				+ tab + rightReference + tab + rightBreakpoint + tab + getRightSoftClipConsensus(); 
-	}
+    public boolean hasMatchingBreakpoints() {
+        return hasMatchingBreakpoints;
+    }
 
-	private String getLeftSoftClipConsensus() {
-		if (leftBreakpointObject == null) {
-			return "\t\t\t\t\t\t\t\t";
-		} else {
-			return leftBreakpointObject.getContigInfo();
-		}
-	}
-	
-	private String getRightSoftClipConsensus() {
-		if (rightBreakpointObject == null) {
-			return "\t\t\t\t\t\t\t\t";
-		} else {
-			return rightBreakpointObject.getContigInfo();
-		}
-	}
-	
-	public String getMicrohomology(String clusterCategory) {
-		String nonTemp = getNonTemplateSequence(clusterCategory);
-		if (nonTemp.equals(QSVConstants.UNTESTED)) {
-			return QSVConstants.UNTESTED;
-		} else {
-			if (nonTemp.length() > 0 && !nonTemp.equals(QSVConstants.NOT_FOUND)) {
-				return QSVConstants.NOT_FOUND;
-			}
-		}
-		
-		String cat = null;
-		
-		if (orientationCategory != null) {
-			if (!orientationCategory.equals("")) {
-				cat = orientationCategory;
-			}
-		} else {
-			if (clusterCategory != null) {
-				cat = clusterCategory;
-			}
-		}
+    public boolean findMatchingBreakpoints() {
+        return getLeftBreakpointObject() != null
+                && getRightBreakpointObject() != null
+                && getRightBreakpointObject().getClipsSize() > 0
+                && getLeftBreakpointObject().getClipsSize() > 0;
+    }
 
-		String leftReferenceSeq;
-		String rightReferenceSeq;
-		
-		if (cat != null) {
-			
-			if (leftBreakpointObject == null || rightBreakpointObject == null) {
-				return "";
-			} else {
-				leftReferenceSeq = leftBreakpointObject.getBreakpointConsenus();
-				rightReferenceSeq = rightBreakpointObject.getBreakpointConsenus();
-			}
-		
-			if (cat.equals(QSVConstants.ORIENTATION_2)) {
-				String tmp = leftReferenceSeq;
-				leftReferenceSeq = rightReferenceSeq;
-				rightReferenceSeq = tmp;		
-			} else if (cat.equals(QSVConstants.ORIENTATION_3)) {
-				rightReferenceSeq = QSVUtil.reverseComplement(rightReferenceSeq);
-			} else if (cat.equals(QSVConstants.ORIENTATION_4)) {
-				leftReferenceSeq = QSVUtil.reverseComplement(leftReferenceSeq);
-			}
-			
-			String mh = "";
-			for (int i = 1; i < rightReferenceSeq.length(); i++) {
-				//startPosition
-				String currentRight = rightReferenceSeq.substring(0, i);
-				
-				if (leftReferenceSeq.endsWith(currentRight)) {
-					if (currentRight.length() > mh.length()) {
-						mh = currentRight;
-					}
-				}
-			}
-			
-			return mh.equals("") ? QSVConstants.NOT_FOUND : mh;
-		} else {
-			return QSVConstants.UNTESTED;
-		}		
-	}
-	
-	public String getOverlappingContigSequence() throws Exception {		
-		
-		if (leftBreakpointObject == null) {
-			return rightBreakpointObject.getCompleteConsensus();
-		} else if (rightBreakpointObject == null) {
-			return leftBreakpointObject.getCompleteConsensus();
-		} else {
-			QSVAssemble a = new QSVAssemble();		
-			return a.getFinalClipContig(leftBreakpointObject.getCompleteConsensus(), rightBreakpointObject.getCompleteConsensus());	
-		}
-	}
-	
-	public int getConsensusSplits(boolean isLeft) {
-		if (isLeft && leftBreakpointObject != null) {
-			return leftBreakpointObject.getSplitConsensusReads();
-		}
-		if (!isLeft && rightBreakpointObject != null) {			
-			return rightBreakpointObject.getSplitConsensusReads();
-		}
-		return 0;
-	}
-	
-	public int getSplitReadTotal(boolean isLeft) {
-		if (isLeft && leftBreakpointObject != null) {			
-			return leftBreakpointObject.getSplitReadsSize();		
-		}
-		if (!isLeft && rightBreakpointObject != null) {
-			return rightBreakpointObject.getSplitReadsSize();
-		}
-		return 0;
-	}
+    public boolean hasClipMatch() {
+        return this.hasClipMatch;
+    }
 
-	public int getConsensusClips(boolean isLeft) {
-		if (isLeft && leftBreakpointObject != null) {
-			return leftBreakpointObject.getClipConsensusReads();
-		}
-		if (!isLeft && rightBreakpointObject != null) {
-			return rightBreakpointObject.getClipConsensusReads();
-		}
-		return 0;
-	}
-	
-	public String getBreakpointConsensus(boolean isLeft) {
-		if (isLeft) {
-			if (leftBreakpointObject != null) {
-				return leftBreakpointObject.getMateConsensus();
-			}
-		} else {
-			if (rightBreakpointObject != null) {
-				return rightBreakpointObject.getMateConsensus();
-			}
-		}
-		return "";
-	}
+    public void setHasClipMatch(boolean clipMatch) {
+        this.hasClipMatch = clipMatch;
+    }
 
-	public int getClipSize(boolean isLeft) {
-		if (isLeft && leftBreakpointObject != null) {
-			return leftBreakpointObject.getTumourClips().size() + leftBreakpointObject.getNormalClips().size();
-		}
-		if (!isLeft && rightBreakpointObject != null) {
-			return rightBreakpointObject.getTumourClips().size() + rightBreakpointObject.getNormalClips().size();
-		}
-		return 0;
-	}
+    public String getOrientationCategory() {
+        return orientationCategory;
+    }
 
-	public String getNonTemplateSequence(String clusterCategory) {
-		String nonTmp = QSVConstants.UNTESTED;
-		if (hasMatchingBreakpoints) {
-			
-			String cat = null;
-			
-			if (orientationCategory != null) {
-				if (!orientationCategory.equals("")) {
-					cat = orientationCategory;
-				}
-			} else {
-				if (clusterCategory != null) {
-					cat = clusterCategory;
-				}
-			}
-			
-			if (cat != null) {
-				
-				String leftClipSeq = rightBreakpointObject.getMateConsensusPosStrand();			
-				String rightClipSeq = leftBreakpointObject.getMateConsensusPosStrand();
-				int leftNonTemp = rightBreakpointObject.getNonTempBases();
-				int rightNonTemp = leftBreakpointObject.getNonTempBases();
-				
-				if (cat.equals(QSVConstants.ORIENTATION_2)) {
-					String tmp = leftClipSeq;			
-					leftClipSeq = rightClipSeq;
-					rightClipSeq = tmp;		
-				}
-				
-				if (leftNonTemp == rightNonTemp) {
-					if (leftNonTemp == 0) {
-						nonTmp = "";
-					}
-					String currentRight = rightClipSeq.substring(0, rightNonTemp);
-					if (leftClipSeq.endsWith(currentRight)) {
-						nonTmp = currentRight;
-					}
-				}
-			}
-		}
-		return nonTmp;
-	}
+    public boolean findMatchingBreakpoints(SoftClipCluster compare) {
 
-	public boolean matchesSplitReadBreakpoints(String splitLeftReference,
-			String splitRightReference, int splitLeftBreakpoint, int splitRightBreakpoint) {
-		
-		if (orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
-			if (leftReference.equals(splitRightReference) && rightReference.equals(splitLeftReference) &&
-					leftBreakpoint == splitRightBreakpoint && rightBreakpoint == splitLeftBreakpoint) {
-				return true;
-			}				
-				
-		} else {
-			if (leftReference.equals(splitLeftReference) && rightReference.equals(splitRightReference) &&
-					leftBreakpoint == splitLeftBreakpoint && rightBreakpoint == splitRightBreakpoint) {
-				return true;
-			}
-		}
-		return false;
-	}
+        Breakpoint left = getSingleBreakpoint();
+        Breakpoint right = compare.getSingleBreakpoint();
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		return result;
-	}
+        if (left != null && right != null) {
+            if (left.getReference().equals(right.getMateReference()) && right.getReference().equals(left.getMateReference())) {
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		SoftClipCluster other = (SoftClipCluster) obj;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		return true;
-	}
+                Integer leftBPPosition = left.compare(right.getReference(), right.getBreakpoint());
+                Integer rightBPPosition = right.compare(left.getReference(), left.getBreakpoint());
+
+                if (leftBPPosition != null && rightBPPosition != null) {
+                    this.hasMatchingBreakpoints = true;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public boolean isGermline() {
+        return (leftBreakpointObject != null && leftBreakpointObject.isGermline())
+                || (rightBreakpointObject != null && rightBreakpointObject.isGermline());
+
+    }
+
+    public int getRealRightBreakpoint() {
+        return this.rightBreakpointObject != null ? rightBreakpointObject.getBreakpoint().intValue()
+                : rightBreakpoint;
+    }
+
+    public int getRealLeftBreakpoint() {
+        return this.leftBreakpointObject != null ? leftBreakpointObject.getBreakpoint()
+                : rightBreakpointObject.getMateBreakpoint();
+    }
+
+    public int getClipCount(boolean isTumour, boolean leftPos) {
+
+        if (leftBreakpointObject != null) {
+            if (leftPos && !orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
+                return getLeftClipCount(isTumour);
+            } else if (!leftPos && orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
+                return getRightClipCount(isTumour);
+            }
+        }
+        if (rightBreakpointObject != null) {
+            if (!leftPos && !orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
+                return getRightClipCount(isTumour);
+            } else {
+                if (leftPos && orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
+                    return getLeftClipCount(isTumour);
+                }
+            }
+        }
+        return 0;
+    }
+
+    private int getLeftClipCount(boolean isTumour) {
+        return isTumour ? leftBreakpointObject.getTumourClips().size() : leftBreakpointObject.getNormalClips().size();
+    }
+
+    private int getRightClipCount(boolean isTumour) {
+        return isTumour ? rightBreakpointObject.getTumourClips().size() : rightBreakpointObject.getNormalClips().size();
+    }
+
+    public String getStrand() {
+        return this.leftStrand + "|" + this.rightStrand;
+    }
+
+    public Breakpoint getSingleBreakpoint() {
+        if (leftBreakpointObject != null && rightBreakpointObject != null) {
+            return null;
+        } else if (leftBreakpointObject != null) {
+            return this.leftBreakpointObject;
+        } else {
+            return this.rightBreakpointObject;
+        }
+    }
+
+    public String getClips(boolean isLeft, boolean isTumour) {
+        if (isLeft) {
+            if (leftBreakpointObject != null && !leftBreakpointObject.isRescued()) {
+                return isTumour ? leftBreakpointObject.getTumourClipString() : leftBreakpointObject.getNormalClipString();
+            }
+        } else {
+            if (rightBreakpointObject != null && !rightBreakpointObject.isRescued()) {
+                return isTumour ? rightBreakpointObject.getTumourClipString() : rightBreakpointObject.getNormalClipString();
+            }
+        }
+        return "";
+    }
+
+    public String getLowConfClips(boolean isLeft, boolean isTumour) {
+        if (isLeft) {
+            if (leftBreakpointObject != null) {
+                if (leftBreakpointObject.isRescued()) {
+                    if (isTumour) {
+                        return leftBreakpointObject.getTumourClipString();
+                    } else {
+                        return leftBreakpointObject.getNormalClipString();
+                    }
+                }
+            }
+        } else {
+            if (rightBreakpointObject != null) {
+                if (rightBreakpointObject.isRescued()) {
+                    if (isTumour) {
+                        return rightBreakpointObject.getTumourClipString();
+                    } else {
+                        return rightBreakpointObject.getNormalClipString();
+                    }
+                }
+            }
+        }
+        return "";
+    }
+
+//    public String getFullName() {
+//        return this.name + TAB + leftReference + TAB + leftBreakpoint + TAB + leftStrand + TAB + rightReference + TAB + rightBreakpoint + TAB + leftMateStrand + TAB;
+//    }
+
+//    public String getLeftInfo() {
+//        int size = 0;
+//        if (leftBreakpointObject != null) {
+//            size = leftBreakpointObject.getClipsSize();
+//        }
+//        return this.name + TAB + leftBreakpoint + TAB + leftStrand + TAB + rightBreakpoint + TAB + leftMateStrand + TAB + size;
+//    }
+
+//    public String getRightInfo() {
+//        int size = 0;
+//        if (rightBreakpointObject != null) {
+//            size = rightBreakpointObject.getClipsSize();
+//        }
+//        return this.name + TAB + rightBreakpoint + TAB + rightStrand + TAB + rightMateStrand + TAB + size;
+//    }
+
+    public void rescueClips(QSVParameters p, TIntObjectMap<int[]> cache, File tumourFile, File normalFile, String softclipDir, int consensusLength, int chrBuffer, Integer minInsertSize) throws Exception {
+
+        Map<Integer, Breakpoint> leftMap = new HashMap<>();
+        Map<Integer, Breakpoint> rightMap = new HashMap<>();
+        TreeMap<Integer, List<UnmappedRead>> splitReads = new TreeMap<>();
+        Integer bp = getOrphanBreakpoint();
+        String ref = getOrphanReference();
+
+
+        if (bp != null) {
+            readRescuedClips(tumourFile, true, ref, bp, leftMap, rightMap, splitReads, consensusLength, chrBuffer, minInsertSize, p.getReadGroupIds(), p.getPairingType());
+            readRescuedClips(normalFile, false, ref, bp, leftMap, rightMap, splitReads, consensusLength, chrBuffer, minInsertSize, p.getReadGroupIds(), p.getPairingType());
+        }
+        findMaxRescueBreakpoint(p, cache, leftMap, rightMap, splitReads, softclipDir);
+    }
+
+    public void findMaxRescueBreakpoint(QSVParameters p, TIntObjectMap<int[]> cache,
+                                        Map<Integer, Breakpoint> leftMap,
+                                        Map<Integer, Breakpoint> rightMap, TreeMap<Integer, List<UnmappedRead>> splitReads, String softclipDir) throws Exception {
+
+        //find maximum breakpoint
+        Breakpoint maxLengthBp = null;
+        int maxLength = 0;
+        int buffer = p.getUpperInsertSize() + 100;
+
+        for (Breakpoint b : leftMap.values()) {
+
+            if (b.getMaxBreakpoint(buffer, splitReads, maxLength)) {
+                if (b.getBreakpoint().intValue() != this.getSingleBreakpoint().getBreakpoint().intValue()) {
+
+                    maxLengthBp = b;
+                    maxLength = b.getMateConsensus().length();
+                }
+            }
+        }
+
+        for (Breakpoint b : rightMap.values()) {
+
+            if (b.getMaxBreakpoint(buffer, splitReads, maxLength)) {
+                if (b.getBreakpoint().intValue() != this.getSingleBreakpoint().getBreakpoint().intValue()) {
+                    maxLengthBp = b;
+                    maxLength = b.getMateConsensus().length();
+                }
+            }
+        }
+
+        if (maxLengthBp != null) {
+
+            if (maxLengthBp.getMateConsensus().length() > 20) {
+                boolean match = maxLengthBp.findRescuedMateBreakpoint(cache, p, softclipDir);
+
+                if (match) {
+                    if (this.getSingleBreakpoint() != null) {
+                        if (this.findMatchingBreakpoints(new SoftClipCluster(maxLengthBp))) {
+                            maxLengthBp.setRescued(false);
+
+                            if (leftBreakpointObject == null) {
+                                leftBreakpointObject = maxLengthBp;
+                            } else {
+                                rightBreakpointObject = maxLengthBp;
+                            }
+
+                            boolean rescuedClips = true;
+                            oneSide = false;
+                            setStartAndEnd();
+                            this.mutationType = defineMutationType();
+                            hasMatchingBreakpoints = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    String getOrphanReference() {
+        if (leftBreakpointObject == null) {
+            //find potential matches for breakpoint
+            return leftReference;
+        }
+
+        if (rightBreakpointObject == null) {
+            return rightReference;
+        }
+        return null;
+    }
+
+    private void readRescuedClips(File file, boolean isTumour, String reference, int bp, Map<Integer, Breakpoint> leftMap, Map<Integer, Breakpoint> rightMap, TreeMap<Integer,
+            List<UnmappedRead>> splitReads, int consensusLength, int chrBuffer, Integer minInsertSize, Collection<String> readGroupIds, String pairingType) throws IOException {
+        int bpStart = bp - chrBuffer;
+        int bpEnd = bp + chrBuffer;
+
+        int referenceStart = bpStart - 120;
+        int referenceEnd = bpEnd + 120;
+        int count = 0;
+
+        try (SamReader reader = SAMFileReaderFactory.createSAMFileReader(file, null, ValidationStringency.SILENT)) {
+
+            SAMRecordIterator iter = reader.queryOverlapping(reference, referenceStart, referenceEnd);
+
+            while (iter.hasNext()) {
+                SAMRecord r = iter.next();
+                String readGroupId = r.getReadGroup().getId();
+
+                if (readGroupIds.contains(readGroupId)) {
+                    if (r.getReadUnmappedFlag()) {
+                        count++;
+                        if (count > 5000) {
+                            break;
+                        }
+                        UnmappedRead splitRead = new UnmappedRead(r, readGroupId, isTumour);
+                        List<UnmappedRead> reads = splitReads.computeIfAbsent(splitRead.getBpPos(), k -> new ArrayList<>());
+                        reads.add(splitRead);
+
+                    } else {
+                        if (!r.getDuplicateReadFlag() && r.getCigarString().contains("S")) {
+                            count++;
+                            if (count > 5000) {
+                                break;
+                            }
+                            Clip c = SoftClipStaticMethods.createSoftClipRecord(r, readGroupId, bpStart, bpEnd, reference);
+                            if (c != null) {
+                                if (c.isLeft()) {
+                                    Breakpoint b = leftMap.get(c.getBpPos());
+                                    if (null == b) {
+                                        b = new Breakpoint(c.getBpPos(), reference, true, consensusLength, minInsertSize);
+                                        b.addTumourClip(c);
+                                        leftMap.put(c.getBpPos(), b);
+                                    } else {
+
+                                        if (isTumour) {
+                                            b.addTumourClip(c);
+                                        } else {
+                                            b.addNormalClip(c);
+                                        }
+                                    }
+                                } else {
+                                    Breakpoint b = rightMap.get(c.getBpPos());
+                                    if (null == b) {
+                                        b = new Breakpoint(c.getBpPos(), reference, false, consensusLength, minInsertSize);
+                                        b.addTumourClip(c);
+                                        rightMap.put(c.getBpPos(), b);
+                                    } else {
+                                        if (isTumour) {
+                                            b.addTumourClip(c);
+                                        } else {
+                                            b.addNormalClip(c);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public Integer getOrphanBreakpoint() throws Exception {
+        if (leftBreakpointObject == null) {
+            //find potential matches for breakpoint
+            return leftBreakpoint;
+        } else if (rightBreakpointObject == null) {
+            return rightBreakpoint;
+        } else {
+            throw new Exception("Null breakpoint");
+        }
+    }
+
+    public boolean alreadyMatched() {
+        return this.alreadyMatched;
+    }
+
+    public void setAlreadyMatched(boolean b) {
+        this.alreadyMatched = b;
+    }
+
+    public String getSoftClipConsensusString(String svId) {
+        String tab = "\t";
+        return svId + tab + leftReference + tab + leftBreakpoint + tab + getLeftSoftClipConsensus()
+                + tab + rightReference + tab + rightBreakpoint + tab + getRightSoftClipConsensus();
+    }
+
+    private String getLeftSoftClipConsensus() {
+        if (leftBreakpointObject == null) {
+            return "\t\t\t\t\t\t\t\t";
+        } else {
+            return leftBreakpointObject.getContigInfo();
+        }
+    }
+
+    private String getRightSoftClipConsensus() {
+        if (rightBreakpointObject == null) {
+            return "\t\t\t\t\t\t\t\t";
+        } else {
+            return rightBreakpointObject.getContigInfo();
+        }
+    }
+
+    public String getMicrohomology(String clusterCategory) {
+        String nonTemp = getNonTemplateSequence(clusterCategory);
+        if (nonTemp.equals(QSVConstants.UNTESTED)) {
+            return QSVConstants.UNTESTED;
+        } else {
+            if (!nonTemp.isEmpty() && !nonTemp.equals(QSVConstants.NOT_FOUND)) {
+                return QSVConstants.NOT_FOUND;
+            }
+        }
+
+        String cat = null;
+
+        if (orientationCategory != null) {
+            if (!orientationCategory.isEmpty()) {
+                cat = orientationCategory;
+            }
+        } else {
+            if (clusterCategory != null) {
+                cat = clusterCategory;
+            }
+        }
+
+        String leftReferenceSeq;
+        String rightReferenceSeq;
+
+        if (cat != null) {
+
+            if (leftBreakpointObject == null || rightBreakpointObject == null) {
+                return "";
+            } else {
+                leftReferenceSeq = leftBreakpointObject.getBreakpointConsenus();
+                rightReferenceSeq = rightBreakpointObject.getBreakpointConsenus();
+            }
+
+            switch (cat) {
+                case QSVConstants.ORIENTATION_2 -> {
+                    String tmp = leftReferenceSeq;
+                    leftReferenceSeq = rightReferenceSeq;
+                    rightReferenceSeq = tmp;
+                }
+                case QSVConstants.ORIENTATION_3 -> rightReferenceSeq = QSVUtil.reverseComplement(rightReferenceSeq);
+                case QSVConstants.ORIENTATION_4 -> leftReferenceSeq = QSVUtil.reverseComplement(leftReferenceSeq);
+            }
+
+            String mh = "";
+            for (int i = 1; i < rightReferenceSeq.length(); i++) {
+                //startPosition
+                String currentRight = rightReferenceSeq.substring(0, i);
+
+                if (leftReferenceSeq.endsWith(currentRight)) {
+                    if (currentRight.length() > mh.length()) {
+                        mh = currentRight;
+                    }
+                }
+            }
+
+            return mh.isEmpty() ? QSVConstants.NOT_FOUND : mh;
+        } else {
+            return QSVConstants.UNTESTED;
+        }
+    }
+
+    public String getOverlappingContigSequence() throws Exception {
+
+        if (leftBreakpointObject == null) {
+            return rightBreakpointObject.getCompleteConsensus();
+        } else if (rightBreakpointObject == null) {
+            return leftBreakpointObject.getCompleteConsensus();
+        } else {
+            QSVAssemble a = new QSVAssemble();
+            return a.getFinalClipContig(leftBreakpointObject.getCompleteConsensus(), rightBreakpointObject.getCompleteConsensus());
+        }
+    }
+
+//    public int getConsensusSplits(boolean isLeft) {
+//        if (isLeft && leftBreakpointObject != null) {
+//            return leftBreakpointObject.getSplitConsensusReads();
+//        }
+//        if (!isLeft && rightBreakpointObject != null) {
+//            return rightBreakpointObject.getSplitConsensusReads();
+//        }
+//        return 0;
+//    }
+
+//    public int getSplitReadTotal(boolean isLeft) {
+//        if (isLeft && leftBreakpointObject != null) {
+//            return leftBreakpointObject.getSplitReadsSize();
+//        }
+//        if (!isLeft && rightBreakpointObject != null) {
+//            return rightBreakpointObject.getSplitReadsSize();
+//        }
+//        return 0;
+//    }
+
+//    public int getConsensusClips(boolean isLeft) {
+//        if (isLeft && leftBreakpointObject != null) {
+//            return leftBreakpointObject.getClipConsensusReads();
+//        }
+//        if (!isLeft && rightBreakpointObject != null) {
+//            return rightBreakpointObject.getClipConsensusReads();
+//        }
+//        return 0;
+//    }
+
+//    public String getBreakpointConsensus(boolean isLeft) {
+//        if (isLeft) {
+//            if (leftBreakpointObject != null) {
+//                return leftBreakpointObject.getMateConsensus();
+//            }
+//        } else {
+//            if (rightBreakpointObject != null) {
+//                return rightBreakpointObject.getMateConsensus();
+//            }
+//        }
+//        return "";
+//    }
+
+//    public int getClipSize(boolean isLeft) {
+//        if (isLeft && leftBreakpointObject != null) {
+//            return leftBreakpointObject.getTumourClips().size() + leftBreakpointObject.getNormalClips().size();
+//        }
+//        if (!isLeft && rightBreakpointObject != null) {
+//            return rightBreakpointObject.getTumourClips().size() + rightBreakpointObject.getNormalClips().size();
+//        }
+//        return 0;
+//    }
+
+    public String getNonTemplateSequence(String clusterCategory) {
+        String nonTmp = QSVConstants.UNTESTED;
+        if (hasMatchingBreakpoints) {
+
+            String cat = null;
+
+            if (orientationCategory != null) {
+                if (!orientationCategory.isEmpty()) {
+                    cat = orientationCategory;
+                }
+            } else {
+                if (clusterCategory != null) {
+                    cat = clusterCategory;
+                }
+            }
+
+            if (cat != null) {
+
+                String leftClipSeq = rightBreakpointObject.getMateConsensusPosStrand();
+                String rightClipSeq = leftBreakpointObject.getMateConsensusPosStrand();
+                int leftNonTemp = rightBreakpointObject.getNonTempBases();
+                int rightNonTemp = leftBreakpointObject.getNonTempBases();
+
+                if (cat.equals(QSVConstants.ORIENTATION_2)) {
+                    String tmp = leftClipSeq;
+                    leftClipSeq = rightClipSeq;
+                    rightClipSeq = tmp;
+                }
+
+                if (leftNonTemp == rightNonTemp) {
+                    if (leftNonTemp == 0) {
+                        nonTmp = "";
+                    }
+                    String currentRight = rightClipSeq.substring(0, rightNonTemp);
+                    if (leftClipSeq.endsWith(currentRight)) {
+                        nonTmp = currentRight;
+                    }
+                }
+            }
+        }
+        return nonTmp;
+    }
+
+    public boolean matchesSplitReadBreakpoints(String splitLeftReference,
+                                               String splitRightReference, int splitLeftBreakpoint, int splitRightBreakpoint) {
+
+        if (orientationCategory.equals(QSVConstants.ORIENTATION_2)) {
+            return leftReference.equals(splitRightReference) && rightReference.equals(splitLeftReference) &&
+                    leftBreakpoint == splitRightBreakpoint && rightBreakpoint == splitLeftBreakpoint;
+
+        } else {
+            return leftReference.equals(splitLeftReference) && rightReference.equals(splitRightReference) &&
+                    leftBreakpoint == splitLeftBreakpoint && rightBreakpoint == splitRightBreakpoint;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SoftClipCluster other = (SoftClipCluster) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
 }
 

--- a/qsv/src/org/qcmg/qsv/softclip/SoftClipStaticMethods.java
+++ b/qsv/src/org/qcmg/qsv/softclip/SoftClipStaticMethods.java
@@ -113,7 +113,7 @@ public class SoftClipStaticMethods {
 	}
 
 	public static String getSoftClipFile(String chromosome, String type, String softclipDir) {
-		return softclipDir + QSVParameters.FILE_SEPERATOR + type  + "."+ chromosome + ".clip";
+		return softclipDir + QSVParameters.FILE_SEPARATOR + type  + "."+ chromosome + ".clip";
 	}
 
 }

--- a/qsv/src/org/qcmg/qsv/splitread/UnmappedRead.java
+++ b/qsv/src/org/qcmg/qsv/splitread/UnmappedRead.java
@@ -23,7 +23,7 @@ public class UnmappedRead {
 	}
 	
 	public UnmappedRead(String line, boolean isTumour) {
-		String values[] = line.split(",");
+		String [] values = line.split(",");
 		this.readName = values[1];
 		this.reference = values[2];
 		this.bpPos = Integer.parseInt(values[3]);
@@ -54,10 +54,6 @@ public class UnmappedRead {
 	public String getSequence() {
 		return sequence;
 	}
-
-	public String toTmpString() {
-		return "unmapped" + "," + readName + "," + reference + "," + bpPos + "," + sequence +  QSVUtil.getNewLine();		
- 	}
 
 	@Override
 	public String toString() {

--- a/qsv/test/org/qcmg/qsv/OptionsTest.java
+++ b/qsv/test/org/qcmg/qsv/OptionsTest.java
@@ -1,10 +1,5 @@
 package org.qcmg.qsv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -27,6 +22,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.meta.QExec;
 import org.qcmg.qsv.util.TestUtil;
+
+import static org.junit.Assert.*;
 
 public class OptionsTest {
 
@@ -144,12 +141,12 @@ public class OptionsTest {
         assertEquals(options.getLog(), "test.log");
         assertEquals(options.getLogLevel(), "DEBUG");
         assertEquals(options.getSampleName(), "test");
-        assertEquals(options.getOutputDirName(), tmp.toString() + Options.FILE_SEPERATOR + options.getUuid() + Options.FILE_SEPERATOR);
+        assertEquals(options.getOutputDirName(), tmp + Options.FILE_SEPARATOR + options.getUuid() + Options.FILE_SEPARATOR);
         assertTrue(options.getReference().contains("reference_file"));
         assertEquals(options.getPreprocessMode(), "both");
         assertEquals(options.getAnalysisMode(), "both");        
         assertEquals(options.getMaxISizeCount(), "all");
-        assertEquals(options.getMinInsertSize(), new Integer(50));
+        assertEquals(options.getMinInsertSize(), Integer.valueOf(50));
         assertTrue(options.isQCMG());
         assertEquals(options.getPairingType(), "lmp");
         assertEquals(options.getPairQuery(), "and(Cigar_M > 35,option_SM > 14,MD_mismatch < 3,Flag_DuplicateRead == false)");
@@ -159,7 +156,7 @@ public class OptionsTest {
         assertEquals(options.getMapper(), "bioscope");
         assertEquals(options.getClipQuery(), "and(Cigar_M > 35,option_SM > 14,MD_mismatch < 3,Flag_DuplicateRead == false)");
         assertEquals(options.getClipSize().intValue(), 3);
-        assertEquals(options.getConsensusLength(), new Integer(20));
+        assertEquals(options.getConsensusLength(), Integer.valueOf(20));
         
         //tumor
         assertEquals(options.getInputFile(), file2);
@@ -181,7 +178,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void testVersionOption() throws QSVException, InvalidFileFormatException, IOException {
+    public void testVersionOption() throws QSVException, IOException {
     	//long form option
         Options options = new Options(new String[] {"--version"});
         assertTrue(options.hasVersionOption());
@@ -198,13 +195,13 @@ public class OptionsTest {
     }
     
     @Test(expected = QSVException.class)
-    public void testBadOptionsNoLogFile() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsNoLogFile() throws QSVException, IOException {
         Options options = new Options(new String[] {"--version"});
         options.detectBadOptions();
     }
     
     @Test(expected = QSVException.class)
-    public void testBadOptionsBadModes() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsBadModes() throws QSVException, IOException {
         Options options = new Options(new String[] {"--version"});
         options.setLogFile("log");
         options.setPreprocessMode("pair");
@@ -213,7 +210,7 @@ public class OptionsTest {
     }
     
     @Test(expected = QSVException.class)
-    public void testBadOptionsBadModes2() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsBadModes2() throws QSVException, IOException {
         Options options = new Options(new String[] {"--version"});
         options.setLogFile("log");
         options.setPreprocessMode("clip");
@@ -222,7 +219,7 @@ public class OptionsTest {
     }
     
     @Test(expected = QSVException.class)
-    public void testBadOptionsNoPairType() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsNoPairType() throws QSVException, IOException {
     	File tmp = testFolder.newFolder();
     	String[] args = TestUtil.getValidOptions(tmp, file1, file2, "pair", "pair");
     	Options options = new Options(args);
@@ -232,7 +229,7 @@ public class OptionsTest {
     }
     
     @Test(expected = QSVException.class)
-    public void testBadOptionsNoMapper() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsNoMapper() throws QSVException, IOException {
     	File tmp = testFolder.newFolder();
     	String[] args = TestUtil.getValidOptions(tmp, file1, file2, "pair", "pair");
     	Options options = new Options(args);
@@ -243,7 +240,7 @@ public class OptionsTest {
     }
     
     @Test(expected = QSVException.class)
-    public void testBadOptionsNoTmpDir() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsNoTmpDir() throws QSVException, IOException {
     	File tmp = testFolder.newFolder();
     	String[] args = TestUtil.getValidOptions(tmp, file1, file2, "both", "both");
     	Options options = new Options(args);
@@ -254,7 +251,7 @@ public class OptionsTest {
     
    
     @Test(expected = QSVException.class)
-    public void testBadOptionsBadAnalysisMode() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsBadAnalysisMode() throws QSVException, IOException {
         Options options = new Options(new String[] {"--version"});
         options.setLogFile("log");
         options.setPreprocessMode("none");
@@ -341,7 +338,7 @@ public class OptionsTest {
 	 	options = new Options(newArgs);
 	 	options.parseIniFile();
 	 	Assert.assertEquals( options.getUuid(), "test-uuid" );
-	 	assertTrue(options.getOutputDirName().endsWith("test-uuid"+Options.FILE_SEPERATOR));
+	 	assertTrue(options.getOutputDirName().endsWith("test-uuid"+Options.FILE_SEPARATOR));
     			
     }
     
@@ -412,7 +409,7 @@ public class OptionsTest {
     }
     
     @Test
-    public void outputDirTest() throws InvalidFileFormatException, QSVException, IOException {
+    public void outputDirTest() throws QSVException, IOException {
     	 
 	 	//output dir not exists without uuid option
     	File tmp1 = testFolder.newFolder();   	
@@ -427,7 +424,7 @@ public class OptionsTest {
     	Path target = new File(tmp2, "test.new.ini").toPath();    	
     	Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);   	
     	FileUtils.deleteDirectory(tmp1);
-    	assertTrue(!tmp1.exists());
+        assertFalse(tmp1.exists());
     	
     	args[1] = target.getParent() + "/" + target.getFileName();
  		options = new Options(args);     	 
@@ -462,16 +459,16 @@ public class OptionsTest {
     }
     
     @Test(expected = QSVException.class)
-    public void testBadOptionsIniFileOption() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsIniFileOption() throws QSVException, IOException {
     	//removed log option from command line, it should inside the ini
     	//Options options = new Options(new String[] {"-log", "log.log", "--loglevel", "INFO"});
     	Options options = new Options(new String[] {"-help"});
-        assertEquals(null, options.getIniFile());
+        assertNull(options.getIniFile());
         options.detectBadOptions();
     }
     
     @Test
-    public void testBadOptionsReference() throws QSVException, InvalidFileFormatException, IOException {
+    public void testBadOptionsReference() throws QSVException, IOException {
     	File tmp = testFolder.newFolder();
     	File iniFile = testFolder.newFile("file.ini");
     	File genericInputFile = testFolder.newFile();
@@ -497,7 +494,7 @@ public class OptionsTest {
         try {
         	options.parseIniFile();
         	Assert.fail("Should have thrown an exception");
-        } catch (QSVException qsve) {}
+        } catch (QSVException ignored) {}
         
         /*
          * create ref index file but not with expected suffix - should still throw an exception
@@ -506,7 +503,7 @@ public class OptionsTest {
         	testFolder.newFile("reference.fasta.fia");
         	options.parseIniFile();
         	Assert.fail("Should have thrown an exception");
-        } catch (QSVException qsve) {}
+        } catch (QSVException ignored) {}
         
         /*
          * create reference index file next to reference file with correct suffix

--- a/qsv/test/org/qcmg/qsv/QSVParametersTest.java
+++ b/qsv/test/org/qcmg/qsv/QSVParametersTest.java
@@ -64,4 +64,26 @@ public class QSVParametersTest {
         assertEquals("ICGC-DBLG-20110506-01-TD", p.getSampleId());
         assertTrue(p.isTumor());
     }
+
+    @Test
+    public void testGetUpdatedFileName() {
+        // Given
+        String fileName1 = "file.sam";
+        String fileName2 = "file.bam";
+        String fileName3 = "file.cram";
+        String fileName4 = "file.file";
+        String extension = ".new";
+
+        // When
+        String updatedName1 = QSVParameters.getUpdatedFileName(fileName1, extension);
+        String updatedName2 = QSVParameters.getUpdatedFileName(fileName2, extension);
+        String updatedName3 = QSVParameters.getUpdatedFileName(fileName3, extension);
+        String updatedName4 = QSVParameters.getUpdatedFileName(fileName4, extension);
+
+        // Then
+        assertEquals("file" + extension + ".sam", updatedName1);
+        assertEquals("file" + extension + ".bam", updatedName2);
+        assertEquals("file" + extension + ".cram", updatedName3);
+        assertEquals("file.file" + extension, updatedName4);
+    }
 }

--- a/qsv/test/org/qcmg/qsv/blat/BLATTest.java
+++ b/qsv/test/org/qcmg/qsv/blat/BLATTest.java
@@ -30,7 +30,7 @@ public class BLATTest {
 	public void setUp() throws Exception {
 		blat = new BLAT("localhost", "8000", "/test");
 		assertEquals(blat.getCommands().size(), 5);
-		assertEquals(blat.getCommands().get(0), "/test" + QSVParameters.FILE_SEPERATOR + "gfClient");
+		assertEquals(blat.getCommands().get(0), "/test" + QSVParameters.FILE_SEPARATOR + "gfClient");
 	}
 	
 	@Test(expected=QSVException.class)

--- a/qsv/test/org/qcmg/qsv/isize/CalculateISizeTest.java
+++ b/qsv/test/org/qcmg/qsv/isize/CalculateISizeTest.java
@@ -18,86 +18,29 @@ public class CalculateISizeTest {
 	CalculateISize isize;
 	ConcurrentHashMap<Integer, AtomicInteger>  map;
 
-	@Before
-	public void setUp() throws QSVException {
-		map = new ConcurrentHashMap<Integer,AtomicInteger>();
-		
-		map.put(new Integer(0), new AtomicInteger(22956));
-		map.put(new Integer(40), new AtomicInteger(2));
-		map.put(new Integer(80), new AtomicInteger(2));
-		map.put(new Integer(90), new AtomicInteger(376));
-		map.put(new Integer(100), new AtomicInteger(2820));
-		map.put(new Integer(110), new AtomicInteger(5772));
-		map.put(new Integer(120), new AtomicInteger(8896));
-		map.put(new Integer(130), new AtomicInteger(11358));
-		map.put(new Integer(140), new AtomicInteger(12626));
-		map.put(new Integer(150), new AtomicInteger(13437));
-		map.put(new Integer(160), new AtomicInteger(14032));
-		map.put(new Integer(170), new AtomicInteger(14451));
-		map.put(new Integer(180), new AtomicInteger(14537));
-		map.put(new Integer(190), new AtomicInteger(14615));
-		map.put(new Integer(200), new AtomicInteger(15806));
-		map.put(new Integer(210), new AtomicInteger(16309));
-		map.put(new Integer(220), new AtomicInteger(17540));
-		map.put(new Integer(230), new AtomicInteger(20509));
-		map.put(new Integer(240), new AtomicInteger(24656));
-		map.put(new Integer(250), new AtomicInteger(28513));
-		map.put(new Integer(260), new AtomicInteger(34720));
-		map.put(new Integer(270), new AtomicInteger(40961));
-		map.put(new Integer(280), new AtomicInteger(49129));
-		map.put(new Integer(290), new AtomicInteger(58384));
-		map.put(new Integer(300), new AtomicInteger(71585));
-		map.put(new Integer(310), new AtomicInteger(73491));
-		map.put(new Integer(320), new AtomicInteger(67551));
-		map.put(new Integer(330), new AtomicInteger(57469));
-		map.put(new Integer(340), new AtomicInteger(46505));
-		map.put(new Integer(350), new AtomicInteger(35617));
-		map.put(new Integer(360), new AtomicInteger(26385));
-		map.put(new Integer(370), new AtomicInteger(17762));
-		map.put(new Integer(380), new AtomicInteger(10119));
-		map.put(new Integer(390), new AtomicInteger(4459));
-		map.put(new Integer(400), new AtomicInteger(1704));
-		map.put(new Integer(410), new AtomicInteger(782));
-		map.put(new Integer(420), new AtomicInteger(536));
-		map.put(new Integer(430), new AtomicInteger(372));
-		map.put(new Integer(440), new AtomicInteger(268));
-		map.put(new Integer(450), new AtomicInteger(266));
-		map.put(new Integer(460), new AtomicInteger(234));
-		map.put(new Integer(470), new AtomicInteger(230));
-		map.put(new Integer(480), new AtomicInteger(254));
-		map.put(new Integer(490), new AtomicInteger(214));
-		map.put(new Integer(500), new AtomicInteger(180));
-		map.put(new Integer(510), new AtomicInteger(148));
-		map.put(new Integer(520), new AtomicInteger(178));
-		map.put(new Integer(530), new AtomicInteger(64));
-		map.put(new Integer(540), new AtomicInteger(44));
-		map.put(new Integer(550), new AtomicInteger(30));
-		map.put(new Integer(560), new AtomicInteger(44));
-		map.put(new Integer(570), new AtomicInteger(20));
-		map.put(new Integer(580), new AtomicInteger(30));
-		map.put(new Integer(590), new AtomicInteger(22));
-		map.put(new Integer(600), new AtomicInteger(32));
-		map.put(new Integer(610), new AtomicInteger(28));
-		map.put(new Integer(620), new AtomicInteger(42));
-		map.put(new Integer(630), new AtomicInteger(22));
-		map.put(new Integer(640), new AtomicInteger(18));
-		map.put(new Integer(650), new AtomicInteger(10));
-		map.put(new Integer(660), new AtomicInteger(2));
-		map.put(new Integer(670), new AtomicInteger(10));
-		map.put(new Integer(680), new AtomicInteger(4));
-		map.put(new Integer(690), new AtomicInteger(8));
-		map.put(new Integer(700), new AtomicInteger(32));
-		map.put(new Integer(710), new AtomicInteger(22));
-		map.put(new Integer(720), new AtomicInteger(18));
-		map.put(new Integer(730), new AtomicInteger(8));
-		map.put(new Integer(780), new AtomicInteger(4));
-		map.put(new Integer(790), new AtomicInteger(2));
-		map.put(new Integer(800), new AtomicInteger(8));
-		map.put(new Integer(810), new AtomicInteger(2));
-		map.put(new Integer(820), new AtomicInteger(4));
-		map.put(new Integer(860), new AtomicInteger(2));
+    @Before
+    public void setUp() throws QSVException {
+        map = new ConcurrentHashMap<>();
 
-	}
+        int[] keys = new int[]{0, 40, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220,
+                230, 240, 250, 260, 270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390,
+                400, 410, 420, 430, 440, 450, 460, 470, 480, 490, 500, 510, 520, 530, 540, 550, 560,
+                570, 580, 590, 600, 610, 620, 630, 640, 650, 660, 670, 680, 690, 700, 710, 720, 730,
+                780, 790, 800, 810, 820, 860};
+        int[] values = new int[]{22956, 2, 2, 376, 2820, 5772, 8896, 11358, 12626, 13437, 14032, 14451, 14537, 14615,
+                15806, 16309, 17540, 20509, 24656, 28513, 34720, 40961, 49129, 58384, 71585, 73491,
+                67551, 57469, 46505, 35617, 26385, 17762, 10119, 4459, 1704, 782, 536, 372, 268, 266,
+                234, 230, 254, 214, 180, 148, 178, 64, 44, 30, 44, 20, 30, 22, 32, 28, 42, 22, 18, 10,
+                2, 10, 4, 8, 32, 22, 18, 8, 4, 2, 8, 2, 4, 2};
+
+        for (int i = 0; i < keys.length; i++) {
+            putValueInMap(keys[i], values[i]);
+        }
+    }
+
+    private void putValueInMap(int key, int value) {
+        map.put(key, new AtomicInteger(value));
+    }
 	
 	@After
 	public void tearDown() {
@@ -106,7 +49,7 @@ public class CalculateISizeTest {
 	}	
 	
 	@Test
-	public void testFindMaxIndex() throws QSVException {
+	public void testFindMaxIndex() {
 		double[] array = new double[4];
 		array[0] = 1.34;
 		array[1] = 2.34;
@@ -120,7 +63,7 @@ public class CalculateISizeTest {
 	@Test(expected=QSVException.class)
 	public void  testCalculateThrowsException() throws QSVException {
 		map.clear();
-		map.put(new Integer(10), new AtomicInteger(6844));
+		map.put(10, new AtomicInteger(6844));
 		
 		
 		assertTrue(map.size() < 10);
@@ -138,7 +81,7 @@ public class CalculateISizeTest {
 	
 	@Test
 	public void testGetLogMaps() {
-		map.remove(new Integer(0));
+		map.remove(0);
 		isize = new CalculateISize(map);
 		isize.getLogMaps();
 		assertEquals(73, map.size());
@@ -148,13 +91,13 @@ public class CalculateISizeTest {
 	
 	@Test
 	public void findFirstDerivative() {
-		map.remove(new Integer(0));
+		map.remove(0);
 		isize = new CalculateISize(map);
-		Map<Integer, Double> xyMap = new TreeMap<Integer, Double>();
+		Map<Integer, Double> xyMap = new TreeMap<>();
 		
-		xyMap.put(new Integer(80), new Double(0.301029995663981));
-		xyMap.put(new Integer(90), new Double(2.57518784492766));
-		xyMap.put(new Integer(100), new Double(3.45024910831936));		
+		xyMap.put( 80, 0.301029995663981);
+		xyMap.put( 90, 2.57518784492766);
+		xyMap.put( 100, 3.45024910831936);
 		
 		double[] dydx = isize.findFirstDerivative(xyMap);
 		

--- a/qsv/test/org/qcmg/qsv/softclip/BreakpointTest.java
+++ b/qsv/test/org/qcmg/qsv/softclip/BreakpointTest.java
@@ -1,33 +1,18 @@
 package org.qcmg.qsv.softclip;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.OptionalInt;
-import java.util.Set;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.model.BLATRecord;
 import org.qcmg.qsv.QSVException;
-import org.qcmg.qsv.QSVParameters;
 import org.qcmg.qsv.assemble.ConsensusRead;
 import org.qcmg.qsv.splitread.UnmappedRead;
 import org.qcmg.qsv.util.QSVUtil;
 import org.qcmg.qsv.util.TestUtil;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
 
 public class BreakpointTest {
 	
@@ -73,15 +58,15 @@ public class BreakpointTest {
 		try {
 			Breakpoint.parseMatchingSplitReads(header, null);
 			fail("Should have thrown an IAE");
-		} catch (IllegalArgumentException iae) {}
+		} catch (IllegalArgumentException ignored) {}
 		try {
 			Breakpoint.parseMatchingSplitReads(null, splitReadsList);
 			fail("Should have thrown an IAE");
-		} catch (IllegalArgumentException iae) {}
+		} catch (IllegalArgumentException ignored) {}
 		try {
 			Breakpoint.parseMatchingSplitReads(null, null);
 			fail("Should have thrown an IAE");
-		} catch (IllegalArgumentException iae) {}
+		} catch (IllegalArgumentException ignored) {}
 		
 		header += "what a great header";
 		splitReadsList.add(new UnmappedRead("column1,what a really great header,column2,3,column4", true));
@@ -202,7 +187,7 @@ READ:GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAA
 		BLATRecord r = new BLATRecord.Builder("52	4	0	0	0	0	1	1	+	GL000219.1_165002_true_+	66	9	65	GL000219.1	179198	165421	165478	2	36,20,	9,45,	165421,165458,").build();
 		
 		assertEquals(0, b.getMateBreakpoint());
-		assertEquals(true, b.findMateBreakpoint(r));
+        assertTrue(b.findMateBreakpoint(r));
 		assertEquals(165478, b.getMateBreakpoint());
 		assertEquals("GL000219.1", b.getMateReference());
 		
@@ -210,7 +195,7 @@ READ:GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAA
 		 * try and match to another blat record - aligned by the tiled aligner of course...
 		 */
 		BLATRecord r2 = new BLATRecord.Builder("57	7	0	0	1	1	0	0	+	name	66	-1	64	GL000219.1	12345	165414	165479	2	43,19	1,46	165415,165460").build();
-		assertEquals(true, b.findMateBreakpoint(r2));
+        assertTrue(b.findMateBreakpoint(r2));
 		assertEquals(165479, b.getMateBreakpoint());			// out by 1
 		assertEquals("GL000219.1", b.getMateReference());
 		assertEquals("GL000219.1_165002_true_+", b.getName());
@@ -250,7 +235,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		 * try and match to another blat record - aligned by the tiled aligner of course...
 		 */
 		BLATRecord r2 = new BLATRecord.Builder("25	0	0	0	0	0	0	0	+	name	25	0	25	chr11	12345	18918919	18918944	1	24	1	18918920").build();
-		assertEquals(true, b.findMateBreakpoint(r2));
+        assertTrue(b.findMateBreakpoint(r2));
 		assertEquals(18918920, b.getMateBreakpoint());			// out by 1
 		assertEquals("chr11", b.getMateReference());
 		assertEquals("chr9_25061047_false_+", b.getName());
@@ -263,8 +248,8 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		String value = "42	1	0	0	0	0	0	0	+	name	59	0	43	chr10	135534747	89700259	89700301	1	42	1	89700259";
 		String[] values =value.split("\t");
 		BLATRecord tiledAlignerBlatRecord = new BLATRecord.Builder(values).build();
-		
-		assertEquals(true, breakpoint.findMateBreakpoint(tiledAlignerBlatRecord));
+
+        assertTrue(breakpoint.findMateBreakpoint(tiledAlignerBlatRecord));
 		assertEquals(QSVUtil.PLUS, breakpoint.getMateStrand());
 		assertEquals("chr10", breakpoint.getMateReference());
 		assertEquals(89700301, breakpoint.getMateBreakpoint());
@@ -331,7 +316,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		BLATRecord record = new BLATRecord.Builder(values).build();
 		
 		breakpoint = TestUtil.getBreakpointNoChr(true, false, 20);
-		assertEquals(true, breakpoint.findMateBreakpoint(record));
+        assertTrue(breakpoint.findMateBreakpoint(record));
 		
 		assertEquals(QSVUtil.PLUS, breakpoint.getMateStrand());
 		assertEquals("chr10", breakpoint.getMateReference());
@@ -395,9 +380,9 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 				}
 			}
 		}
-//		//char strand, int clipSize, int length, int readLength,
 		ConsensusRead cr = Breakpoint.calculate(breakpoint.getStrand(), breakpoint.getClipsSize(), posLength, posReadLength, breakpoint.getTumourClips(), breakpoint.getNormalClips(), breakpoint.isGermline(), breakpoint.isLeft(), 20);
-		assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT",cr.getSequence());
+        assert cr != null;
+        assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT", cr.getSequence());
 	}
 	
 	@Test
@@ -419,7 +404,8 @@ FULL:AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGG
 CLIPS:AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTA
 READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT
 		 */
-		assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTA", cr.getClipMateSequence());
+        assert cr != null;
+        assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTA", cr.getClipMateSequence());
 		assertEquals("AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT", cr.getReferenceSequence());
 		assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT", cr.getSequence());
 	}
@@ -450,7 +436,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		breakpoint.setMateReference("chr1");
 		assertNull(breakpoint.compare("chr2", 12345));
 		assertNull(breakpoint.compare("chr1", 12356));
-		assertEquals(new Integer(12350), breakpoint.compare("chr1", 12350));
+		assertEquals(Integer.valueOf(12350), breakpoint.compare("chr1", 12350));
 	}
 	
 	@Test
@@ -471,7 +457,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 	private void assertStrand(char strand1, char strand2, boolean isGermline,
 			int posStrandCount, int negStrandCount) throws QSVException {
 		breakpoint = new Breakpoint(1, "reference", true, 1, 1);	
-		HashSet<Clip> set = new HashSet<Clip>();
+		HashSet<Clip> set = new HashSet<>();
 		set.add(new Clip("test,chr10,89712341,"+strand1+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));		
 		set.add(new Clip("test2,chr10,89712341,"+strand2+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));
 		for (Clip c : set) {
@@ -510,21 +496,21 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 	@Test
 	public void belowMinInsertSizeSameBP() {
 		// same bp and mate bp
-		assertEquals(true, Breakpoint.belowMinInsertSize(0, 0, 0));
-		assertEquals(true, Breakpoint.belowMinInsertSize(1, 1, 0));
-		assertEquals(true, Breakpoint.belowMinInsertSize(12345, 12345, 0));
-		assertEquals(true, Breakpoint.belowMinInsertSize(-12345, -12345, 0));
+        assertTrue(Breakpoint.belowMinInsertSize(0, 0, 0));
+        assertTrue(Breakpoint.belowMinInsertSize(1, 1, 0));
+        assertTrue(Breakpoint.belowMinInsertSize(12345, 12345, 0));
+        assertTrue(Breakpoint.belowMinInsertSize(-12345, -12345, 0));
 	}
 	@Test
 	public void belowMinInsertSizeDiffBP() {
 		// same bp and mate bp
-		assertEquals(false, Breakpoint.belowMinInsertSize(0, 1, 0));
-		assertEquals(true, Breakpoint.belowMinInsertSize(0, 1, 1));
-		assertEquals(true, Breakpoint.belowMinInsertSize(1, 0, 1));
-		assertEquals(false, Breakpoint.belowMinInsertSize(2, 0, 1));
-		assertEquals(false, Breakpoint.belowMinInsertSize(0, 2, 1));
-		assertEquals(true, Breakpoint.belowMinInsertSize(0, 2, 2));
-		assertEquals(true, Breakpoint.belowMinInsertSize(2, 1, 2));
+        assertFalse(Breakpoint.belowMinInsertSize(0, 1, 0));
+        assertTrue(Breakpoint.belowMinInsertSize(0, 1, 1));
+        assertTrue(Breakpoint.belowMinInsertSize(1, 0, 1));
+        assertFalse(Breakpoint.belowMinInsertSize(2, 0, 1));
+        assertFalse(Breakpoint.belowMinInsertSize(0, 2, 1));
+        assertTrue(Breakpoint.belowMinInsertSize(0, 2, 2));
+        assertTrue(Breakpoint.belowMinInsertSize(2, 1, 2));
 	}
 	
 	private int[][] setUpBases(int a, int b, int c, int d, int e) {


### PR DESCRIPTION
# Description

qSV needs to be able to run with CRAM files. There were a few places where qSV was catering specifically foe SAM and BAM files, and this PR addresses that.
 Removed references to "BLAT" in the logging (confusing seeing as BLAT is not used)



## Type of change

Please delete options that are not relevant.


- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Additional unit tests, and code has been run and compared against older code to check for equality

# Are WDL Updates Required?

no

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
