### PR TITLE
fix(qbasepileup): chrM was automatically changed to chrMT

### DIFF
--- a/qbasepileup/src/org/qcmg/qbasepileup/QBasePileupUtil.java
+++ b/qbasepileup/src/org/qcmg/qbasepileup/QBasePileupUtil.java
@@ -39,15 +39,7 @@ public class QBasePileupUtil {
 		
 		// if ref starts with chr or GL, just return it
 		if (ref.startsWith("chr") || ref.startsWith("GL")) {
-			if (ref.equals("chrM")) {
-				return "chrMT";
-			}
 			return ref;
-		}
-		
-		
-		if (ref.equals("M")) {
-			return "chrMT";
 		}
 		
 		if (addChromosomeReference(ref)) {

--- a/qbasepileup/test/org/qcmg/qbasepileup/QBasePileupUtilTest.java
+++ b/qbasepileup/test/org/qcmg/qbasepileup/QBasePileupUtilTest.java
@@ -16,7 +16,7 @@ public class QBasePileupUtilTest {
 		
 		assertEquals("chr10", QBasePileupUtil.getFullChromosome("10"));
 		assertEquals("chr10", QBasePileupUtil.getFullChromosome("chr10"));
-		assertEquals("chrMT", QBasePileupUtil.getFullChromosome("M"));
+		assertEquals("chrM", QBasePileupUtil.getFullChromosome("M"));
 		assertEquals("chrMT", QBasePileupUtil.getFullChromosome("MT"));
 		assertEquals("GL12345", QBasePileupUtil.getFullChromosome("GL12345"));
 	}

--- a/qbasepileup/test/org/qcmg/qbasepileup/snp/SnpPositionTest.java
+++ b/qbasepileup/test/org/qcmg/qbasepileup/snp/SnpPositionTest.java
@@ -50,9 +50,9 @@ public class SnpPositionTest {
 	}
 	
 	@Test
-	public void doesMurnIntochrMT() {
+	public void doesMurnIntochrM() {
 		SnpPosition p = new SnpPosition("test", "M", 1234, 1235);
-		assertEquals("chrMT", p.getFullChromosome());
+		assertEquals("chrM", p.getFullChromosome());
 	}
 	@Test
 	public void doesMTurnIntochrMT() {


### PR DESCRIPTION
Fix to remove condition where chrM was automatically changed to chrMT, and so was failing with GRCh38 chrM SNPs

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Updated qbasepileup tests


# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
