### PR TITLE
Qsv matefile

### DIFF
--- a/qsv/src/org/qcmg/qsv/discordantpair/MatePairsReader.java
+++ b/qsv/src/org/qcmg/qsv/discordantpair/MatePairsReader.java
@@ -85,7 +85,7 @@ public class MatePairsReader {
 					//contains ND or TD
 					if (s.contains(type)) {
 
-						String key = s.substring(0, s.indexOf("_"));
+						String key = s.substring(0, s.indexOf("_xxx_"));
 						String value = dirString + s;
 
 						File file = new File(value);

--- a/qsv/src/org/qcmg/qsv/discordantpair/MatePairsWriter.java
+++ b/qsv/src/org/qcmg/qsv/discordantpair/MatePairsWriter.java
@@ -28,7 +28,7 @@ public class MatePairsWriter {
         this.zp = zp;
         this.matePairs = new TreeMap<String, Map<String, MatePair>>();
         this.dirToWrite = matePairFilePath + zp.getPairingClassification() + FILE_SEPARATOR;
-        this.fileName = "_" + type + "_" + zp.getPairingClassification();  
+        this.fileName = "_xxx_" + type + "_" + zp.getPairingClassification();
         this.pairType = pairType;
     }
 

--- a/qsv/test/org/qcmg/qsv/discordantpair/FindDiscorantPairClustersMTTest.java
+++ b/qsv/test/org/qcmg/qsv/discordantpair/FindDiscorantPairClustersMTTest.java
@@ -74,8 +74,8 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testRunTumorWithGermline() throws InterruptedException, ExecutionException, IOException {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_TD_AAC");
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_ND_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_TD_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_ND_AAC");
 		findReader = new MatePairsReader(PairGroup.valueOf("AAC"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "TD");
 		compareReader = new MatePairsReader(PairGroup.valueOf("AAC"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "ND");
 		//germline
@@ -92,7 +92,7 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testRunTumorWithSomatic() throws InterruptedException, ExecutionException, IOException {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_TD_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_TD_AAC");
 		findReader = new MatePairsReader(PairGroup.valueOf("AAC"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "TD");
 		compareReader = new MatePairsReader(PairGroup.valueOf("AAC"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "ND");
 		//germline
@@ -108,7 +108,7 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testRunNormal() throws InterruptedException, ExecutionException, IOException {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_ND_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_ND_AAC");
 		findReader = new MatePairsReader(PairGroup.valueOf("AAC"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "TD");
 		compareReader = new MatePairsReader(PairGroup.valueOf("AAC"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "ND");
 		findClusters = new FindDiscordantPairClustersMT(PairGroup.AAC, countDownLatch, compareReader,
@@ -124,8 +124,8 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testFindCxxClusters() throws Exception {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.Cxx, "chr4-chr15_test_TD_AAC");
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.Cxx, "chr4-chr15_test_ND_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.Cxx, "chr4-chr15_xxx_test_TD_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.Cxx, "chr4-chr15_xxx_test_ND_AAC");
 
 		findReader = new MatePairsReader(PairGroup.valueOf("Cxx"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "TD");
 		compareReader = new MatePairsReader(PairGroup.valueOf("Cxx"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "ND");
@@ -143,10 +143,10 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testFindClusters() throws Exception {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_TD_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_TD_AAC");
 		findClusters = new FindDiscordantPairClustersMT(PairGroup.AAC, countDownLatch, findReader, compareReader, tumor, normal, countReport, "", true);
 		findReader = new MatePairsReader(PairGroup.valueOf("AAC"), matePairDir.getAbsolutePath() + FILE_SEPARATOR, "test", "TD");
-		List<MatePair> pairs = TestUtil.readInMatePairs(new File(matePairDir.getAbsolutePath() + FILE_SEPARATOR + "AAC" + FILE_SEPARATOR + "chr7_test_TD_AAC"));
+		List<MatePair> pairs = TestUtil.readInMatePairs(new File(matePairDir.getAbsolutePath() + FILE_SEPARATOR + "AAC" + FILE_SEPARATOR + "chr7_xxx_test_TD_AAC"));
 
 		assertEquals(6, pairs.size());
 		List<DiscordantPairCluster> list = findClusters.findClusters(pairs);
@@ -157,9 +157,9 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testClassifyGermlineCluster() throws IOException, Exception {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_ND_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_ND_AAC");
 		findClusters = new FindDiscordantPairClustersMT(PairGroup.AAC, countDownLatch, findReader, compareReader, tumor, normal, countReport, "", true); 
-		List<MatePair> pairs = TestUtil.readInMatePairs(new File(matePairDir.getAbsolutePath() + FILE_SEPARATOR + "AAC" + FILE_SEPARATOR + "chr7_test_ND_AAC"));
+		List<MatePair> pairs = TestUtil.readInMatePairs(new File(matePairDir.getAbsolutePath() + FILE_SEPARATOR + "AAC" + FILE_SEPARATOR + "chr7_xxx_test_ND_AAC"));
 		findClusters.classifyClusters(Arrays.asList(TestUtil.setupSolidCluster(PairGroup.AAC, "somatic", testFolder.getRoot(), "chr7", "chr7")), pairs);
 
 		assertEquals(1, findClusters.getClustersMap().get("germline").size());	
@@ -167,7 +167,7 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testClassifySomaticCluster() throws IOException, Exception {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_ND_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_ND_AAC");
 		findClusters = new FindDiscordantPairClustersMT(PairGroup.AAC, countDownLatch, findReader, compareReader, tumor, normal, countReport, query, true); 
 
 		findClusters.classifyClusters(Arrays.asList(TestUtil.setupSolidCluster(PairGroup.AAC, "somatic", testFolder.getRoot(), "chr7", "chr7")), Arrays.asList(new MatePair("722_126_792:20110412030837875,chr4,100,200,Cxx,129,false,722_126_792:20110412030837875,chr15,300,400,Cxx,65,false,F2F1\n")));
@@ -176,7 +176,7 @@ public class FindDiscorantPairClustersMTTest {
 
 	@Test
 	public void testClassifyNormalGermlineCluster() throws IOException, Exception {
-		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_test_ND_AAC");
+		TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPARATOR, PairClassification.AAC, "chr7_xxx_test_ND_AAC");
 		findClusters = new FindDiscordantPairClustersMT(PairGroup.AAC, countDownLatch, compareReader, findReader, normal, tumor, countReport, query, true); 
 
 		findClusters.classifyClusters(Arrays.asList(TestUtil.setupSolidCluster(PairGroup.AAC, "somatic", testFolder.getRoot(), "chr7", "chr7")), Collections.emptyList());

--- a/qsv/test/org/qcmg/qsv/discordantpair/FindMatePairsMTTest.java
+++ b/qsv/test/org/qcmg/qsv/discordantpair/FindMatePairsMTTest.java
@@ -63,7 +63,7 @@ public class FindMatePairsMTTest {
 
         assertEquals(testFolder.getRoot().toString() + FILE_SEPARATOR + "matepair" + FILE_SEPARATOR + "AAC"
         + FILE_SEPARATOR, findMatePairs.getMatePairWritersMap().get(PairClassification.AAC).getDirToWrite());
-        assertEquals("_test_AAC", findMatePairs.getMatePairWritersMap().get(PairClassification.AAC).getFileName());
+        assertEquals("_xxx_test_AAC", findMatePairs.getMatePairWritersMap().get(PairClassification.AAC).getFileName());
     }
 
     @Test

--- a/qsv/test/org/qcmg/qsv/discordantpair/MatePairsReaderTest.java
+++ b/qsv/test/org/qcmg/qsv/discordantpair/MatePairsReaderTest.java
@@ -21,7 +21,8 @@ public class MatePairsReaderTest {
     private MatePairsReader reader;
     private File matePairDir;
     private static final String FILE_SEPERATOR = System.getProperty("file.separator");
-    private String fileName = "chr7_test_TD_AAC";
+    private String fileName = "chr7_xxx_test_TD_AAC";
+    private String fileNameChrUn = "chrUn_KI270438v1_xxx_test_TD_AAC";
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
@@ -30,11 +31,16 @@ public class MatePairsReaderTest {
     public void setUp() throws IOException, QSVException {
        matePairDir = testFolder.newFolder("matepair");
        TestUtil.createTmpClusterFile(matePairDir.getAbsolutePath() + FILE_SEPERATOR, PairClassification.AAC, fileName);
+       TestUtil.createTmpClusterChrUnFile(matePairDir.getAbsolutePath() + FILE_SEPERATOR, PairClassification.AAC, fileNameChrUn);
+
        reader = new MatePairsReader(PairGroup.AAC, matePairDir.getAbsolutePath() + FILE_SEPERATOR, fileName, "TD");
    	   assertNotNull(reader.getFilesToRead());
    	   assertNotNull(reader.getFilesToRead().get("chr7"));
    	   assertEquals(1, reader.getFilesToRead().get("chr7").size());
    	   assertEquals(fileName, reader.getFilesToRead().get("chr7").getFirst().getName());
+       assertNotNull(reader.getFilesToRead().get("chrUn_KI270438v1"));
+       assertEquals(1, reader.getFilesToRead().get("chrUn_KI270438v1").size());
+       assertEquals(fileNameChrUn, reader.getFilesToRead().get("chrUn_KI270438v1").getFirst().getName());
     }
     
     @After
@@ -53,6 +59,16 @@ public class MatePairsReaderTest {
        assertEquals(6, list.size());
        assertEquals("1789_1456_806:20110221052813657", list.get(0).getReadName());
        assertEquals("1789_1456_806:20110221052813657", list.get(0).getReadName());
+    }
+
+    @Test
+    public void testReadInChrUnPairs() throws Exception {
+        List<File> files = new ArrayList<File>();
+        files.add(new File(matePairDir.getAbsolutePath() + FILE_SEPERATOR + "AAC" + FILE_SEPERATOR + fileNameChrUn));
+        List<MatePair> list = reader.getMatePairsListByFiles(files, true);
+
+        assertEquals(4, list.size());
+        assertEquals("H3HHCALXX:2:1105:3188332:0:07262735-323a-489b-bd6d-10dcdc6726d0", list.get(0).getReadName());
     }
 
 }

--- a/qsv/test/org/qcmg/qsv/discordantpair/MatePairsWriterTest.java
+++ b/qsv/test/org/qcmg/qsv/discordantpair/MatePairsWriterTest.java
@@ -49,7 +49,7 @@ public class MatePairsWriterTest {
     public void testWriteMatePairsToFile() throws IOException {
         writer.addNewMatePair(matePairs.getFirst());
         writer.writeMatePairsToFile();
-        File file = new File(mateDir, "chr7-1_TD_AAC");
+        File file = new File(mateDir, "chr7-1_xxx_TD_AAC");
         assertTrue(file.exists());
         assertTrue(file.length() > 100);
     }

--- a/qsv/test/org/qcmg/qsv/util/TestUtil.java
+++ b/qsv/test/org/qcmg/qsv/util/TestUtil.java
@@ -643,9 +643,33 @@ public class TestUtil {
 		
 		return outFile;
 	}
+
+	public static String createTmpClusterChrUnFile(String dirName, PairClassification pc, String fileName) throws IOException {
+
+		File testDir = new File(dirName + pc.getPairingClassification());
+		testDir.mkdir();
+		String outFile = testDir + FILE_SEPARATOR + fileName;
+
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(new File(outFile)))) {
+
+			if (pc.equals(PairClassification.AAC)) {
+				writeChrUnAACPairs(writer);
+			}
+		}
+
+		return outFile;
+	}
 		
-	public static void writeAACPairs(BufferedWriter writer) throws IOException {	
-		
+	public static void writeChrUnAACPairs(BufferedWriter writer) throws IOException {
+		writer.write("H3HHCALXX:2:1105:3188332:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,88809,88954,AAC,97,false,H3HHCALXX:2:1105:3188332:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,92960,93119,AAC,145,true,F1R2" + NEWLINE);
+		writer.write("H3HHCALXX:2:1105:4467207:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,88917,89066,AAC,97,false,H3HHCALXX:2:1105:4467207:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,93030,93161,AAC,145,true,F1R2" + NEWLINE);
+		writer.write("H3HHCALXX:2:1108:478183:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,102130,102212,AAC,161,false,H3HHCALXX:2:1108:478183:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,108627,108768,AAC,81,true,F2R1" + NEWLINE);
+		writer.write("H3HHCALXX:2:1213:3573424:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,100014,100163,AAC,161,false,H3HHCALXX:2:1213:3573424:0:07262735-323a-489b-bd6d-10dcdc6726d0,chrUn_KI270438v1,102786,102935,AAC,81,true,F2R1" + NEWLINE);
+
+	}
+
+	public static void writeAACPairs(BufferedWriter writer) throws IOException {
+
 		writer.write("254_166_1407:20110221052813657,chr7,140188379,140188428,AAC,129,false,254_166_1407:20110221052813657,chr7,140191044,140191093,AAC,65,false,F2F1," + NEWLINE);
 		writer.write("1789_1456_806:20110221052813657,chr7,140188227,140188276,AAC,129,false,1789_1456_806:20110221052813657,chr7,140191179,140191228,AAC,65,false,F2F1," + NEWLINE);
 		writer.write("515_451_1845:20110221052813657,chr7,140188449,140188498,AAC,129,false,515_451_1845:20110221052813657,chr7,140191238,140191287,AAC,65,false,F2F1" + NEWLINE);


### PR DESCRIPTION
# Description
Bugfix. For GRCh38, temporary matepair files names separated reference name from file ending with an underscore, but scaffold contigs in GRCh38 also have an underscore, so mate pairs were incorrectly matched. Changed file name to include "xxx"


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests and ran qsv for previously failing sample

# Are WDL Updates Required?

sv.wdl will need to be updated to a new release of adamajava to include this change.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
