### PR TITLE
perf(qprofiler2): reduce calls to size on map

### DIFF
--- a/qprofiler2/src/org/qcmg/qprofiler2/bam/TagSummaryReport.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/bam/TagSummaryReport.java
@@ -1,11 +1,16 @@
 package org.qcmg.qprofiler2.bam;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
 import org.qcmg.common.log.QLogger;
 import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.common.model.QCMGAtomicLongArray;
@@ -26,31 +31,31 @@ public class TagSummaryReport {
 
 	public static final int ADDI_TAG_MAP_LIMIT = 100;
 	public static final int errReadLimit  = 10;	
-	public static final String seperator = Constants.COLON_STRING;	
+	public static final String separator = Constants.COLON_STRING;
 
 	private static final SAMTagUtil STU = SAMTagUtil.getSingleton();
-	private final short md = STU.MD;	
-	
-	// TAGS		
+
+    // TAGS
 	@SuppressWarnings("unchecked")
-	final CycleSummary<Character>[] tagMDMismatchByCycle = new CycleSummary[] {new CycleSummary<Character>(BamSummaryReport.cc, 512), new CycleSummary<Character>(BamSummaryReport.cc, 512), new CycleSummary<Character>(BamSummaryReport.cc, 512)};
+	final CycleSummary<Character>[] tagMDMismatchByCycle = new CycleSummary[] {new CycleSummary<>(BamSummaryReport.cc, 512), new CycleSummary<>(BamSummaryReport.cc, 512), new CycleSummary<>(BamSummaryReport.cc, 512)};
 	private final QCMGAtomicLongArray[] mdRefAltLengthsForward = new QCMGAtomicLongArray[] {new QCMGAtomicLongArray(32), new QCMGAtomicLongArray(32), new QCMGAtomicLongArray(32)};	
 	private final QCMGAtomicLongArray[] mdRefAltLengthsReverse = new QCMGAtomicLongArray[] {new QCMGAtomicLongArray(32), new QCMGAtomicLongArray(32), new QCMGAtomicLongArray(32)};	
     final QCMGAtomicLongArray[] allReadsLineLengths = new QCMGAtomicLongArray[] {new QCMGAtomicLongArray(1024), new QCMGAtomicLongArray(1024), new QCMGAtomicLongArray(1024)};
 
-	private final ConcurrentMap<String, ConcurrentSkipListMap<String, AtomicLong>> additionalTags = new ConcurrentSkipListMap<>();
+	private final ConcurrentMap<String, ConcurrentMap<String, AtomicLong>> additionalTags = new ConcurrentHashMap<>();
 	protected QLogger logger = QLoggerFactory.getLogger(getClass());	
 	private long errMdReadNo = 0 ;	
-	private AtomicLong mdTagCounts = new AtomicLong();
+	private final AtomicLong mdTagCounts = new AtomicLong();
 	
 	public void parseTAGs(final SAMRecord record, boolean isLongReadBam)  {
-				
+		String mdValue = null;
 		for ( SAMTagAndValue tag : record.getAttributes()) {
 			if (tag.tag.equals("MD")) {
+				mdValue = (String) tag.value;
 				continue;
 			}
 			
-			// the type may be one of A (character), B (generalarray), f (real number), H (hexadecimal array), i (integer), or Z (string).
+			// the type may be one of A (character), B (general array), f (real number), H (hexadecimal array), i (integer), or Z (string).
 			// Note that H tag type is never written anymore, because B style is more compact.	         
 			String type = ":B";			
 			if (tag.value instanceof Integer) {
@@ -63,29 +68,27 @@ public class TagSummaryReport {
 				type = ":A";
 			}
 
-			String key = tag.tag + type;
-			Map<String, AtomicLong> map = additionalTags.computeIfAbsent(key, k -> new ConcurrentSkipListMap<String, AtomicLong>());
+			Map<String, AtomicLong> map = additionalTags.computeIfAbsent(tag.tag + type, k -> new ConcurrentHashMap<>());
 			XmlUtils.updateMapWithLimit(map, tag.value + "", ADDI_TAG_MAP_LIMIT);				 
 		}
 						
 		// MD	 
-		String value = (String) record.getAttribute(md);
-		if (null != value) {
+		if (null != mdValue) {
 			mdTagCounts.incrementAndGet();
 			byte[] readBases = record.getReadBases();
 			boolean reverseStrand = record.getReadNegativeStrandFlag();		
 
 			// 0: unpaired , 1: firstOfPair , 2: secondOfPair				
 			int order = (!record.getReadPairedFlag()) ? 0 : (record.getFirstOfPairFlag()) ? 1 : 2;					
-			String err = CycleSummaryUtils.tallyMDMismatches( value, record.getCigar(), tagMDMismatchByCycle[order], 
+			String err = CycleSummaryUtils.tallyMDMismatches( mdValue, record.getCigar(), tagMDMismatchByCycle[order],
 					readBases, reverseStrand, mdRefAltLengthsForward[order], mdRefAltLengthsReverse[order], isLongReadBam);
 			// limit err message on log file
 			if ( err != null && (( errMdReadNo ++) < errReadLimit)) {
 				logger.warn(record.getReadName() + ": " + err);
 			}
 			
-			// this counts will be used to caculate % for MD
-			for ( int i = 1; i <= record.getReadLength(); i ++ ) {
+			// this counts will be used to calculate % for MD
+			for ( int i = 1, len = readBases.length; i <= len; i ++ ) {
 				allReadsLineLengths[order].increment(i);		
 			}		
 		}		
@@ -95,8 +98,8 @@ public class TagSummaryReport {
 				
 		// "tags:MD:Z" mismatchbycycle
 		if ( mdTagCounts.get() > 0) {
-			Element ele = XmlUtils.createMetricsNode(parent, "tags:MD:Z", 
-					new Pair<String, Number>(ReadGroupSummary.READ_COUNT, mdTagCounts.get()));
+			Element ele = XmlUtils.createMetricsNode(parent, "tags:MD:Z",
+                    new Pair<>(ReadGroupSummary.READ_COUNT, mdTagCounts.get()));
 			for (int order = 0; order < 3; order ++) {
 				// so choose 1st cycle base counts as read count, since all read at least have one base. 
 				tagMDMismatchByCycle[order].toXml( ele, BamSummaryReport.sourceName.get(order), allReadsLineLengths[order].get(1) );
@@ -121,20 +124,26 @@ public class TagSummaryReport {
 		}
 		
 		// additional tags includes RG
-		for (Entry<String,  ConcurrentSkipListMap<String, AtomicLong>> entry : additionalTags.entrySet()) {			
-			outputTag(parent, entry.getKey(),  entry.getValue());
-		}			
+		// sort as we are no longer using SkipListMap
+		List<String> sortedKeys = additionalTags.keySet().stream().sorted().toList();
+		for (String key : sortedKeys) {
+			outputTag(parent, key, additionalTags.get(key));
+		}
 	}
 	
 	
 	private <T> void outputTag(Element ele, String tag,  Map<T, AtomicLong> tallys) {
-	
-		long counts = tallys.values().stream().mapToLong(x -> x.get()).sum();
+
+		/*
+		 *  create sorted map, and pass that to outputTallyGroupWithSize
+		 */
+		Map<T, AtomicLong> sortedMap = new TreeMap<>(tallys);
+		long counts = sortedMap.values().stream().mapToLong(AtomicLong::get).sum();
 		
-		ele = XmlUtils.createMetricsNode(ele, "tags:" + tag, new Pair<String, Number>(ReadGroupSummary.READ_COUNT, counts));
+		ele = XmlUtils.createMetricsNode(ele, "tags:" + tag, new Pair<>(ReadGroupSummary.READ_COUNT, counts));
 			
-		String name = tag.substring(0, tag.indexOf(seperator));			
-		XmlUtils.outputTallyGroupWithSize(ele, name, tallys, ADDI_TAG_MAP_LIMIT, false);
+		String name = tag.substring(0, tag.indexOf(separator));
+		XmlUtils.outputTallyGroupWithSize(ele, name, sortedMap, ADDI_TAG_MAP_LIMIT, false);
 					
 	}
 	

--- a/qprofiler2/src/org/qcmg/qprofiler2/summarise/CycleSummary.java
+++ b/qprofiler2/src/org/qcmg/qprofiler2/summarise/CycleSummary.java
@@ -34,8 +34,7 @@ import org.w3c.dom.Element;
  * 
  */
 public class CycleSummary<T> {
-	public static final String baseOnCycle = "cycle";
-	
+
 	private static final int MAX_ARRAY_CAPACITY = 2048 * 2048;		// over 4 million
 		
 	/**
@@ -251,7 +250,7 @@ public class CycleSummary<T> {
 	 * @return a map of counts for each possible value on this cycle
 	 */
 	public ConcurrentMap<T, AtomicLong> getValue(Integer key) {
-		ConcurrentMap<T, AtomicLong> cm = new ConcurrentHashMap<T, AtomicLong>();
+		ConcurrentMap<T, AtomicLong> cm = new ConcurrentHashMap<>();
 		
 		// loop through keys to get ones with this cycle number		
 		for (int i = 0 , length = tally.length() ; i < length ; i++) {
@@ -259,7 +258,7 @@ public class CycleSummary<T> {
 			// whole bunch of zeros in here - only want >0 values
 			if (arrayValue > 0) {
 				int [] cycleKey = getCycleKeyFromArrayPosition(i);
-				if (cycleKey[0] == key.intValue()) {
+				if (cycleKey[0] == key) {
 					cm.put(getTypeFromInt(cycleKey[1]), new AtomicLong(arrayValue));
 				}
 			}
@@ -271,7 +270,7 @@ public class CycleSummary<T> {
 	 * @return SortedSet relating to the cycles currently held by this summary object.
 	 */
 	public SortedSet<Integer> cycles() {
-		HashSet<Integer> ts = new HashSet<Integer>();		
+		HashSet<Integer> ts = new HashSet<>();
 		for (int i = 0 , length = tally.length() ; i < length ; i++) {
 			if (tally.get(i) <= 0) {
 				continue;		 
@@ -279,7 +278,7 @@ public class CycleSummary<T> {
 			int [] cycleKey = getCycleKeyFromArrayPosition(i);
 			ts.add(cycleKey[0]);		
 		}		
-		return new TreeSet<Integer>(ts);
+		return new TreeSet<>(ts);
 	}
 	
 	/**
@@ -289,7 +288,7 @@ public class CycleSummary<T> {
 	 */
 	public Set<T> getPossibleValues() {	
 		
-		HashSet<T> allValues = new HashSet<T>();
+		HashSet<T> allValues = new HashSet<>();
 		
 		for (int i = 0 , length = tally.length() ; i < length ; i++) {
 			if (tally.get(i) <= 0) {
@@ -299,7 +298,7 @@ public class CycleSummary<T> {
 		}		
 		// order as ACGTN
 		if (type instanceof Character) {					
-			List<T> notATGC = new ArrayList<T>();
+			List<T> notATGC = new ArrayList<>();
 			
 			for (T v : allValues) {
 				char v1 =   (Character)  v; 
@@ -308,11 +307,11 @@ public class CycleSummary<T> {
 				}				
 			}	
 			
-			allValues.removeAll(notATGC);
+			notATGC.forEach(allValues::remove);
 			return   Stream.concat(allValues.stream().sorted(), notATGC.stream()).collect(Collectors.toCollection(LinkedHashSet::new));	
 		} else if (type instanceof Integer) {				
  			// Integer reverse order for QUAL			 
-			TreeSet<T> treeSetObj = new TreeSet<T>((i1,i2) -> ((Integer) i2).compareTo((Integer) i1));
+			TreeSet<T> treeSetObj = new TreeSet<>((i1, i2) -> ((Integer) i2).compareTo((Integer) i1));
 		    treeSetObj.addAll(allValues);
 		    return treeSetObj; 
 		}
@@ -351,7 +350,7 @@ public class CycleSummary<T> {
 
 	// xu totalSize should be seprate to first and second of pair		
 	public Map<Integer, AtomicLong> getLengthMapFromCycle() {
-		Map<Integer, AtomicLong> map = new HashMap<Integer, AtomicLong>();		
+		Map<Integer, AtomicLong> map = new HashMap<>();
 		
 		long previousTally = -1;	
 		Integer last = 0;


### PR DESCRIPTION
# Description

When profiling qprofiler2 running against a CRAM, I noticed that the producer thread was spending around 30% of its time calling the size method on the queue that it was populating (and that the consumer threads were ingesting from).
I have reduced the frequency of these calls to size, from every record to every 1 million records.

Also use a ConcurrentHashMap rather than a ConcurrentSkipListMap for the Tag tallies - much faster, and we can order at the point of displaying the data

And finally, some changes suggested by my IDE to make the code more up-to-date

# How Has This Been Tested?

Existing tests pass, and the updated ode has been profiled.

# Are WDL Updates Required?

nope

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
