### PR TITLE
refactor(qprofiler2): add bad option check for longread

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/QProfiler2.java
@@ -99,6 +99,10 @@ public class QProfiler2 {
 				index = cmdLineIndexFiles[i];
 			}
 			ProfileType type = ProfileType.getType2(f);
+			if (type != ProfileType.BAM & isLongReadBam) {
+				   throw new Exception( Messages.getMessage(msgResource, "FILE_TYPE_LONG_READ_ERROR"));
+		    }
+
 			sortedFiles.computeIfAbsent(type, v -> new ArrayList<>()).add(Pair.of(f, index));
 		}		
 				

--- a/qprofiler2/src/org/qcmg/qprofiler2/messages.properties
+++ b/qprofiler2/src/org/qcmg/qprofiler2/messages.properties
@@ -29,3 +29,4 @@ DATA_RECORD_ERROR = Data Record is null, or starts with an invalid character
 ID_RECORD_ERROR = ID Record is null, or starts with an invalid character
 OUTPUT_FILE_WRITE_ERROR = Cannot write to specified output file
 INPUT_FILE_ERROR = Cannot read supplied input file {0}
+FILE_TYPE_LONG_READ_ERROR = Long read option can only be chosen for BAM files

--- a/qprofiler2/test/org/qcmg/qprofiler2/QProfiler2Test.java
+++ b/qprofiler2/test/org/qcmg/qprofiler2/QProfiler2Test.java
@@ -131,6 +131,25 @@ public class QProfiler2Test {
     }
 
     @Test
+    public final void executeWithInvalidFileTypeAndLongReadOption() throws Exception {
+                File gffFile = testFolder.newFile("executeWithInvalidFileTypeLongRead.vcf");
+                File logFile = testFolder.newFile("executeWithInvalidFileTypeLongRead.log");
+                File inputFile = testFolder.newFile("executeWithInvalidFileTypeLongRead.xml");
+
+                String[] args1 = {"-input", inputFile.getAbsolutePath(), "-log", logFile.getAbsolutePath(), "--long-read"};
+                String[] args2 = new String[]{"-input", gffFile.getAbsolutePath(), "-log", logFile.getAbsolutePath(), "--long-read"};
+
+                for (String[] args : new String[][]{args1, args2}) {
+                try {
+                    new QProfiler2().setup(args);
+                    fail("Should have thrown a QProfilerException");
+                } catch (Exception qpe) {
+                    assertTrue(qpe.getMessage().contains("Long read option can only be chosen for BAM files"));
+                }
+            }
+    }
+
+    @Test
     public void schmeFileTest() throws IOException {
         String nameSpace = "https://adamajava.org/xsd/qprofiler2/v3";
         String xmlns = "xmlns=\"" + nameSpace + "\"";


### PR DESCRIPTION
Long read only works with BAM input files, adding code to throw exception if incorrect file format

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Added junit tests

# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ X New and existing unit tests pass locally with my changes
