### PR TITLE
refactor: refactoring including removal of some unused parameters

### DIFF
--- a/qsv/src/org/qcmg/qsv/Chromosome.java
+++ b/qsv/src/org/qcmg/qsv/Chromosome.java
@@ -158,12 +158,9 @@ public class Chromosome implements Comparable<Chromosome>{
 		if (startPosition != other.startPosition)
 			return false;
 		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		return true;
-	}
+            return other.name == null;
+		} else return name.equals(other.name);
+    }
 	
 }
 

--- a/qsv/src/org/qcmg/qsv/Options.java
+++ b/qsv/src/org/qcmg/qsv/Options.java
@@ -41,7 +41,7 @@ public class Options {
 	private static final String VERSION_OPTION = Messages.getMessage("VERSION_OPTION");
 	private static final String INI_OPTION = Messages.getMessage("INI_OPTION");
 	private static final String TEMP_DIR_OPTION = Messages.getMessage("TEMPDIR_OPTION");
-	private static final String UUID_OPTION = Messages.getMessage("UUID_OPTION");;
+	private static final String UUID_OPTION = Messages.getMessage("UUID_OPTION");
 	
 	
 	private final OptionParser parser = new OptionParser();

--- a/qsv/src/org/qcmg/qsv/QSV.java
+++ b/qsv/src/org/qcmg/qsv/QSV.java
@@ -7,6 +7,7 @@
 package org.qcmg.qsv;
 
 import java.io.File;
+import java.nio.file.FileSystems;
 import java.util.Date;
 import java.util.UUID;
 
@@ -22,12 +23,10 @@ import org.qcmg.qsv.util.QSVUtil;
  */
 public class QSV {
 	
-	private static final String FILE_SEPERATOR = System.getProperty("file.separator");
+	private static final String FILE_SEPARATOR = FileSystems.getDefault().getSeparator();
 	private static QLogger logger;
-	
-	private Options options;
 
-	public static void main(String[] args) throws Exception {	
+    public static void main(String[] args) {
 
 		QSV qsv = new QSV();
 		
@@ -52,7 +51,7 @@ public class QSV {
 			if (args.length == 0) {
 				System.err.println(Messages.USAGE);
 			} else {
-				this.options = new Options(args);
+                Options options = new Options(args);
 				if (options.hasHelpOption()) {
 					System.err.println(Messages.USAGE);
 					options.displayHelp();
@@ -71,13 +70,13 @@ public class QSV {
 					logger.info("QSV files will be written to the directory: " + options.getOutputDirName());					
 					
 					//Run the QSV pipeline
-					QSVPipeline pipeline = new QSVPipeline(options, options.getOutputDirName(),new Date(), options.getUuid(), exec);
+					QSVPipeline pipeline = new QSVPipeline(options, options.getOutputDirName(), new Date(), options.getUuid(), exec);
 					pipeline.runPipeline();
 				}
 			}
 		} catch (Exception e) {	
 		    System.err.println(Messages.USAGE);
-			e.printStackTrace();
+
 			exitStatus = 1;
 			if (null != logger) {				
 				logger.error(QSVUtil.getStrackTrace(e));
@@ -91,7 +90,7 @@ public class QSV {
 	//qSV_<sampleName>_<date> is no longer used
 	@Deprecated 
 	public static String getAnalysisId(boolean isQCMG, String overrideOutput, String sample, Date analysisDate) {
-		String analysisId = null;
+		String analysisId;
 		if (isQCMG && null != overrideOutput ) {
 			/*
 			 * Assume that the overrideOutput directory is an analysis folder containing the uuid we want to use
@@ -118,22 +117,13 @@ public class QSV {
 	public static String getResultsDirectory(String overrideOutput, String outputDir, String analysisId) {
 		
 		if ( ! StringUtils.isNullOrEmpty(overrideOutput)) {
-			return overrideOutput.endsWith(FILE_SEPERATOR) ? overrideOutput : overrideOutput + FILE_SEPERATOR;
+			return overrideOutput.endsWith(FILE_SEPARATOR) ? overrideOutput : overrideOutput + FILE_SEPARATOR;
 		}
 		
 		if (null == outputDir || null == analysisId) {
 			throw new IllegalArgumentException("QSV.getResultsDirectory passed null values for some arguments!!!");
 		}
-		return outputDir + FILE_SEPERATOR + analysisId + FILE_SEPERATOR;
+		return outputDir + FILE_SEPARATOR + analysisId + FILE_SEPARATOR;
 	}
-	
 
-
-	/**
-	 * Get the results direct
-	 * @return the full path of the results directory
-	 */
-//	public String getResultsDirectory() {
-//		return options.getOutputDirName();
-//	}
 }

--- a/qsv/src/org/qcmg/qsv/QSVCluster.java
+++ b/qsv/src/org/qcmg/qsv/QSVCluster.java
@@ -958,9 +958,9 @@ public class QSVCluster {
 	 * get string summary of the SV cluster. File types that have a string associtated 
 	 * with them are: dcc, tab delimited, verbose, qprimer, softclip
 	 */
-	public String getDataString(String fileType, String tumourFindType, String normalFindType, boolean isQCMG, String validationPlatform) {
+	public String getDataString(String fileType, String tumourFindType, String normalFindType, boolean isQCMG) {
         return switch (fileType) {
-            case "dcc" -> toDCCString(validationPlatform);
+            case "dcc" -> toDCCString();
             case "tab" -> toTabString();
             case "verbose" -> toVerboseString(tumourFindType, normalFindType, isQCMG);
             case "qprimer" -> getQPrimerString();
@@ -1159,17 +1159,17 @@ public class QSVCluster {
 	 * Attempts to create a split read contig for the SV using clips, unmapped reads and discordant pairs
 	 */
 	public void createSplitReadContig(TIntObjectMap<int[]> cache,
-			QSVParameters tumourParameters, QSVParameters normalParameters,
-			String softClipDir, Integer consensusLength, boolean isQCMG,
-			Integer minInsertSize, boolean singleSided, boolean isSplitRead,
-			String reference, String blatFile) throws Exception {
-		createSplitReadContig(cache, tumourParameters,  normalParameters, softClipDir,  consensusLength,  isQCMG, minInsertSize,  singleSided,  isSplitRead, reference,  blatFile, false);
+									  QSVParameters tumourParameters, QSVParameters normalParameters,
+									  String softClipDir,
+									  boolean isSplitRead,
+									  String reference, String blatFile) throws Exception {
+		createSplitReadContig(cache, tumourParameters,  normalParameters, softClipDir, isSplitRead, reference,  blatFile, false);
 	}
 		public void createSplitReadContig(TIntObjectMap<int[]> cache,
-				QSVParameters tumourParameters, QSVParameters normalParameters,
-				String softClipDir, Integer consensusLength, boolean isQCMG,
-				Integer minInsertSize, boolean singleSided, boolean isSplitRead,
-				String reference, String blatFile, boolean log) throws Exception {
+										  QSVParameters tumourParameters, QSVParameters normalParameters,
+										  String softClipDir,
+										  boolean isSplitRead,
+										  String reference, String blatFile, boolean log) throws Exception {
 		
 		if (!isGermline && !rescued) {
 			
@@ -1196,7 +1196,7 @@ public class QSVCluster {
 	 * to be written in the dcc1 results file
 	 * @return dcc string
 	 */
-	private String toDCCString(String validationPlatform) {
+	private String toDCCString() {
 		StringBuilder sb = new StringBuilder();
 		
 		String category = getOrientationCategory();	
@@ -1206,10 +1206,8 @@ public class QSVCluster {
 		    	String tmp = chrFrom;
 		    	chrFrom = chrTo;
 		    	chrTo = tmp;
-	    }	    
-	    
-	    String confidence = getConfidenceLevel();
-	    
+	    }
+
         sb.append(analysisId).append(TAB); // analysis_id
         sb.append(sampleId).append(TAB); // tumour_sample_id
         sb.append(svId).append(TAB); // sv_id

--- a/qsv/src/org/qcmg/qsv/report/DCCReport.java
+++ b/qsv/src/org/qcmg/qsv/report/DCCReport.java
@@ -114,7 +114,7 @@ public class DCCReport extends QSVReport {
 		try ( BufferedWriter writer = new BufferedWriter(new FileWriter(file, true))) {
 		    for (QSVCluster r: qsvRecords) {
 			    if (r.printRecord(isSingleSided)) {
-				    String str = r.getDataString("dcc", tumourFindType, normalFindType, true, getValidationPlatform(platform)); 				 
+				    String str = r.getDataString("dcc", tumourFindType, normalFindType, true);
 				    writer.write(str +  QSVUtil.getNewLine());
 			    }
 		    }

--- a/qsv/src/org/qcmg/qsv/report/QSVClusterReport.java
+++ b/qsv/src/org/qcmg/qsv/report/QSVClusterReport.java
@@ -83,7 +83,7 @@ public class QSVClusterReport extends QSVReport {
     			for (QSVCluster r: qsvRecords) {   
     				if (r.printRecord(isSingleSided)) {
 	    			 
-    					String str = r.getDataString(fileType, tumourFindType, normalFindType, isQCMG, "");
+    					String str = r.getDataString(fileType, tumourFindType, normalFindType, isQCMG);
     					if (fileType.equals("softclip")) {   
     						if (!str.equals("") && r.hasSoftClipEvidence()) {
     							writer.write(str + QSVUtil.getNewLine());

--- a/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
+++ b/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
@@ -351,7 +351,7 @@ public class FindClipClustersMT  {
 		String blatFile = softClipDir + QSVUtil.getFileSeparator() + UUID.randomUUID();
 		for (QSVCluster cluster: inputClusters) {
 			cluster.rescueClippping(cache, tumourParameters, normalParameters, softClipDir, CONSENSUS_LENGTH, MIN_INSERT_SIZE);
-			cluster.createSplitReadContig(cache, tumourParameters, normalParameters, softClipDir, CONSENSUS_LENGTH, isQCMG, MIN_INSERT_SIZE, singleSided, isSplitRead, reference, blatFile);               		 
+			cluster.createSplitReadContig(cache, tumourParameters, normalParameters, softClipDir, isSplitRead, reference, blatFile);
 		}
 
 		for (QSVCluster r: inputClusters) {
@@ -1044,7 +1044,7 @@ public class FindClipClustersMT  {
 						for (QSVCluster cluster: inputClusters) {
 							cluster.rescueClippping(cache, tumourParameters, normalParameters, softclipDir, consensusLength, minInsertSize);
 							logger.debug("rescue clipping about to call createSplitReadContig");
-							cluster.createSplitReadContig(cache, tumourParameters, normalParameters, softclipDir, consensusLength, isQCMG, minInsertSize, singleSided, isSplitRead, reference, blatFile, log);
+							cluster.createSplitReadContig(cache, tumourParameters, normalParameters, softclipDir, isSplitRead, reference, blatFile, log);
 							logger.debug("rescue clipping, cluster: " + cluster.toTabString());
 						}
 						

--- a/qsv/test/org/qcmg/qsv/QSVClusterTest.java
+++ b/qsv/test/org/qcmg/qsv/QSVClusterTest.java
@@ -136,12 +136,12 @@ public class QSVClusterTest {
     	record = new QSVCluster(cluster, false,  "id");
     	record.addQSVClipRecord(TestUtil.setUpClipRecord("chr10", "chr10", false, false));
     	record.setIdParameters("sv1", "test", "testsample");
-    	assertEquals(37, record.getDataString("dcc", "TD", "ND", true, "solid").split("\t").length);
+    	assertEquals(37, record.getDataString("dcc", "TD", "ND", true).split("\t").length);
     	//assertEquals(8,record.getDataString("vcf", "TD", "ND", true).split("\t").length);
-    	assertEquals(20,record.getDataString("tab", "TD", "ND", true, "solid").split("\t").length);
-    	assertEquals(1,record.getDataString("verbose", "TD", "ND", true, "solid").split("\t").length);
-    	assertEquals(5,record.getDataString("qprimer", "TD", "ND", true, "solid").split("\t").length);
-    	assertEquals(23,record.getDataString("softclip", "TD", "ND", true, "solid").split("\t").length);
+    	assertEquals(20,record.getDataString("tab", "TD", "ND", true).split("\t").length);
+    	assertEquals(1,record.getDataString("verbose", "TD", "ND", true).split("\t").length);
+    	assertEquals(5,record.getDataString("qprimer", "TD", "ND", true).split("\t").length);
+    	assertEquals(23,record.getDataString("softclip", "TD", "ND", true).split("\t").length);
     }
     
     @Test


### PR DESCRIPTION
# Description

Refactoring of qSV based on IDE suggestions. Includes removal of unused parameter validationPlatform which is not used in writing to the output dcc file (always -999). Affects a number of files and required a change to a test, so thought I should merge now. 

# How Has This Been Tested?

Modified one test to remove the validationPlatform parameter

- [ X] QSVClusterTest/testGetDataString()

# Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
