### PR TITLE
perf(adamajava): ensure code that calls SAMRecord.getReadGroup() does so sparingly

### DIFF
--- a/qbammerge/src/org/qcmg/bammerge/FileMerger.java
+++ b/qbammerge/src/org/qcmg/bammerge/FileMerger.java
@@ -780,8 +780,9 @@ public final class FileMerger {
 
 		while (iter.hasNext() && !hasReachedNumberRecords()) {
 			SAMRecord record = iter.next();
+			SAMReadGroupRecord srgr = record.getReadGroup();
 
-			if (null == record.getReadGroup()) {
+			if (null == srgr) {
 				logger.warn(record.getSAMString());
 				logger.warn(record.getAttribute(RG_TAG).toString());
 				logger.warn(record.getHeader().toString());
@@ -790,7 +791,7 @@ public final class FileMerger {
 
 			SamReader fileReader = iter.getCurrentSAMFileReader();
 			if ( ! replacementMap.isEmpty()) {
-				String oldGroup = record.getReadGroup().getReadGroupId();
+				String oldGroup = srgr.getReadGroupId();
 				File file = inputReader.getFile(fileReader);
 				String newGroup = getReplacementGroup(file, oldGroup);
 				if (null != newGroup) {
@@ -800,7 +801,6 @@ public final class FileMerger {
 			Integer oldZc = record.getIntegerAttribute(ZC);
 			if (null == oldZc) {
 				Integer zc = inputReader.getDefaultZc(fileReader);
-//				assert null != zc;
 				record.setAttribute(ZC, zc);
 			} else {
 				Set<Integer> permissibleZcs = inputReader.getOldZcs(fileReader);

--- a/qpicard/src/org/qcmg/picard/MultiSAMFileReader.java
+++ b/qpicard/src/org/qcmg/picard/MultiSAMFileReader.java
@@ -48,7 +48,7 @@ public final class MultiSAMFileReader implements Closeable, Iterable<SAMRecord> 
 			if (SAMFileHeader.SortOrder.coordinate != header.getSortOrder()) {
 				throw new Exception("Input files must be coordinate sorted");
 			}
-			final Set<Integer> zcs = new HashSet<Integer>(8);
+			final Set<Integer> zcs = new HashSet<>(8);
 			for (SAMReadGroupRecord record : header.getReadGroups()) {
 				final String attribute  = getAttributeZc( record);
 				if (null != attribute ) {				 

--- a/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizer.java
+++ b/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizer.java
@@ -16,11 +16,7 @@ import static java.util.stream.Collectors.toList;
 import java.io.File;
 import java.util.List;
 
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.ValidationStringency;
-import htsjdk.samtools.SAMProgramRecord;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.*;
 
 import org.qcmg.common.date.DateUtils;
 import org.qcmg.common.log.QLevel;
@@ -68,7 +64,7 @@ public class BamSummarizer implements Summarizer {
 		bamSummaryReport.setStartTime(DateUtils.getCurrentDateAsString());
 		
 		try(SamReader reader = SAMFileReaderFactory.createSAMFileReaderAsStream(input, index, vs);) {
-			readGroupIds = reader.getFileHeader().getReadGroups().stream().map( it -> it.getId()  ).collect(toList()); 
+			readGroupIds = reader.getFileHeader().getReadGroups().stream().map(SAMReadGroupRecord::getId).collect(toList());
 			bamSummaryReport.setReadGroups(readGroupIds);
 			
 			boolean logLevelEnabled = logger.isLevelEnabled(QLevel.DEBUG);

--- a/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizerMT.java
+++ b/qprofiler/src/org/qcmg/qprofiler/bam/BamSummarizerMT.java
@@ -25,14 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.ValidationStringency;
-import htsjdk.samtools.SAMProgramRecord;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMRecordIterator;
-import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.*;
 
 import org.qcmg.common.date.DateUtils;
 import org.qcmg.common.log.QLogger;
@@ -120,7 +113,7 @@ public class BamSummarizerMT implements Summarizer {
 			
 			samSeqDict = reader.getFileHeader().getSequenceDictionary();
 			bamHeader = HeaderUtils.getHeaderStringFromHeader(header);
-			readGroupIds = header.getReadGroups().stream().map( it -> it.getId()  ).collect(toList()); 
+			readGroupIds = header.getReadGroups().stream().map(SAMReadGroupRecord::getId).collect(toList());
 
 			List<SAMProgramRecord> pgLines = header.getProgramRecords();
 			for (SAMProgramRecord pgLine : pgLines) {

--- a/qprofiler/src/org/qcmg/qprofiler/bam/BamSummaryReport.java
+++ b/qprofiler/src/org/qcmg/qprofiler/bam/BamSummaryReport.java
@@ -484,9 +484,8 @@ public class BamSummaryReport extends SummaryReport {
         updateRecordsParsed();
         MAPQMatrix matrix = null;
 
-        String readGroup = SummaryReportUtils.UNKNOWN_READGROUP;
-        if (record.getReadGroup() != null && record.getReadGroup().getId() != null)
-            readGroup = record.getReadGroup().getReadGroupId();
+        SAMReadGroupRecord srgr = record.getReadGroup();
+        String readGroup = srgr == null ? SummaryReportUtils.UNKNOWN_READGROUP : srgr.getReadGroupId();
 
         // Xu code: check if record has its fail or duplicate flag set. if so, miss out some of the summaries
         //anyway, add to summary and then add to it's readgroup

--- a/qprofiler/src/org/qcmg/qprofiler/summarise/ReadGroupSummary.java
+++ b/qprofiler/src/org/qcmg/qprofiler/summarise/ReadGroupSummary.java
@@ -46,11 +46,10 @@ public class ReadGroupSummary {
 	QCMGAtomicLongArray readLength = new QCMGAtomicLongArray(128);
 	QCMGAtomicLongArray overlapBase = new QCMGAtomicLongArray(128);	
 		 
-	//QCMGAtomicLongArray.get(arrayTlenLimit) for tlen=[bigTlenValue, ~)
-	QCMGAtomicLongArray isize = new QCMGAtomicLongArray(bigTlenValue + 1);		
+	QCMGAtomicLongArray isize = new QCMGAtomicLongArray(bigTlenValue + 1);
 	AtomicInteger maxIsize = new AtomicInteger(); 
 	
-	//bad reads inforamtion
+	//bad reads information
 	AtomicLong duplicate = new AtomicLong();
 	AtomicLong secondary  = new AtomicLong();
 	AtomicLong supplementary  = new AtomicLong();
@@ -77,9 +76,8 @@ public class ReadGroupSummary {
 	
 	private final String readGroupId; 		
 	public ReadGroupSummary(String rgId){	this.readGroupId = rgId; }
-	public String getReadGroupId(){return readGroupId; }
-		
- 	private class Pair {
+
+	private class Pair {
  		private final String name;		
  		Pair(String name){this.name = name;}
  		

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizer.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummarizer.java
@@ -18,11 +18,7 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.ValidationStringency;
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.*;
 
 import org.qcmg.common.date.DateUtils;
 import org.qcmg.common.log.QLevel;
@@ -52,10 +48,10 @@ public class BamSummarizer implements Summarizer {
 		// create the SummaryReport
 		
 		SAMSequenceDictionary samSeqDict  = header.getSequenceDictionary();
-		List<String> readGroupIds = header.getReadGroups().stream().map( it -> it.getId()  ).collect(toList()); 		
-		readGroupIds.sort(Comparator.comparing( String::toString ) ); // Natural order  
-		
-		BamSummaryReport bamSummaryReport = new BamSummaryReport( maxRecords, isFullBamHeader );									
+        // Natural order
+        List<String> readGroupIds = header.getReadGroups().stream().map(SAMReadGroupRecord::getId).sorted(Comparator.comparing(String::toString)).collect(toList());
+
+        BamSummaryReport bamSummaryReport = new BamSummaryReport( maxRecords, isFullBamHeader );
 		bamSummaryReport.setBamHeader(header, isFullBamHeader);		
 		bamSummaryReport.setSamSequenceDictionary(samSeqDict);
 		bamSummaryReport.setReadGroups(readGroupIds);		

--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/BamSummaryReport.java
@@ -363,7 +363,7 @@ public class BamSummaryReport extends SummaryReport {
 		} 
 						
 		// check if record has its fail or duplicate flag set. if so, miss out some of the summaries
-		ReadGroupSummary rgSumm = rgSummaries.computeIfAbsent(readGroup, k -> new ReadGroupSummary(k));	
+		ReadGroupSummary rgSumm = rgSummaries.computeIfAbsent(readGroup, ReadGroupSummary::new);
 		if (rgSumm.parseRecord(record)) {
 						
 			// SEQ 
@@ -419,12 +419,12 @@ public class BamSummaryReport extends SummaryReport {
 				summary.readSummary2Xml(rgEle);
 				summary.pairSummary2Xml(rgEle); 
 				// presummary
-				lostBase += summary.getDuplicateBase() + summary.getUnmappedBase() + summary.getnotPoperPairedBase()
+				lostBase += summary.getDuplicateBase() + summary.getUnmappedBase() + summary.getNotProperPairedBase()
 					+ summary.getTrimmedBase() + summary.getOverlappedBase() + summary.getSoftClippedBase() + summary.getHardClippedBase();
 				maxBases += summary.getReadCount() * summary.getMaxReadLength();						
 				duplicateBase += summary.getDuplicateBase();
 				unmappedBase += summary.getUnmappedBase();
-				noncanonicalBase += summary.getnotPoperPairedBase();
+				noncanonicalBase += summary.getNotProperPairedBase();
 				trimBases += summary.getTrimmedBase();
 				overlappedBase += summary.getOverlappedBase();
 				softClippedBase += summary.getSoftClippedBase();

--- a/qsv/src/org/qcmg/qsv/softclip/SoftClipStaticMethods.java
+++ b/qsv/src/org/qcmg/qsv/softclip/SoftClipStaticMethods.java
@@ -20,11 +20,7 @@ import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
 
 public class SoftClipStaticMethods {
-	
-	public static void writeSoftClipRecord(BufferedWriter writer, SAMRecord record, int start, int end, String chromosome) throws IOException {
-		SAMReadGroupRecord rg = record.getReadGroup();
-		writeSoftClipRecord( writer, record, (null != rg ? rg.getId() : Constants.EMPTY_STRING), start, end, chromosome);
-	}
+
 	public static void writeSoftClipRecord(BufferedWriter writer, SAMRecord record, String rgId, int start, int end, String chromosome) throws IOException {
 
 		String clipRecordString = createSoftClipRecordString(record, rgId, start, end, chromosome);


### PR DESCRIPTION

# Description

The `getReadGroup`() method in `SAMRecord` is non-trivial, and there were instances in the code where it was being used carelessly. This PR addresses this by calling the method once and caching the value (where appropriate)


# How Has This Been Tested?

Existing tests pass, and regression tests are green

# Are WDL Updates Required?

nope

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
