### PR TITLE
fix(qsv and q3tiledaligner): fix for GRCh38

### DIFF
--- a/q3tiledaligner/src/au/edu/qimr/tiledaligner/util/TiledAlignerUtil.java
+++ b/q3tiledaligner/src/au/edu/qimr/tiledaligner/util/TiledAlignerUtil.java
@@ -842,6 +842,14 @@ public class TiledAlignerUtil {
 		}
 		return is.toArray();
 	}
+
+	public static String[] splitString(String name) {
+		if (name.contains("_xxx_")) {
+			return name.split("_xxx_");
+		} else {
+			return name.split("_");
+		}
+	}
 	
 	public static List<BLATRecord> getBlatRecordsSWAll(String refFile, Map<ChrPosition, LongRange> refIndexMap, TIntObjectMap<int[]> cache, String sequence, final String name, int tileLength, String originatingMethod, boolean log, boolean recordsMustComeFromChrInName) {
 		if (null == cache || cache.isEmpty()) {
@@ -902,7 +910,7 @@ public class TiledAlignerUtil {
 			/*
 			 * get chromosome names from name
 			 */
-			String [] nameArray = name.split("_");
+			String [] nameArray = splitString(name);
 			for (String s : nameArray) {
 				if (s.startsWith("chr") || s.startsWith("GL")) {
 					acceptableRanges.add(PositionChrPositionMap.getLongStartAndStopPositionFromChrPosition(new ChrPointPosition(s, 1), refIndexMap));
@@ -1316,7 +1324,7 @@ public class TiledAlignerUtil {
 			/*
 			 * really only care if we have different chromosomes
 			 */
-			String[] nameArray = name.split("_");
+			String [] nameArray = splitString(name);
 			if (nameArray.length > 4 &&  ! nameArray[1].equals(nameArray[3])) {
 				logger.debug("got a splitcon: " + name + " with no of recs: " + uniqueResults.size() + ", taRec: " + taRec);
 				for (BLATRecord br : uniqueResults) {

--- a/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TiledAlignerUtilTest.java
+++ b/q3tiledaligner/test/au/edu/qimr/tiledaligner/util/TiledAlignerUtilTest.java
@@ -161,6 +161,21 @@ public class TiledAlignerUtilTest {
 		assertEquals(0, ranges.get(0).getMinimum().intValue());
 		assertEquals(9, ranges.get(0).getMaximum().intValue());
 	}
+
+	@Test
+	public void testSplitString() {
+		String[] array = TiledAlignerUtil.splitString("chr22_xxx_49157941_xxx_false_xxx_+");
+		assertEquals(4, array.length);
+		assertEquals(array[0], "chr22");
+
+		array = TiledAlignerUtil.splitString("chr22_xxx_49157941_xxx_false_xxx_+");
+		assertEquals(4, array.length);
+		assertEquals(array[0], "chr22");
+
+		array = TiledAlignerUtil.splitString("chrUn_KI270448v1_xxx_1_xxx_true_xxx_-");
+		assertEquals(4, array.length);
+		assertEquals(array[0], "chrUn_KI270448v1");
+	}
 	
 	@Test
 	public void binarySearch() {

--- a/qsv/src/org/qcmg/qsv/Chromosome.java
+++ b/qsv/src/org/qcmg/qsv/Chromosome.java
@@ -94,9 +94,10 @@ public class Chromosome implements Comparable<Chromosome>{
 		String thisName = name.toLowerCase();
 		String otherName = other.name.toLowerCase();		
 		
-		if (thisName.contains("gl") || otherName.contains("gl")) {
+		if (thisName.contains("gl") || otherName.contains("gl") || thisName.contains("random") || otherName.contains("random")
+		|| thisName.contains("chrun") || otherName.contains("chrun") || thisName.contains("ebv") || otherName.contains("ebv")) {
 			return thisName.compareTo(otherName);
-		} else if (thisName.contains("chrmt")) {
+		} else if (thisName.contains("chrmt") || thisName.contains("chrm")) {
 			if (otherName.contains("x") || otherName.contains("y")) {
 				return 1;
 			} else {
@@ -106,7 +107,7 @@ public class Chromosome implements Comparable<Chromosome>{
 					return thisName.compareTo(otherName);
 				}
 			}
-		} else if (otherName.contains("chrmt")) {
+		} else if (otherName.contains("chrmt") || otherName.contains("chrm")) {
 			if (thisName.contains("x") || thisName.contains("y")) {
 				return -1;
 			} else {

--- a/qsv/src/org/qcmg/qsv/QSVCluster.java
+++ b/qsv/src/org/qcmg/qsv/QSVCluster.java
@@ -257,6 +257,8 @@ public class QSVCluster {
 	 * @return true if clip record overlaps by +-50bp
 	 */
 	public boolean findClipOverlap(SoftClipCluster clipRecord) {
+
+
 		int potentialLeftStart = clipRecords.getFirst().getLeftBreakpoint();
 		int potentialLeftEnd =  clipRecords.getFirst().getLeftBreakpoint();
 		
@@ -266,6 +268,11 @@ public class QSVCluster {
 		
 		for (int i=1, size = clipRecords.size() ; i < size ; i++) {
 			SoftClipCluster clip = clipRecords.get(i);
+			if ( ! clipRecord.getMutationType().equals(clip.getMutationType())
+					&& ! clipRecord.getOrientationCategory().equals(clip.getOrientationCategory())) {
+				return false;
+			}
+
 			if (clip.getLeftBreakpoint() < potentialLeftStart) {
 				potentialLeftStart = clip.getLeftBreakpoint();
 			}
@@ -280,12 +287,12 @@ public class QSVCluster {
 				potentialRightEnd = clip.getRightBreakpoint();
 			}
 		}
-		
+
 		if (clipRecord.getLeftBreakpoint() >= (potentialLeftStart - 50)
 				&& clipRecord.getLeftBreakpoint() <= (potentialLeftEnd + 50) &&
 				clipRecord.getRightBreakpoint() >= (potentialRightStart - 50) 
 				&& clipRecord.getRightBreakpoint() <= (potentialRightEnd + 50)) {
-			
+
 			clipRecords.add(clipRecord);
 			if (clipRecord.isGermline()) {
 				isGermline = true;

--- a/qsv/src/org/qcmg/qsv/softclip/Breakpoint.java
+++ b/qsv/src/org/qcmg/qsv/softclip/Breakpoint.java
@@ -137,7 +137,7 @@ public class Breakpoint implements Comparable<Breakpoint>{
 	}
 
 	public String getName() {
-		return reference + "_" + breakpoint + "_" + isLeft + "_" + (positiveStrand ? QSVUtil.PLUS : QSVUtil.MINUS);
+		return reference + "_xxx_" + breakpoint + "_xxx_" + isLeft + "_xxx_" + (positiveStrand ? QSVUtil.PLUS : QSVUtil.MINUS);
 	}
 
 	public Integer getBreakpoint() {

--- a/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
+++ b/qsv/src/org/qcmg/qsv/softclip/FindClipClustersMT.java
@@ -242,6 +242,7 @@ public class FindClipClustersMT  {
 
 	private void findOverlappingClusters(String referenceKey, List<QSVCluster> records, List<DiscordantPairCluster> clusters, List<SoftClipCluster> clips, boolean translocation) {
 
+
 		if (clusters != null && clips != null) {
 			logger.info(referenceKey + "- number of clusters: "  + clusters.size() + ", number of clips " + clips.size());
 			if (translocation) {
@@ -308,6 +309,8 @@ public class FindClipClustersMT  {
 
 	private void findOverlaps(List<QSVCluster> records, List<DiscordantPairCluster> clusters, List<SoftClipCluster> clips) {
 		Iterator<DiscordantPairCluster> iter = clusters.iterator();
+		//Sort clips
+		Collections.sort(clips);
 
 		// look for matches
 		while (iter.hasNext()) {
@@ -320,23 +323,20 @@ public class FindClipClustersMT  {
 					potentialClip.setHasClusterMatch(true);
 				}
 			}
-
 			records.add(record);			
 			iter.remove();
 		}
 
 		// remaining soft clips
 		int i = 0, size = clips.size();
-		for (SoftClipCluster clip : clips) {			
-
+		for (SoftClipCluster clip : clips) {
 			//already added elsewhere
 			if ( ! clip.hasClipMatch() && ! clip.hasClusterMatch()) {
-
 				QSVCluster record = new QSVCluster(clip, tumourParameters.getSampleId());
 				//find matches
 				for (int j = i + 1; j < size ; j++) {
 					SoftClipCluster clip2 = clips.get(j);
-					if (record.findClipOverlap(clip2)) {
+					if (! clip2.hasClusterMatch() && ! clip2.hasClipMatch() && record.findClipOverlap(clip2)) {
 						clip2.setHasClipMatch(true);
 					}
 				}
@@ -775,6 +775,7 @@ public class FindClipClustersMT  {
 				AbstractQueue<List<QSVCluster>> queueIn = new ConcurrentLinkedQueue<>();
 
 				int listSize = 50;
+
 				for (int i = 0; i < records.size(); i += listSize) {
 					if (((records.size()) - i) < listSize) {						
 						queueIn.add(records.subList(i, records.size()));
@@ -819,6 +820,7 @@ public class FindClipClustersMT  {
 				}
 				int count = rescuedClusters.size();
 				records.clear();
+				
 				qsvRecordWriter.writeTumourSVRecords(rescuedClusters);
 				logger.info("Finished finding split read alignments for "+ key +", number processed: " + count);
 			}
@@ -884,6 +886,7 @@ public class FindClipClustersMT  {
 						List<QSVCluster> records = new ArrayList<>();
 						findOverlappingClusters(referenceKey, records, clusters, clips, true);
 						rescueQSVRecords(referenceKey, records);
+
 						qsvRecordWriter.writeTumourSVRecords(records);
 					} // end else
 				}// end while

--- a/qsv/src/org/qcmg/qsv/softclip/SoftClipCluster.java
+++ b/qsv/src/org/qcmg/qsv/softclip/SoftClipCluster.java
@@ -12,9 +12,12 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.ValidationStringency;
+import org.qcmg.common.log.QLogger;
+import org.qcmg.common.log.QLoggerFactory;
 import org.qcmg.picard.SAMFileReaderFactory;
 import org.qcmg.qsv.QSVParameters;
 import org.qcmg.qsv.assemble.QSVAssemble;
+import org.qcmg.qsv.splitread.SplitReadContig;
 import org.qcmg.qsv.splitread.UnmappedRead;
 import org.qcmg.qsv.util.QSVConstants;
 import org.qcmg.qsv.util.QSVUtil;
@@ -24,6 +27,7 @@ import java.io.IOException;
 import java.util.*;
 
 public class SoftClipCluster implements Comparable<SoftClipCluster> {
+
 
     final String name;
     Breakpoint leftBreakpointObject;
@@ -196,9 +200,25 @@ public class SoftClipCluster implements Comparable<SoftClipCluster> {
     }
 
     @Override
-    public int compareTo(SoftClipCluster o) {
-        return this.name.compareTo(o.getName());
+    public int compareTo(SoftClipCluster other) {
+        int result = this.leftReference.compareTo(other.leftReference);
+        if (result != 0) return result;
+
+        result = this.rightReference.compareTo(other.rightReference);
+        if (result != 0) return result;
+
+        result = this.leftBreakpoint.compareTo(other.leftBreakpoint);
+        if (result != 0) return result;
+
+        result = this.rightBreakpoint.compareTo(other.rightBreakpoint);
+        if (result != 0) return result;
+
+        result = Character.compare(this.leftStrand, other.leftStrand);
+        if (result != 0) return result;
+
+        return Character.compare(this.rightStrand, other.rightStrand);
     }
+
 
     public String getName() {
         return name;

--- a/qsv/src/org/qcmg/qsv/splitread/SplitReadContig.java
+++ b/qsv/src/org/qcmg/qsv/splitread/SplitReadContig.java
@@ -190,7 +190,7 @@ public class SplitReadContig {
 		Date date = new Date();
 		Random r = new Random();
 		int random = r.nextInt(900000);
-		return "splitcon_" + knownSV.toString() + "_" + isTumour() + "_" + date.getTime() + "_" + random;
+		return "splitcon_xxx_" + knownSV.toString() + "_xxx_" + isTumour() + "_xxx_" + date.getTime() + "_xxx_" + random;
 	}
 	
 	public void setLeftSequence(String leftSequence) {
@@ -652,7 +652,7 @@ public class SplitReadContig {
 	}
 
 	void recheckMicrohomologyForSingleAlignment() {
-		
+
 		String leftRef = getReferenceSequence(splitreadSV.getLeftReference(), splitreadSV.getLeftBreakpoint() + 1, 0, 50, chromosomes);
 		String rightRef = getReferenceSequence(splitreadSV.getRightReference(), splitreadSV.getRightBreakpoint() - 1, 50, 0, chromosomes);	
 		int end = leftSequence.length();

--- a/qsv/src/org/qcmg/qsv/splitread/StructuralVariant.java
+++ b/qsv/src/org/qcmg/qsv/splitread/StructuralVariant.java
@@ -73,7 +73,7 @@ public class StructuralVariant {
 	
 	@Override
 	public String toString() {
-		return leftReference + "_" + leftBreakpoint + "_" + rightReference + "_" + rightBreakpoint + "_"+ orientationCategory; 
+		return leftReference + "_xxx_" + leftBreakpoint + "_xxx_" + rightReference + "_xxx_" + rightBreakpoint + "_xxx_"+ orientationCategory;
 	}
 
 	public boolean equalReference() {

--- a/qsv/test/org/qcmg/qsv/softclip/BreakpointTest.java
+++ b/qsv/test/org/qcmg/qsv/softclip/BreakpointTest.java
@@ -15,9 +15,9 @@ import java.util.*;
 import static org.junit.Assert.*;
 
 public class BreakpointTest {
-	
+
 	Breakpoint breakpoint;
-	
+
 	@Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
@@ -28,10 +28,10 @@ public class BreakpointTest {
 		assertFalse(breakpoint.isGermline());
 		assertEquals("somatic", breakpoint.getType());
 		assertEquals(QSVUtil.MINUS, breakpoint.getStrand());
-		assertEquals("chr10_89700299_false_-", breakpoint.getName());
+		assertEquals("chr10_xxx_89700299_xxx_false_xxx_-", breakpoint.getName());
 		assertEquals("CCCTGCCCTAAGAGCAGCAAATTGCTGAACTCCTCTGGTGGACCTCTTACACAAAGTATAATCTC", breakpoint.getMateConsensus());
 	}
-	
+
 	@Test
 	public void testDefineBreakpointPassesFilterWithGermlineLeft() throws Exception {
 		breakpoint = TestUtil.getBreakpoint(true, true, 20, false);
@@ -39,16 +39,16 @@ public class BreakpointTest {
 		assertTrue(breakpoint.isGermline());
 		assertEquals("germline", breakpoint.getType());
 		assertEquals(QSVUtil.PLUS, breakpoint.getStrand());
-		assertEquals("chr10_89712341_true_+", breakpoint.getName());
+		assertEquals("chr10_xxx_89712341_xxx_true_xxx_+", breakpoint.getName());
 		assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTA", breakpoint.getMateConsensus());
 	}
-	
+
 	@Test
 	public void getClipString() {
 		Set<Clip> clips = TestUtil.getLeftClips(false);
 		assertEquals(1439, Breakpoint.getClipString(clips).length());
 	}
-	
+
 	@Test
 	public void parseMatchingSplitReads() {
 		String header = "";
@@ -67,7 +67,7 @@ public class BreakpointTest {
 			Breakpoint.parseMatchingSplitReads(null, null);
 			fail("Should have thrown an IAE");
 		} catch (IllegalArgumentException ignored) {}
-		
+
 		header += "what a great header";
 		splitReadsList.add(new UnmappedRead("column1,what a really great header,column2,3,column4", true));
 		Breakpoint.parseMatchingSplitReads(header, splitReadsList);
@@ -90,14 +90,14 @@ public class BreakpointTest {
 		header += "split_what a great header";
 		Breakpoint.parseMatchingSplitReads(header, splitReadsList);
 		assertEquals(1, splitReadsList.size());
-		
+
 		splitReadsList.add(new UnmappedRead("column1,what a great header,column2,3,column4", true));
 		splitReadsList.add(new UnmappedRead("column1,what a great header,column2,3,column4", true));
 		splitReadsList.add(new UnmappedRead("column1,what a great header,column2,3,column4", true));
 		Breakpoint.parseMatchingSplitReads(header, splitReadsList);
 		assertEquals(4, splitReadsList.size());
 	}
-	
+
 	@Test
 	public void matchBreakpoint() throws Exception {
 		/*
@@ -169,7 +169,7 @@ READ:GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAA
 		b.addTumourClip(new Clip("ST-E00104:642:HF55MALXX:8:1123:24353:62523:3ae5af45-d754-4534-80f3-e08252df172b,GL000219.1,165002,+,left,ATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGAGTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACC,ATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGA,GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACC"));
 		b.addTumourClip(new Clip("ST-E00129:529:HF5FTALXX:2:1106:19928:34500:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,GL000219.1,165002,+,left,GAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGAGTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCA,GAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGA,GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCA"));
 		b.addTumourClip(new Clip("ST-E00104:642:HF55MALXX:8:2108:23794:21895:3ae5af45-d754-4534-80f3-e08252df172b,GL000219.1,165002,-,left,CACTCAGAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGAGTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGA,CACTCAGAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGA,GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGA"));
-		
+
 		b.addNormalClip(new Clip("ST-E00129:529:HF5FTALXX:5:1115:15483:5458:71b40638-002b-4c7b-8a66-3b6209527a93,GL000219.1,165002,-,left,AACACTCAGAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGAGTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCA,AACACTCAGAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGA,GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCA"));
 		b.addNormalClip(new Clip("ST-E00129:529:HF5FTALXX:5:1122:26646:26659:71b40638-002b-4c7b-8a66-3b6209527a93,GL000219.1,165002,-,left,AAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGAGTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCAC,AAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGA,GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCAC"));
 		b.addNormalClip(new Clip("ST-E00129:529:HF5FTALXX:5:1223:11038:57706:71b40638-002b-4c7b-8a66-3b6209527a93,GL000219.1,165002,+,left,CAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGAGTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCACAGCA,CAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGA,GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCACAGCA"));
@@ -183,14 +183,14 @@ READ:GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAA
 		b.setConsensusRead(new ConsensusRead("clipContigFor,fullclip_ST-E00104:642:HF55MALXX:8:2115:26047:18942:3ae5af45-d754-4534-80f3-e08252df172b,fullclip_ST-E00129:529:HF5FTALXX:2:2102:16163:65459:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00104:642:HF55MALXX:5:1202:1621:35133:00587a9e-66fc-4fd2-a972-eee4cbaf9613,fullclip_ST-E00129:529:HF5FTALXX:5:1223:11038:57706:71b40638-002b-4c7b-8a66-3b6209527a93,fullclip_ST-E00104:642:HF55MALXX:2:2223:6248:2680:a7408e63-f751-46d8-b0ec-849c8b653631,fullclip_ST-E00104:642:HF55MALXX:8:1123:24353:62523:3ae5af45-d754-4534-80f3-e08252df172b,fullclip_ST-E00129:529:HF5FTALXX:2:1106:19928:34500:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00104:642:HF55MALXX:2:2208:3447:10697:a7408e63-f751-46d8-b0ec-849c8b653631,fullclip_ST-E00129:529:HF5FTALXX:2:2103:20446:28330:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00129:529:HF5FTALXX:2:2118:14367:57600:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00129:529:HF5FTALXX:2:2117:26606:15373:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00129:529:HF5FTALXX:5:2116:17939:10767:71b40638-002b-4c7b-8a66-3b6209527a93,fullclip_ST-E00104:642:HF55MALXX:2:2205:28747:49988:a7408e63-f751-46d8-b0ec-849c8b653631,fullclip_ST-E00129:529:HF5FTALXX:2:1205:18284:22018:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00129:529:HF5FTALXX:2:2121:16701:57565:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00129:529:HF5FTALXX:4:2109:20689:25411:4ea3b900-5fd2-4e6e-bb7d-2f2fbec977bd,fullclip_ST-E00129:529:HF5FTALXX:5:1122:26646:26659:71b40638-002b-4c7b-8a66-3b6209527a93,fullclip_ST-E00129:529:HF5FTALXX:3:2223:31314:6724:8c954e28-d035-4a28-806e-b8837caab052,fullclip_ST-E00129:529:HF5FTALXX:4:2119:32167:23319:4ea3b900-5fd2-4e6e-bb7d-2f2fbec977bd,fullclip_ST-E00129:529:HF5FTALXX:2:1124:5507:35643:ff341031-8dc5-4e50-9ff2-e9e1ee8f614f,fullclip_ST-E00104:642:HF55MALXX:5:2216:17066:61503:00587a9e-66fc-4fd2-a972-eee4cbaf9613,fullclip_ST-E00104:642:HF55MALXX:8:1115:25560:25798:3ae5af45-d754-4534-80f3-e08252df172b,fullclip_ST-E00129:529:HF5FTALXX:5:1218:28696:13931:71b40638-002b-4c7b-8a66-3b6209527a93,fullclip_ST-E00104:642:HF55MALXX:5:2215:28381:35819:00587a9e-66fc-4fd2-a972-eee4cbaf9613"
 				,"CTCAGAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGAGTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCACAGCAGTGTTCT"
 				,"CTCAGAAAACAGCATTAGTGTTTTGCAATCCTATGGGAGGGACAACATTCACACCCTTGTAGCAGA","GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAACATGCAGACCCTCACAGCAGTGTTCT"));
-		
+
 		BLATRecord r = new BLATRecord.Builder("52	4	0	0	0	0	1	1	+	GL000219.1_165002_true_+	66	9	65	GL000219.1	179198	165421	165478	2	36,20,	9,45,	165421,165458,").build();
-		
+
 		assertEquals(0, b.getMateBreakpoint());
         assertTrue(b.findMateBreakpoint(r));
 		assertEquals(165478, b.getMateBreakpoint());
 		assertEquals("GL000219.1", b.getMateReference());
-		
+
 		/*
 		 * try and match to another blat record - aligned by the tiled aligner of course...
 		 */
@@ -198,9 +198,9 @@ READ:GTTCTGGAATCCTGTGTGAGGGACAAACATTCAGACCACTGCAGGATTGTTCAGGAATCCTATCTGAGGGACAAA
         assertTrue(b.findMateBreakpoint(r2));
 		assertEquals(165479, b.getMateBreakpoint());			// out by 1
 		assertEquals("GL000219.1", b.getMateReference());
-		assertEquals("GL000219.1_165002_true_+", b.getName());
+		assertEquals("GL000219.1_xxx_165002_xxx_true_xxx_+", b.getName());
 	}
-	
+
 	@Test
 	public void matchBreakpoint2() throws Exception {
 		/*
@@ -230,7 +230,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		b.setConsensusRead(new ConsensusRead(">clipContigFor,fullclip_ST-E00104:642:HF55MALXX:5:1121:3285:7814:00587a9e-66fc-4fd2-a972-eee4cbaf9613,fullclip_ST-E00104:642:HF55MALXX:3:1222:24779:64808:30a4cb83-388a-48a6-84e4-9e82f3ec8df5,fullclip_ST-E00104:642:HF55MALXX:5:1123:13941:59429:00587a9e-66fc-4fd2-a972-eee4cbaf9613,fullclip_ST-E00104:642:HF55MALXX:4:1219:29264:26835:cd63589e-70c3-4c57-b11c-4bb05ca22592,fullclip_ST-E00129:529:HF5FTALXX:5:2122:12388:59727:71b40638-002b-4c7b-8a66-3b6209527a93"
 				,"AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTGCCTTTCTTTCAGAGATGGCTTGCCCAGAGAGGAGGAATCTAGAGAGGCAGTCTGGCTACAGTGGCCAGTCAGAACTTCCAGGTGGCTTTG"
 				,"CAGTCAGAACTTCCAGGTGGCTTTG","AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTGCCTTTCTTTCAGAGATGGCTTGCCCAGAGAGGAGGAATCTAGAGAGGCAGTCTGGCTACAGTGGC"));
-		
+
 		/*
 		 * try and match to another blat record - aligned by the tiled aligner of course...
 		 */
@@ -238,13 +238,13 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
         assertTrue(b.findMateBreakpoint(r2));
 		assertEquals(18918920, b.getMateBreakpoint());			// out by 1
 		assertEquals("chr11", b.getMateReference());
-		assertEquals("chr9_25061047_false_+", b.getName());
+		assertEquals("chr9_xxx_25061047_xxx_false_xxx_+", b.getName());
 	}
-	
+
 	@Test
 	public void findMateBreakpointIsTrueTA() throws Exception {
 		breakpoint = TestUtil.getBreakpoint(true, true, 20, false);
-		
+
 		String value = "42	1	0	0	0	0	0	0	+	name	59	0	43	chr10	135534747	89700259	89700301	1	42	1	89700259";
 		String[] values =value.split("\t");
 		BLATRecord tiledAlignerBlatRecord = new BLATRecord.Builder(values).build();
@@ -255,7 +255,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		assertEquals(89700301, breakpoint.getMateBreakpoint());
 		assertEquals("chr10:chr10", breakpoint.getReferenceKey());
 	}
-	
+
 	@Test
 	public void addClip() throws Exception {
 		Breakpoint b = new Breakpoint(25061047, "chr9", false, 20, 50);
@@ -267,7 +267,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		 */
 		b.addTumourClip(new Clip("ST-E00104:642:HF55MALXX:5:1121:3285:7814:00587a9e-66fc-4fd2-a972-eee4cbaf9613,chr9,25061047,+,right,CACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCAGAACTTCCAGGTGGCT,CAGTCAGAGGTGGCT,CACCCAGGTGCTCTTACAGTGGC"));
 		assertEquals(1, b.getClipsSize());
-		
+
 		/*
 		 * add in a normal
 		 */
@@ -276,31 +276,31 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		b.addNormalClip(new Clip("ST-E00104:642:HF55MALXX:5:1121:3285:7814:00587a9e-66fc-4fd2-a972-eee4cbaf9613,chr9,25061047,+,right,CACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCAGAACTTCCAGGTGGCT,CAGTCAGAGGTGGCT,CACCCAGGTGCTCTTACAGTGGC"));
 		assertEquals(2, b.getClipsSize());
 	}
-	
+
 	@Test
 	public void testDefineBreakpointNoPassesFilterClipSizeFilter() throws Exception {
 		breakpoint = TestUtil.getBreakpoint(true, true, 20, false);
 		assertFalse(breakpoint.defineBreakpoint(10, false, null));
 	}
-	
+
 	@Test
 	public void testDefineBreakpointNoPassesFilterConsensusFilter() throws Exception {
 		breakpoint = TestUtil.getBreakpoint(true, true, 100, false);
 		assertFalse(breakpoint.defineBreakpoint(3, false, null));
 	}
-	
+
 	@Test
 	public void testDefineBreakpointNoPassesHighNCountFilter() throws Exception {
 		breakpoint = TestUtil.getBreakpoint(true, true, 20, true);
 		assertFalse(breakpoint.defineBreakpoint(3, false, null));
 	}
-	
+
 	@Test
 	public void testFindMateBreakpointIsTrue() throws Exception {
 		String value = "48\t1\t0\t0\t2\t0\t3\t0\t+\tchr10-89712341-true-pos\t66\t0\t48\tchr10\t135534747\t89700251\t89700299\t1\t48,\t0,\t89700251,";
 		String[] values =value.split("\t");
 		BLATRecord record = new BLATRecord.Builder(values).build();
-		
+
 		breakpoint = TestUtil.getBreakpoint(true, false, 20, false);
 		assertTrue(breakpoint.findMateBreakpoint(record));
 		assertEquals(QSVUtil.PLUS, breakpoint.getMateStrand());
@@ -308,33 +308,33 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		assertEquals(89700299, breakpoint.getMateBreakpoint());
 		assertEquals("chr10:chr10", breakpoint.getReferenceKey());
 	}
-	
+
 	@Test
 	public void testFindMateBreakpointIsTrueWithNoChr() throws Exception {
 		String value = "48\t1\t0\t0\t2\t0\t3\t0\t+\t10-89712341-true-pos\t66\t0\t48\tchr10\t135534747\t89700251\t89700299\t1\t48,\t0,\t89700251,";
 		String[] values =value.split("\t");
 		BLATRecord record = new BLATRecord.Builder(values).build();
-		
+
 		breakpoint = TestUtil.getBreakpointNoChr(true, false, 20);
         assertTrue(breakpoint.findMateBreakpoint(record));
-		
+
 		assertEquals(QSVUtil.PLUS, breakpoint.getMateStrand());
 		assertEquals("chr10", breakpoint.getMateReference());
 		assertEquals(89700299, breakpoint.getMateBreakpoint());
 		assertEquals("10:chr10", breakpoint.getReferenceKey());
 	}
-	
+
 	@Test
 	public void testFindMateBreakpointWithReordering() throws Exception {
 		String value = "48\t1\t0\t0\t2\t0\t3\t0\t+\tchr10-89712341-true-pos\t66\t0\t48\tchr7\t135534747\t89700251\t89700299\t1\t48,\t0,\t89700251,";
 		String[] values =value.split("\t");
 		BLATRecord record = new BLATRecord.Builder(values).build();
-		
+
 		breakpoint = TestUtil.getBreakpoint(false, false, 20, false);
 		assertTrue(breakpoint.findMateBreakpoint(record));
 		assertEquals("chr7:chr10", breakpoint.getReferenceKey());
 	}
-	
+
 	@Test
 	public void calculateConsensusActual() throws Exception {
 		breakpoint = TestUtil.getBreakpoint(true, true, 20, false);
@@ -350,7 +350,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		assertEquals("TTACACAAAGAGATTATATGACTTAGGACAGGTTGATCTTTGCAGATCTGTTCGTTTTGTGAAACAAGGTCTCGATCTGTTGCCTAT", Breakpoint.calculateConsensus(breakpoint.getStrand(), breakpoint.getBreakpointConsenus().length(), false, breakpoint.getTumourClips(), breakpoint.getNormalClips(), breakpoint.isGermline()));
 		assertEquals("NNNNNNNNNNNNNNNNNNNNNCCCTGCCCTAAGAGCAGCAAATTGCTGAACTCCTCTGGTGGACCTCTTACACAAAGTATAATCTC", Breakpoint.calculateConsensus(breakpoint.getStrand(), breakpoint.getBreakpointConsenus().length(), true, breakpoint.getTumourClips(), breakpoint.getNormalClips(), breakpoint.isGermline()));
 	}
-	
+
 	@Test
 	public void calculate() throws Exception {
 		breakpoint = TestUtil.getBreakpoint(true, true, 20, false);
@@ -358,7 +358,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		int posLength = 0;
 		int negReadLength = 0;
 		int posReadLength = 0;
-		
+
 		for (Clip c: breakpoint.getTumourClips()) {
 			if (QSVUtil.PLUS == c.getStrand()) {
 				posLength = Math.max(posLength, c.getLength());
@@ -370,7 +370,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		}
 		if (breakpoint.isGermline()) {
 			for (Clip c: breakpoint.getNormalClips()) {
-				
+
 				if (QSVUtil.PLUS == c.getStrand()) {
 					posLength = Math.max(posLength, c.getLength());
 					posReadLength = Math.max(posReadLength, c.getReferenceSequence().length());
@@ -384,7 +384,7 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
         assert cr != null;
         assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT", cr.getSequence());
 	}
-	
+
 	@Test
 	public void calculateClipConsensus() throws Exception {
 		Set<Clip> testClips = new HashSet<>();
@@ -395,9 +395,9 @@ READ:AGCCACCCTTTCACCCAGGTGCTCTGTCACAGGGAGATGAGAGTTTTATCTATAAGCCTCTGACTGGGGCTGCTG
 		controlClips.add(new Clip("HWI-ST1240:47:D12NAACXX:5:2311:7722:24906:20110221052813657,chr10,89712341,+,left,TCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGA,TCTCTTTGTGTAAGAGATTATACTTTGTGTA,AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGA"));
 		controlClips.add(new Clip("HWI-ST1240:47:D12NAACXX:7:2210:12278:86346:20110221052813657,chr10,89712341,+,left,ACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT,ACTTTGTGTA,AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT"));
 		controlClips.add(new Clip("HWI-ST1240:47:D12NAACXX:4:2105:19785:71299:20110221052813657,chr10,89712341,+,left,AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGG,AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTA,AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGG"));
-		
+
 		ConsensusRead cr = Breakpoint.calculateClipConsensus(0, testClips, controlClips, true, true, 20, true, 6, 0);
-		
+
 		/*
 		 * >consensusread
 FULL:AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT
@@ -409,7 +409,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		assertEquals("AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT", cr.getReferenceSequence());
 		assertEquals("AAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAAT", cr.getSequence());
 	}
-	
+
 	@Test
 	public void calculateConsensus() {
 		assertEquals("A", Breakpoint.getBaseCountString(setUpBases(1,0,0,0,0)));
@@ -420,7 +420,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		assertEquals("N", Breakpoint.getBaseCountString(setUpBases(1,1,0,0,0)));
 		assertEquals("A", Breakpoint.getBaseCountString(setUpBases(2,1,0,0,0)));
 	}
-	
+
 	@Test
 	public void calculateStrand() throws QSVException {
 		assertStrand(QSVUtil.PLUS, QSVUtil.PLUS, false, 2,0);
@@ -428,7 +428,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		assertStrand(QSVUtil.PLUS, QSVUtil.PLUS, true, 4,0);
 		assertStrand(QSVUtil.MINUS, QSVUtil.MINUS, true, 0, 4);
 	}
-	
+
 	@Test
 	public void testCompare() {
 		breakpoint = new Breakpoint(1, "reference", true, 1, 1);
@@ -438,7 +438,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		assertNull(breakpoint.compare("chr1", 12356));
 		assertEquals(Integer.valueOf(12350), breakpoint.compare("chr1", 12350));
 	}
-	
+
 	@Test
 	public void compare() {
 		assertEquals(OptionalInt.of(0), Breakpoint.compare("", 0, "", 0));
@@ -453,12 +453,12 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		assertEquals(OptionalInt.empty(), Breakpoint.compare("chr1", 32, "chr1", 21));
 		assertEquals(OptionalInt.empty(), Breakpoint.compare("chr2", 10, "chr1", 20));
 	}
-	
+
 	private void assertStrand(char strand1, char strand2, boolean isGermline,
 			int posStrandCount, int negStrandCount) throws QSVException {
-		breakpoint = new Breakpoint(1, "reference", true, 1, 1);	
+		breakpoint = new Breakpoint(1, "reference", true, 1, 1);
 		HashSet<Clip> set = new HashSet<>();
-		set.add(new Clip("test,chr10,89712341,"+strand1+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));		
+		set.add(new Clip("test,chr10,89712341,"+strand1+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));
 		set.add(new Clip("test2,chr10,89712341,"+strand2+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));
 		for (Clip c : set) {
 			breakpoint.addTumourClip(c);
@@ -466,7 +466,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		if (isGermline) {
 			breakpoint.setGermline(true);
 			set.clear();
-			set.add(new Clip("test3,chr10,89712341,"+strand1+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));		
+			set.add(new Clip("test3,chr10,89712341,"+strand1+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));
 			set.add(new Clip("test4,chr10,89712341,"+strand2+",left,ACTTTGAAAAAACAGTAATTAA,ACTTTGAAAAAACAGTAATT,AA"));
 			for (Clip c : set) {
 				breakpoint.addNormalClip(c);
@@ -477,13 +477,13 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		assertEquals(posStrandCount, breakpoint.getPosStrandCount());
 		assertEquals(negStrandCount, breakpoint.getNegStrandCount());
 	}
-	
+
 	@Test
 	public void testConsensusRead() throws Exception {
 		breakpoint = new Breakpoint(1, "reference", true, 1, 1);
 		breakpoint.setStrand(QSVUtil.PLUS);
 		breakpoint.setConsensusRead(new ConsensusRead("test", "ACTTTGAAAAAACAGTAATTAA","ACTTTGAAAAAACAGTAATT","AA"));
-		
+
 		assertEquals("ACTTTGAAAAAACAGTAATTAA", breakpoint.getCompleteConsensus());
 		assertEquals("ACTTTGAAAAAACAGTAATT", breakpoint.getMateConsensus());
 		assertEquals("AA", breakpoint.getBreakpointConsenus());
@@ -492,7 +492,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
 		assertEquals("ACTTTGAAAAAACAGTAATT", breakpoint.getMateConsensus());
 		assertEquals("TT", breakpoint.getBreakpointConsenus());
 	}
-	
+
 	@Test
 	public void belowMinInsertSizeSameBP() {
 		// same bp and mate bp
@@ -512,7 +512,7 @@ READ:AGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACT
         assertTrue(Breakpoint.belowMinInsertSize(0, 2, 2));
         assertTrue(Breakpoint.belowMinInsertSize(2, 1, 2));
 	}
-	
+
 	private int[][] setUpBases(int a, int b, int c, int d, int e) {
 		int[][] bases = new int[1][5];
 		bases[0][0] = a;

--- a/qsv/test/org/qcmg/qsv/splitread/SplitReadContigTest.java
+++ b/qsv/test/org/qcmg/qsv/splitread/SplitReadContigTest.java
@@ -29,21 +29,21 @@ import gnu.trove.map.hash.TIntObjectHashMap;
 
 
 public class SplitReadContigTest {
-	
+
 	BLAT blat;
 	QSVParameters p;
 	SplitReadContig splitReadContig;
 	List<BLATRecord> records;
 	SplitReadAlignment left;
 	SplitReadAlignment right;
-	
+
 	@Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
 	@Before
 	public void setUp() throws Exception {
 		records = new ArrayList<BLATRecord>();
-		
+
 	}
 
 	@After
@@ -55,7 +55,7 @@ public class SplitReadContigTest {
 		left = null;
 		right = null;
 	}
-	
+
 	@Test
 	public void getMutationType() {
 		createStandardObject(1);
@@ -63,7 +63,7 @@ public class SplitReadContigTest {
 		splitReadContig.determineSplitReadPotential();
 		assertEquals(null, splitReadContig.getMutationType());
 	}
-	
+
 	@Test
 	public void testLeftLower() throws UnsupportedEncodingException, QSVException {
 		createStandardObject(1);
@@ -72,7 +72,7 @@ public class SplitReadContigTest {
 		splitReadContig.setSplitReadAlignments(right, left);
 		assertFalse(SplitReadContig.leftLower(right.getQueryStart(), left.getQueryStart()));
 	}
-	
+
 	@Test
 	public void getSingleSplitReadAlignment() {
 		createStandardObject(1);
@@ -81,49 +81,55 @@ public class SplitReadContigTest {
 		assertEquals(right, SplitReadContig.getSingleSplitReadAlignment(null, right));
 		assertEquals(null, SplitReadContig.getSingleSplitReadAlignment(null, null));
 	}
-	
+
 	@Test
 	public void testGetName() {
 		createStandardObject(1);
-		assertTrue(splitReadContig.getName().startsWith("splitcon_chr10_89700299_chr10_89712341_1_false"));
+		assertTrue(splitReadContig.getName().startsWith("splitcon_xxx_chr10_xxx_89700299_xxx_chr10_xxx_89712341_xxx_1_xxx_false"));
 	}
-	
+
+	@Test
+	public void testGetChrUnName() {
+		createStandardObjectWithChrUn(1);
+		assertTrue(splitReadContig.getName().startsWith("splitcon_xxx_chrUn_KI270442v1_xxx_44617_xxx_chrUn_KI270442v1_xxx_45730_xxx_2_xxx_false"));
+	}
+
 	@Test
 	public void testReorder() {
 		createStandardObject(1);
 		splitReadContig.setSplitReadAlignments(right, left);
 		assertTrue(splitReadContig.getLeft().getStartPos() > splitReadContig.getRight().getStartPos());
-		
+
 		assertCorrectSplitReadAlignmentOrder(null);
-		
+
 		left = new SplitReadAlignment("chr15", QSVUtil.PLUS, 89700210, 89700299, 1, 90);
 		splitReadContig.setSplitReadAlignments(left, right);
 		assertEquals("chr15", splitReadContig.getLeft().getReference());
-		assertCorrectSplitReadAlignmentOrder("chr10");		
+		assertCorrectSplitReadAlignmentOrder("chr10");
 	}
-	
+
 	private void assertCorrectSplitReadAlignmentOrder(String chr) {
 		createStandardObject(1);
-		splitReadContig.reorder();			
+		splitReadContig.reorder();
 		if (chr != null) {
 			assertEquals(chr, splitReadContig.getLeft().getReference());
 		} else {
-			assertTrue(splitReadContig.getLeft().getStartPos() < splitReadContig.getRight().getStartPos());			
+			assertTrue(splitReadContig.getLeft().getStartPos() < splitReadContig.getRight().getStartPos());
 		}
 	}
 
 	@Test
 	public void testCalculateMicrohomologyIsAbsent() throws QSVException, IOException {
 		createStandardObject(1);
-		splitReadContig.setNonTemplateSequence(null);	
+		splitReadContig.setNonTemplateSequence(null);
 		splitReadContig.calculateMicrohomology();
 		assertEquals(QSVConstants.UNTESTED, splitReadContig.getMicrohomology());
-		
+
 		splitReadContig.setNonTemplateSequence("ACTG");
 		splitReadContig.calculateMicrohomology();
 		assertEquals(QSVConstants.NOT_FOUND, splitReadContig.getMicrohomology());
 	}
-	
+
 	@Test
 	public void testCalculateMicrohomology() throws QSVException, IOException {
 		createStandardObject(1);
@@ -133,7 +139,7 @@ public class SplitReadContigTest {
 		splitReadContig.setRightSequence("CAACAGTTATTTAAAAATGTTCATCATCACTAATCATGAAAGAAATGCAAAGCAAAA");
 		splitReadContig.calculateMicrohomology();
 		assertEquals("CAA", splitReadContig.getMicrohomology());
-		
+
 		splitReadContig.setLeftSequence("TAAATGACCCTGTCTCCTTTGCTCTGTGTACTCTCGTGGC");
 		splitReadContig.setRightSequence("AACAGTTATTTAAAAATGTTCATCATCACTAATCATGAAAAAA");
 		splitReadContig.calculateMicrohomology();
@@ -148,9 +154,9 @@ public class SplitReadContigTest {
 		splitReadContig.determineSplitReadPotential();
 		assertTrue(splitReadContig.getIsPotentialSplitRead());
 	}
-	
+
 	@Test
-	public void testNeedToReverseComplement() {	
+	public void testNeedToReverseComplement() {
 		assertEquals(false, SplitReadContig.needToReverseComplement(QSVConstants.ORIENTATION_4, QSVUtil.MINUS));
 		assertEquals(true, SplitReadContig.needToReverseComplement(QSVConstants.ORIENTATION_3, QSVUtil.MINUS));
 		assertEquals(true, SplitReadContig.needToReverseComplement(QSVConstants.ORIENTATION_2, QSVUtil.MINUS));
@@ -159,41 +165,41 @@ public class SplitReadContigTest {
 		assertEquals(false, SplitReadContig.needToReverseComplement(QSVConstants.ORIENTATION_3, QSVUtil.PLUS));
 		assertEquals(false, SplitReadContig.needToReverseComplement(QSVConstants.ORIENTATION_2, QSVUtil.PLUS));
 		assertEquals(false, SplitReadContig.needToReverseComplement(QSVConstants.ORIENTATION_1, QSVUtil.PLUS));
-	}	
-	
+	}
+
 	@Test
 	public void testCat1and2Nontemplate() {
 		createStandardObject(1);
 		splitReadContig.setCat1and2NonTemplate();
 		assertEquals("GAGATTATACTTTGTGTA", splitReadContig.getNonTemplateSequence());
-	
+
 		left = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299,109, 282);
 		right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89712341, 89712514,  1, 90);
 		splitReadContig.setSplitReadAlignments(left, right);
 		splitReadContig.setCat1and2NonTemplate();
-		assertEquals("GAGATTATACTTTGTGTA", splitReadContig.getNonTemplateSequence());	
+		assertEquals("GAGATTATACTTTGTGTA", splitReadContig.getNonTemplateSequence());
 	}
-	
+
 	@Test
 	public void testCat3and4Nontemplate() {
 		createStandardObject(1);
 		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89712341, 89712514,  1, 90);
 		left = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299,109, 282);
 		assertCat3and4NonTemplate(left, right, "3");
-		
+
 		right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89712341, 89712514,  1, 90);
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299,109, 282);
 		assertCat3and4NonTemplate(left, right, "4");
-		
+
 		left = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89712341, 89712514,  109, 282);
 		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299,1, 90);
 		assertCat3and4NonTemplate(left, right, "3");
-		
+
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89712341, 89712514,  109, 282);
 		right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299,1, 90);
-		assertCat3and4NonTemplate(left, right, "4");		
+		assertCat3and4NonTemplate(left, right, "4");
 	}
-	
+
 	private void assertCat3and4NonTemplate(SplitReadAlignment left,
 			SplitReadAlignment right, String cat) {
 		createStandardObject(1);
@@ -201,19 +207,19 @@ public class SplitReadContigTest {
 		splitReadContig.setSplitreadSV(new StructuralVariant("chr10", "chr10", 89700299, 89712341, cat));
 		splitReadContig.setCat3and4NonTemplate();
 		assertEquals(18, splitReadContig.getNonTemplateSequence().length());
-		assertEquals("GAGATTATACTTTGTGTA", splitReadContig.getNonTemplateSequence());	
+		assertEquals("GAGATTATACTTTGTGTA", splitReadContig.getNonTemplateSequence());
 	}
-	
+
 	@Test
 	public void setSplitReadAlignments() {
 		/*
 		 * consensus: CTAGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTAGACAAGGTCTCGCTGTGTTGCCCAGGCTGGCCTTGAACTCCTGGCCTTGAGTGAGCCTCCCACCTCAACCTCCCGAGGTGCTGAGGTTACAAATGTGAGCTACTGCACCTGGCACTAGAAATTAGCTTTTATTTACACTTTCTAAGCATTCACACTGTGCCTGGTTCCGGTT
-		 * 214		215	1	0	0	0	0	0	0+	splitcon_chr7_101126970_chr7_156838178__true_1557450089062_845461	232	15	231	chr7	12345	101127272	101127488	1	216	15	101127287	, 
-		 * r2: 74		118	39	0	0	3	3	2	2	-	splitcon_chr7_101126970_chr7_156838178__true_1557450089062_845461	232	-1	144	chr7	12345	100341191	100341351	2	14,145	-1,-1	100341190,100341190	, 
+		 * 214		215	1	0	0	0	0	0	0+	splitcon_chr7_101126970_chr7_156838178__true_1557450089062_845461	232	15	231	chr7	12345	101127272	101127488	1	216	15	101127287	,
+		 * r2: 74		118	39	0	0	3	3	2	2	-	splitcon_chr7_101126970_chr7_156838178__true_1557450089062_845461	232	-1	144	chr7	12345	100341191	100341351	2	14,145	-1,-1	100341190,100341190	,
 		 * left: null, right: null, lhsBp: 101126970, rhsBp: 156838178, confidenceLevel: 6, length: 232
 		 */
-		BLATRecord r1 = new BLATRecord.Builder("215	1	0	0	0	0	0	0	+	splitcon_chr7_101126970_chr7_156838178__true_1557450089062_845461	232	15	231	chr7	12345	101127272	101127488	1	216	15	101127287".split("\t")).build();
-		BLATRecord r2 = new BLATRecord.Builder("118	39	0	0	3	3	2	2	-	splitcon_chr7_101126970_chr7_156838178__true_1557450089062_845461	232	-1	144	chr7	12345	100341191	100341351	2	14,145	-1,-1	100341190,100341190".split("\t")).build();
+		BLATRecord r1 = new BLATRecord.Builder("215	1	0	0	0	0	0	0	+	splitcon_xxx_chr7_xxx_101126970_xxx_chr7_xxx_156838178_xxx__xxx_true_xxx_1557450089062_xxx_845461	232	15	231	chr7	12345	101127272	101127488	1	216	15	101127287".split("\t")).build();
+		BLATRecord r2 = new BLATRecord.Builder("118	39	0	0	3	3	2	2	-	splitcon_xxx_chr7_xxx_101126970_xxx_chr7_xxx_156838178_xxx__xxx_true_xxx_1557450089062_xxx_845461	232	-1	144	chr7	12345	100341191	100341351	2	14,145	-1,-1	100341190,100341190".split("\t")).build();
 		SplitReadAlignment left = null;
 		SplitReadAlignment right = null;
 		int lhsBp = 101126970;
@@ -226,13 +232,13 @@ public class SplitReadContigTest {
 		assertEquals(false, left == null);
 		assertEquals(true, right == null);
 	}
-	
+
 	@Test
 	public void setSplitReadAlignments2() {
 		/*
 		 * consensus: CGTGGGGGTGGGATCCACTGAGCTAGAACACTTGGCTCCCTGGCTTTGGCCCCCTTTCCAGGGGAGTGAACAGTTCTGTCTTGCTGGTGTTCCAGGCGCCACTGGGGTATGAAAAATATTCCTGCAGCTAGCTCAGTGTCTTCTTGGCAATGTGGGCACTTTTTTGGTTCCATATGAATTTTAAAGTAGTTTTTTCCAATTCTGTGAAGAAA
-		 *r1: 144		160	8	0	0	4	4	4	4+	name	212	0	172	chr9	12345	22496387	22496559	2	159,13	0,159	22496387,22496546	, 
-		 *r2: 116		146	22	0	0	2	26	6	-	name	212	-1	110	chr9	12345	79456284	79456454	2	63,111	-1,-1	79456283,79456283	, 
+		 *r1: 144		160	8	0	0	4	4	4	4+	name	212	0	172	chr9	12345	22496387	22496559	2	159,13	0,159	22496387,22496546	,
+		 *r2: 116		146	22	0	0	2	26	6	-	name	212	-1	110	chr9	12345	79456284	79456454	2	63,111	-1,-1	79456283,79456283	,
 		 *left: null, right: null, lhsBp: 22496527, rhsBp: 22504346, confidenceLevel: 6, length: 212
 		 */
 		BLATRecord r1 = new BLATRecord.Builder("160	8	0	0	4	4	4	4	+	name	212	0	172	chr9	12345	22496387	22496559	2	159,13	0,159	22496387,22496546".split("\t")).build();
@@ -253,12 +259,12 @@ public class SplitReadContigTest {
 		assertEquals(1, left.getQueryStart().intValue());
 		assertEquals(159, left.getQueryEnd().intValue());
 	}
-	
+
 	@Test
 	public void setSplitReadAlignments3() {
 		/*
-		 *WARNING org.qcmg.qsv.splitread.SplitReadContig - about to call setSplitReadAlignments with r1: 155     172     3       0       0       7       19      7       23      +       name    194     0       194     chr8    12345   136887841       136888039       8       4,2,3,13,6,9,2,155      0,4,6,9,22,28,37,39     136887841,136887845,136887847,136887850,136887863,136887869,136887878,136887880, 
-		 *r2: 105        144     11      0       0       13      39      15      25      +       name    194     0	194     chr8    12345   136848254       136848434       16      60,1,1,9,3,52,9,4,4,11,7,2,5,4,2,20     0,1,1,62,9,74,126,74,139,143,130,25,163,144,1,174       136848254,136848255,136848255,136848316,136848263,136848328,136848380,136848328,136848393,136848397,136848384,136848279,136848417,136848398,136848255,136848428, 
+		 *WARNING org.qcmg.qsv.splitread.SplitReadContig - about to call setSplitReadAlignments with r1: 155     172     3       0       0       7       19      7       23      +       name    194     0       194     chr8    12345   136887841       136888039       8       4,2,3,13,6,9,2,155      0,4,6,9,22,28,37,39     136887841,136887845,136887847,136887850,136887863,136887869,136887878,136887880,
+		 *r2: 105        144     11      0       0       13      39      15      25      +       name    194     0	194     chr8    12345   136848254       136848434       16      60,1,1,9,3,52,9,4,4,11,7,2,5,4,2,20     0,1,1,62,9,74,126,74,139,143,130,25,163,144,1,174       136848254,136848255,136848255,136848316,136848263,136848328,136848380,136848328,136848393,136848397,136848384,136848279,136848417,136848398,136848255,136848428,
 		 *left: null, right: null, lhsBp: 136848311, rhsBp: 136887903, confidenceLevel: 6, length: 194
 		 */
 		BLATRecord r1 = new BLATRecord.Builder("172	3	0	0	7	19	7	23	+	name	194	0	194	chr8	12345	136887841	136888039	8	4,2,3,13,6,9,2,155	0,4,6,9,22,28,37,39	136887841,136887845,136887847,136887850,136887863,136887869,136887878,136887880".split("\t")).build();
@@ -274,7 +280,7 @@ public class SplitReadContigTest {
 		right = pair.getRight();
 		assertEquals(false, left == null);
 		assertEquals(false, right == null);
-		
+
 		System.out.println("left strand: " + left.getStrand());
 		System.out.println("right strand: " + right.getStrand());
 		System.out.println("left lower: " + (left.getQueryStart() < right.getQueryStart()));
@@ -283,16 +289,16 @@ public class SplitReadContigTest {
 		System.out.println("left getStartPos: " + left.getStartPos());
 		System.out.println("right getQueryStart: " + right.getQueryStart());
 		System.out.println("right getQueryEnd: " + right.getQueryEnd());
-		
+
 		assertEquals(1, right.getQueryStart().intValue());
 		assertEquals(60, right.getQueryEnd().intValue());
 		assertEquals(40, left.getQueryStart().intValue());
 		assertEquals(194, left.getQueryEnd().intValue());
 	}
-	
+
 	@Test
 	public void passesNewAlignmentFilters() {
-		SplitReadAlignment newAlign = new SplitReadAlignment(new BLATRecord.Builder("215	1	0	0	0	0	0	0	+	splitcon_chr7_101126970_chr7_156838178__true_1557450089062_845461	232	15	231	chr7	12345	101127272	101127488	1	216	15	101127287".split("\t")).build());
+		SplitReadAlignment newAlign = new SplitReadAlignment(new BLATRecord.Builder("215	1	0	0	0	0	0	0	+	splitcon_xxx_chr7_xxx_101126970_xxx_chr7_xxx_156838178_xxx__xxx_true_xxx_1557450089062_xxx_845461	232	15	231	chr7	12345	101127272	101127488	1	216	15	101127287".split("\t")).build());
 		assertEquals(false, SplitReadContig.passesNewAlignmentFilters(newAlign, "6", 101126970, 156838178, 232));
 	}
 	@Test
@@ -300,7 +306,7 @@ public class SplitReadContigTest {
 		SplitReadAlignment newAlign = new SplitReadAlignment("chr15",'+',	24397930	,24398008	,152	,230);
 		assertEquals(true, SplitReadContig.passesNewAlignmentFilters(newAlign, "6", 23831661, 23992703, 230));
 	}
-	
+
 	@Test
 	public void getBestBlocksFromBlat() {
 		/*
@@ -309,58 +315,58 @@ public class SplitReadContigTest {
 		SplitReadAlignment left = null;
 		SplitReadAlignment right = null;
 		StructuralVariant knownSV = new StructuralVariant("chr7", "chr7", 100867120, 100867215, null);
-		
-		BLATRecord record = new BLATRecord.Builder("395	0	0	0	1	1	2	210	+	splitcon_chr7_100867120_chr7_100867215__true_1584581279378_768689	398	1	397	chr7	12345	100866756	100867361	3	78,171,147	1,79,250	100866757,100866835,100867006,").build();
+
+		BLATRecord record = new BLATRecord.Builder("395	0	0	0	1	1	2	210	+	splitcon_xxx_chr7_xxx_100867120_xxx_chr7_xxx_100867215_xxx__xxx_true_xxx_1584581279378_xxx_768689	398	1	397	chr7	12345	100866756	100867361	3	78,171,147	1,79,250	100866757,100866835,100867006,").build();
 		Pair<SplitReadAlignment, SplitReadAlignment> pair = SplitReadContig.getBestBlocksFromBLAT(record, true, left, right, "6",  knownSV, 398);
 		assertEquals(true, pair.getLeft() != null);
 		assertEquals(true, pair.getRight() != null);
 		System.out.println("left: " + pair.getLeft());
 		System.out.println("right: " + pair.getRight());
-		
+
 	}
-	
+
 	@Test
 	public void getBestBlocksFromBlat2() {
 		SplitReadAlignment left = null;
 		SplitReadAlignment right = null;
 		StructuralVariant knownSV = new StructuralVariant("chr7", "chr7", 100867120, 100867215, null);
-		
+
 		BLATRecord record = new BLATRecord.Builder("172	0	0	0	0	0	1	94	+	name	172	0	172	chr7	12345	100867054	100867320	2	66,106	0,66	100867054,100867120,").build();
 		Pair<SplitReadAlignment, SplitReadAlignment> pair = SplitReadContig.getBestBlocksFromBLAT(record, true, left, right, "6", knownSV, 172);
 		assertEquals(true, pair.getLeft() != null);
 		assertEquals(true, pair.getRight() != null);
-		
+
 		System.out.println("left: " + pair.getLeft());
 		System.out.println("right: " + pair.getRight());
-		
+
 	}
-	
+
 	@Test
 	public void getBestBlocksFromBlat3() {
 		/*
-		 *  getBestBlocksFromBLAT rec: 80    104     20      0       0       1       1       3       13      -       splitcon_chr10_127633807_chr15_34031839__true_1587614939343_235036      188     63      188     chr10   12345   127633738       127633875       4       31,16,7,71      63,94,110,117   127633801,127633833,127633860,127633868, 
-		 *  left: chr15    +       34031839        34031957        70      188, 
-		 *  right: null, confidenceLevel: 6, 
+		 *  getBestBlocksFromBLAT rec: 80    104     20      0       0       1       1       3       13      -       splitcon_chr10_127633807_chr15_34031839__true_1587614939343_235036      188     63      188     chr10   12345   127633738       127633875       4       31,16,7,71      63,94,110,117   127633801,127633833,127633860,127633868,
+		 *  left: chr15    +       34031839        34031957        70      188,
+		 *  right: null, confidenceLevel: 6,
 		 *  knownSV: chr10_127633807_chr15_34031839_, length: 188
 		 */
 		SplitReadAlignment left = new SplitReadAlignment("chr15", '+', 34031839, 34031957, 70, 188);
 		SplitReadAlignment right = null;
 		StructuralVariant knownSV = new StructuralVariant("chr10", "chr15", 127633807, 34031839, null);
-		
-		BLATRecord record = new BLATRecord.Builder("104	20	0	0	1	1	3	13	-	splitcon_chr10_127633807_chr15_34031839__true_1587614939343_235036	188	63	188	chr10	12345	127633738	127633875	4	31,16,7,71	63,94,110,117	127633801,127633833,127633860,127633868,").build();
+
+		BLATRecord record = new BLATRecord.Builder("104	20	0	0	1	1	3	13	-	splitcon_xxx_chr10_xxx_127633807_xxx_chr15_xxx_34031839_xxx__xxx_true_xxx_1587614939343_xxx_235036	188	63	188	chr10	12345	127633738	127633875	4	31,16,7,71	63,94,110,117	127633801,127633833,127633860,127633868,").build();
 		Pair<SplitReadAlignment, SplitReadAlignment> pair = SplitReadContig.getBestBlocksFromBLAT(record, true, left, right, "6", knownSV, 188);
 		assertEquals(true, pair.getLeft() != null);
 		assertEquals(true, pair.getRight() == null);
-		
+
 		System.out.println("left: " + pair.getLeft());
 		System.out.println("right: " + pair.getRight());
-		
-		
+
+
 		/*
 		 * this is the record returned from blat
 		 * 67      2       0       0       0       0       0       0       -       splitcon_chr10_127633807_chr15_34031839__true_1586132281792_839799      188     0       69      chr10   135534747       127633806       127633875       1       69,     119,    127633806,
 		 */
-		
+
 		BLATRecord blatRecord = new BLATRecord.Builder("67	2	0	0	0	0	0	0	-	splitcon_chr10_127633807_chr15_34031839__true_1586132281792_839799	188	0	69	chr10	135534747	127633806	127633875	1	69,	119,	127633806,").build();
 		knownSV = new StructuralVariant("chr10", "chr15", 127633807, 34031839, null);
 		pair = SplitReadContig.getBestBlocksFromBLAT(blatRecord, true, left, right, "6", knownSV, 188);
@@ -368,10 +374,10 @@ public class SplitReadContigTest {
 		System.out.println("left: " + pair.getLeft());
 		System.out.println("right: " + pair.getRight());
 	}
-	
+
 	@Test
 	public void determineMutationType() {
-		StructuralVariant sv = new StructuralVariant("chrX", "chrX", 100, 1000, "1");		
+		StructuralVariant sv = new StructuralVariant("chrX", "chrX", 100, 1000, "1");
 		assertEquals("DEL/ITX", SplitReadContig.determineMutationType(sv));
 		sv = new StructuralVariant("chrX", "chrX", 100, 1000, "2");
 		assertEquals("DUP/INS/ITX", SplitReadContig.determineMutationType(sv));
@@ -384,63 +390,63 @@ public class SplitReadContigTest {
 		sv = new StructuralVariant("chrX", "chrX", 100, 1000, null);
 		assertEquals("", SplitReadContig.determineMutationType(sv));
 	}
-	
+
 	@Test
 	public void getAlignmentDifference() {
 		SplitReadAlignment sra = new SplitReadAlignment("chr1", '-', 1000, 900, 1, 50);
 		assertEquals(null, SplitReadContig.getAlignmentDifference(null, null, 10, sra, QSVConstants.LEVEL_HIGH, 89700299, 89712341, 282));
 		assertEquals(sra, SplitReadContig.getAlignmentDifference(null, null, 10, sra, QSVConstants.LEVEL_SINGLE_CLIP, 89700299, 89712341, 282));
-		
+
 		sra = new SplitReadAlignment("chr1", '-', 89700299, 89712341, 1, 50);
 		assertEquals(sra, SplitReadContig.getAlignmentDifference(null, null, 10, sra, QSVConstants.LEVEL_HIGH, 89700299, 89712341, 282));
-		
+
 	}
-	
+
 	@Test
 	public void testPassesBreakpointFilter() {
 		createStandardObject(1);
 		splitReadContig.setConfidenceLevel(QSVConstants.LEVEL_HIGH);
 		assertTrue(SplitReadContig.passesBreakpointFilter(left, right, QSVConstants.LEVEL_HIGH, 89700299, 89712341));
-		
+
 		splitReadContig.setConfidenceLevel(QSVConstants.LEVEL_SINGLE_CLIP);
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89719299, 1, 90);
 		right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89712341, 89712514, 109, 282);
 		assertTrue(SplitReadContig.passesBreakpointFilter(left, right, QSVConstants.LEVEL_SINGLE_CLIP, 89700299, 89712341));
 		splitReadContig.setConfidenceLevel(QSVConstants.LEVEL_HIGH);
-		assertFalse(SplitReadContig.passesBreakpointFilter(left, right, QSVConstants.LEVEL_HIGH, 89700299, 89712341));		
-	}	
-	
+		assertFalse(SplitReadContig.passesBreakpointFilter(left, right, QSVConstants.LEVEL_HIGH, 89700299, 89712341));
+	}
+
 	@Test
 	public void testQueryStringPositionFilter() {
 		createStandardObject(1);
 		assertTrue(SplitReadContig.passesQueryPositionFilter(right, left, 282));
-		
+
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299, 1, 200);
 		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89712341, 89712514, 20, 232);
 		assertFalse(SplitReadContig.passesQueryPositionFilter(left, right, 282));
-		
+
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299, 1, 120);
 		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89712341, 89712514, 110, 232);
 		assertTrue(SplitReadContig.passesQueryPositionFilter(left, right, 282));
 	}
-	
+
 	@Test
 	public void testQueryLengthFilter() {
 		createStandardObject(1);
 		assertTrue(SplitReadContig.queryLengthFilter(right, left, 282));
-		
+
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299, 1, 10);
 		assertFalse(SplitReadContig.queryLengthFilter(left, right, 282));
-		
+
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299, 0, 290);
 		assertFalse(SplitReadContig.queryLengthFilter(left, right, 282));
-		
+
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299, 1, 90);
 		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89712341, 89712514, 1, 200);
 		assertFalse(SplitReadContig.queryLengthFilter(left, right, 282));
-		assertFalse(SplitReadContig.queryLengthFilter(right, left, 282));	
+		assertFalse(SplitReadContig.queryLengthFilter(right, left, 282));
 	}
-	
+
 	@Test
 	public void testPassesSizeFilter() {
 		createStandardObject(1);
@@ -448,32 +454,32 @@ public class SplitReadContigTest {
 		assertFalse(SplitReadContig.passesSizeFilter(new SplitReadAlignment("chr10", QSVUtil.PLUS, 2970200, 2970220, 1, 270), 282));
 		assertTrue(SplitReadContig.passesSizeFilter(new SplitReadAlignment("chr10", QSVUtil.PLUS, 2970200, 2970220, 1, 100), 282));
 	}
-	
+
 	@Test
 	public void testPassesBreakpointFilterSingleAlignment() {
 		createStandardObject(1);
 		splitReadContig.setConfidenceLevel(QSVConstants.LEVEL_MID);
 		assertTrue(SplitReadContig.passesBreakpointFilter(left, QSVConstants.LEVEL_MID, 89700299, 89712341));
 		assertTrue(SplitReadContig.passesBreakpointFilter(right, QSVConstants.LEVEL_MID, 89700299, 89712341));
-		
+
 		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 100, 200, 1, 200);
-		
+
 		assertFalse(SplitReadContig.passesBreakpointFilter(right, QSVConstants.LEVEL_MID, 89700299, 89712341));
 	}
-	
+
 	@Test
 	public void testCheckBlockSize() throws QSVException {
 		createStandardObject(1);
-		assertFalse(SplitReadContig.checkBlockSize(new BLATRecord.Builder("187\t5\t0\t0\t2\t61\t1\t17709\t-\tsplitcon_chr22_21353096_chr22_21566646_3_true\t253\t0\t253\tchr22\t51304566\t25002854\t25020755\t3\t17,10,165,\t0,22,88,\t25002854,25002871,25020590,\t").build()));
-		assertTrue(SplitReadContig.checkBlockSize(new BLATRecord.Builder("187\t5\t0\t0\t2\t61\t1\t17709\t-\tsplitcon_chr22_21353096_chr22_21566646_3_true\t253\t0\t253\tchr22\t51304566\t25002854\t25020755\t2\t270,165,\t22,88,\t25002854,25020590,\t").build()));
+		assertFalse(SplitReadContig.checkBlockSize(new BLATRecord.Builder("187\t5\t0\t0\t2\t61\t1\t17709\t-\tsplitcon_xxx_chr22_xxx_21353096_xxx_chr22_xxx_21566646_xxx_3_xxx_true\t253\t0\t253\tchr22\t51304566\t25002854\t25020755\t3\t17,10,165,\t0,22,88,\t25002854,25002871,25020590,\t").build()));
+		assertTrue(SplitReadContig.checkBlockSize(new BLATRecord.Builder("187\t5\t0\t0\t2\t61\t1\t17709\t-\tsplitcon_xxx_chr22_xxx_21353096_xxx_chr22_xxx_21566646_xxx_3_xxx_true\t253\t0\t253\tchr22\t51304566\t25002854\t25020755\t2\t270,165,\t22,88,\t25002854,25020590,\t").build()));
 	}
-	
+
 	@Test
 	public void testGetMatch() {
 		assertTrue(SplitReadContig.getMatch(100, 125));
 		assertFalse(SplitReadContig.getMatch(100, 155));
 	}
-	
+
 	@Test
 	public void testMatchingQueryString() {
 		createStandardObject(1);
@@ -482,7 +488,7 @@ public class SplitReadContigTest {
 		assertEquals(true, SplitReadContig.matchingQueryString(286, 1, 95, right, 282));
 		assertEquals(false, SplitReadContig.matchingQueryString(286, 20, 232, right, 282));
 	}
-	
+
 	private void createStandardObject(int num) {
 		p = createMock(QSVParameters.class);
 		expect(p.isTumor()).andReturn(false);
@@ -494,53 +500,76 @@ public class SplitReadContigTest {
 			expect(p.getRepeatCountCutoff()).andReturn(1000);
 			expect(p.getRepeatCountCutoff()).andReturn(1000);
 		}
-		
+
 		replay(p);
 		blat = createMock(BLAT.class);
 		replay(blat);
 		splitReadContig = new SplitReadContig(new TIntObjectHashMap<int[]>(), p, "chr10", "chr10", 89700299, 89712341, QSVConstants.ORIENTATION_1);
-		splitReadContig.setConsensus("CAGATAGGCAACAGATCGAGACCTTGTTTCACAAAACGAACAGATCTGCAAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAATGGTGACAAAGCAATGAAAAGGAAAGGAAGAAGTGATAAGACATGGCAGCAAGCTGAAGTATGATGAGTAAAGAATAGGAATCA");				
+		splitReadContig.setConsensus("CAGATAGGCAACAGATCGAGACCTTGTTTCACAAAACGAACAGATCTGCAAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAATGGTGACAAAGCAATGAAAAGGAAAGGAAGAAGTGATAAGACATGGCAGCAAGCTGAAGTATGATGAGTAAAGAATAGGAATCA");
 		left = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89700210, 89700299, 1, 90);
 		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 89712341, 89712514, 109, 282);
 		splitReadContig.setSplitReadAlignments(left, right);
 	}
 
+	private void createStandardObjectWithChrUn(int num) {
+		p = createMock(QSVParameters.class);
+		expect(p.isTumor()).andReturn(false);
+		expect(p.getPairingType()).andReturn("pe");
+		expect(p.getPairingType()).andReturn("pe");
+		if (num ==1) {
+			expect(p.getRepeatCountCutoff()).andReturn(1000);
+		} else {
+			expect(p.getRepeatCountCutoff()).andReturn(1000);
+			expect(p.getRepeatCountCutoff()).andReturn(1000);
+		}
+
+		replay(p);
+		blat = createMock(BLAT.class);
+		replay(blat);
+
+		splitReadContig = new SplitReadContig(new TIntObjectHashMap<int[]>(), p, "chrUn_KI270442v1", "chrUn_KI270442v1", 45730, 44617, QSVConstants.ORIENTATION_2);
+		splitReadContig.setConsensus("TCCCCTCCATTCGATGCCATTCAATTCCACCCGCTTCGATTCCACTTGATTCCATTGGATTCAGTTTTTTATGTTCGATTCCATTCGATTTCATTTGATTGCATATGATTCGATTTGATTCAATTTGATTCACTTCCATGTGATTCCATGTGATTCCATGCTATTCCATTACTTTCCATTCCACTCCA");
+		left = new SplitReadAlignment("chrUn_KI270442v1", QSVUtil.PLUS, 45730, 45735, 1, 5);
+		right = new SplitReadAlignment("chr10", QSVUtil.PLUS, 44617, 44627, 1, 10);
+		splitReadContig.setSplitReadAlignments(left, right);
+	}
+
 	@Test
 	public void testOrientation1() throws Exception {
-		records.add(new BLATRecord.Builder("263\t1\t0\t0\t1\t18\t1\t12041\t+\tsplitcon-chr10_89700299_chr10_89712341_1_true\t282\t0\t282\tchr10\t135534747\t89700209\t89712514\t2\t90,174,\t0,108,\t89700209,89712340,\t").build());
+		records.add(new BLATRecord.Builder("263\t1\t0\t0\t1\t18\t1\t12041\t+\tsplitcon_xxx_chr10_xxx_89700299_xxx_chr10_xxx_89712341_xxx_1_xxx_true\t282\t0\t282\tchr10\t135534747\t89700209\t89712514\t2\t90,174,\t0,108,\t89700209,89712340,\t").build());
 		createStandardObject(2);
-		testOrientationCategory("chr10", "chr10", 89700299, 89712341, QSVConstants.ORIENTATION_1, 
-			"CAGATAGGCAACAGATCGAGACCTTGTTTCACAAAACGAACAGATCTGCAAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAATGGTGACAAAGCAATGAAAAGGAAAGGAAGAAGTGATAAGACATGGCAGCAAGCTGAAGTATGATGAGTAAAGAATAGGAATCA");		
+		testOrientationCategory("chr10", "chr10", 89700299, 89712341, QSVConstants.ORIENTATION_1,
+			"CAGATAGGCAACAGATCGAGACCTTGTTTCACAAAACGAACAGATCTGCAAAGATCAACCTGTCCTAAGTCATATAATCTCTTTGTGTAAGAGATTATACTTTGTGTAAGAGGTCCACCAGAGGAGTTCAGCAATTTGCTGCTCTTAGGGCAGGGATCAATTCCTTAATATCTTAGGAAGACTAGGTATTGACAGTAATGGTGACAAAGCAATGAAAAGGAAAGGAAGAAGTGATAAGACATGGCAGCAAGCTGAAGTATGATGAGTAAAGAATAGGAATCA");
 		assertEquals("GAGATTATACTTTGTGTA", splitReadContig.getNonTemplateSequence());
 		assertEquals(QSVConstants.NOT_FOUND, splitReadContig.getMicrohomology());
 	}
-	
+
 	@Test
 	public void testOrientation2() throws Exception {
-		
-		createStandardObject(2);
-		records.add(new BLATRecord.Builder("103\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon-chr7_104612302_chr7_104485067_2_true\t255\t0\t103\tchr7\t159138663\t104612199\t104612302\t1\t103,\t0,\t104612199,\t").build());
-		records.add(new BLATRecord.Builder("154\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon-chr7_104612302_chr7_104485067_2_true\t255\t101\t255\tchr7\t159138663\t104485066\t104485220\t1\t154,\t101,\t104485066,\t").build());
 
-		testOrientationCategory("chr7", "chr7", 104485067, 104612302, QSVConstants.ORIENTATION_2, 
-			"ACTGGTCTGTTCAAATAGTGTGTAATTCAAAGCAATTGCTGCTCCCTAGGCAGGAATTTACAATTGCTACATGTGAAGGGAGGATAATGTGTCATTCCAAGGGTATTGCCTGAGGAAACCAAAGATAAAATAAAAACAACAATGATGTCTAACTCTTAGATAATGCTTGGTATTGACTAGGAATATTCTTTCCTTGTAGAATAATAGAGATATTCTAAGTATTTCTTTTCTTTCTTTTTTGAGACGCAATTTTGC");		
-		
+		createStandardObject(2);
+		records.add(new BLATRecord.Builder("103\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon_xxx_chr7_xxx_104612302_xxx_chr7_xxx_104485067_xxx_2_xxx_true\t255\t0\t103\tchr7\t159138663\t104612199\t104612302\t1\t103,\t0,\t104612199,\t").build());
+		records.add(new BLATRecord.Builder("154\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon_xxx_chr7_xxx_104612302_xxx_chr7_xxx_104485067_xxx_2_xxx_true\t255\t101\t255\tchr7\t159138663\t104485066\t104485220\t1\t154,\t101,\t104485066,\t").build());
+
+		testOrientationCategory("chr7", "chr7", 104485067, 104612302, QSVConstants.ORIENTATION_2,
+			"ACTGGTCTGTTCAAATAGTGTGTAATTCAAAGCAATTGCTGCTCCCTAGGCAGGAATTTACAATTGCTACATGTGAAGGGAGGATAATGTGTCATTCCAAGGGTATTGCCTGAGGAAACCAAAGATAAAATAAAAACAACAATGATGTCTAACTCTTAGATAATGCTTGGTATTGACTAGGAATATTCTTTCCTTGTAGAATAATAGAGATATTCTAAGTATTTCTTTTCTTTCTTTTTTGAGACGCAATTTTGC");
+
 		assertEquals(QSVConstants.NOT_FOUND, splitReadContig.getNonTemplateSequence());
 		assertEquals("GG", splitReadContig.getMicrohomology());
 	}
-	
+
 	@Test
 	public void testOrientation3() throws Exception {
 		createStandardObject(2);
-		records.add(new BLATRecord.Builder("78\t8\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr15_23831661_chr15_23992703_3_false\t230\t144\t230\tchr15\t102531392\t24563867\t24563953\t1\t86,\t0,\t24563867,\t").build());
-		records.add(new BLATRecord.Builder("80\t6\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr15_23831661_chr15_23992703_3_false\t230\t144\t230\tchr15\t102531392\t24928398\t24928484\t1\t86,\t0,\t24928398,\t").build());
-		records.add(new BLATRecord.Builder("80\t6\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr15_23831661_chr15_23992703_3_false\t230\t144\t230\tchr15\t102531392\t24771250\t24771336\t1\t86,\t0,\t24771250,\t").build());
-		records.add(new BLATRecord.Builder("86\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr15_23831661_chr15_23992703_3_false\t230\t144\t230\tchr15\t102531392\t23831575\t23831661\t1\t86,\t0,\t23831575,\t").build());
-		records.add(new BLATRecord.Builder("225\t5\t0\t0\t0\t0\t2\t405222\t+\tsplitcon-chr15_23831661_chr15_23992703_3_false\t230\t0\t230\tchr15\t102531392\t23992556\t24398008\t3\t147,4,79,\t0,147,151,\t23992556,23993156,24397929,\t").build());
-	
-		testOrientationCategory("chr15", "chr15", 
-				23831661,23992703, QSVConstants.ORIENTATION_3, 
-			"TTTTCCCCACATCCTTGCCAGTATTCATTATCGCCTGTCTATTTGAACACAAAGCCATTTTACCTGGGGTAAGATGATATTTCATTGTGATTTTGCTTTGCATTTCTTTCATGATTAGTGATGATGAACATTTTTAAATAACTGTTGCCACGAGAGTACACAGAGCAAAGGAGACAGGGTCATTTATACCCTGATGCGTCCACCCCACTGCTGTGTCCGGTTTCCATTGG");		
+		records.add(new BLATRecord.Builder("78\t8\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr15_xxx_23831661_xxx_chr15_xxx_23992703_xxx_3_xxx_false\t230\t144\t230\tchr15\t102531392\t24563867\t24563953\t1\t86,\t0,\t24563867,\t").build());
+		records.add(new BLATRecord.Builder("80\t6\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr15_xxx_23831661_xxx_chr15_xxx_23992703_xxx_3_xxx_false\t230\t144\t230\tchr15\t102531392\t24928398\t24928484\t1\t86,\t0,\t24928398,\t").build());
+		records.add(new BLATRecord.Builder("80\t6\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr15_xxx_23831661_xxx_chr15_xxx_23992703_xxx_3_xxx_false\t230\t144\t230\tchr15\t102531392\t24771250\t24771336\t1\t86,\t0,\t24771250,\t").build());
+		records.add(new BLATRecord.Builder("86\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr15_xxx_23831661_xxx_chr15_xxx_23992703_xxx_3_xxx_false\t230\t144\t230\tchr15\t102531392\t23831575\t23831661\t1\t86,\t0,\t23831575,\t").build());
+		records.add(new BLATRecord.Builder("225\t5\t0\t0\t0\t0\t2\t405222\t+\tsplitcon_xxx_chr15_xxx_23831661_chr15_23992703_xxx_3_false\t230\t0\t230\tchr15\t102531392\t23992556\t24398008\t3\t147,4,79,\t0,147,151,\t23992556,23993156,24397929,\t").build());
+
+		testOrientationCategory("chr15", "chr15",
+				23831661,23992703, QSVConstants.ORIENTATION_3,
+			"TTTTCCCCACATCCTTGCCAGTATTCATTATCGCCTGTCTATTTGAACACAAAGCCATTTTACCTGGGGTAAGATGATATTTCATTGTGATTTTGCTTTGCATTTCTTTCATGATTAGTGATGATGAACATTTTTAAATAACTGTTGCCACGAGAGTACACAGAGCAAAGGAGACAGGGTCATTTATACCCTGATGCGTCCACCCCACTGCTGTGTCCGGTTTCCATTGG");
 		assertEquals(QSVConstants.NOT_FOUND, splitReadContig.getNonTemplateSequence());
 		assertEquals("CAA", splitReadContig.getMicrohomology());
 	}
@@ -548,56 +577,56 @@ public class SplitReadContigTest {
 	@Test
 	public void testOrientation4() throws Exception {
 		createStandardObject(2);
-		records.add(new BLATRecord.Builder("90\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr3_24565106_chr3_24566179_3_true\t266\t0\t90\tchr3\t198022430\t24565105\t24565195\t1\t90,\t176,\t24565105,\t").build());
-		records.add(new BLATRecord.Builder("178\t1\t0\t0\t0\t0\t0\t0\t+\tsplitcon-chr3_24565106_chr3_24566179_3_true\t266\t87\t266\tchr3\t198022430\t24566178\t24566357\t1\t179,\t87,\t24566178,\t").build());
-	
-		testOrientationCategory("chr3", "chr3", 24565106,24566179, QSVConstants.ORIENTATION_4, 
-			"TTCATAACCAACAATATGTAGGAAGCCATTATCTGAAGTGTAAGCAACTGCATAGTGCTATTTTAATTATGCATTGCAGGGAAACTGTGAGCAGAGCTATATATTTAGGTAGACTGCTCTCAGGCAGAATGAAACACGATGGCACCTGCCACTCACGACCAGGAACCAAACAGGAAAGAATCCAAATTCTGTGTTTACAGGGCTTTCATGCTCAGTAAAATGCATAAGCACTTTTATTAGGGTTCTTAAAATTAGAAATCTATACT");		
+		records.add(new BLATRecord.Builder("90\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr3_xxx_24565106_xxx_chr3_xxx_24566179_xxx_3_xxx_true\t266\t0\t90\tchr3\t198022430\t24565105\t24565195\t1\t90,\t176,\t24565105,\t").build());
+		records.add(new BLATRecord.Builder("178\t1\t0\t0\t0\t0\t0\t0\t+\tsplitcon_xxx_chr3_xxx_24565106_xxx_chr3_xxx_24566179_xxx_3_xxx_true\t266\t87\t266\tchr3\t198022430\t24566178\t24566357\t1\t179,\t87,\t24566178,\t").build());
+
+		testOrientationCategory("chr3", "chr3", 24565106,24566179, QSVConstants.ORIENTATION_4,
+			"TTCATAACCAACAATATGTAGGAAGCCATTATCTGAAGTGTAAGCAACTGCATAGTGCTATTTTAATTATGCATTGCAGGGAAACTGTGAGCAGAGCTATATATTTAGGTAGACTGCTCTCAGGCAGAATGAAACACGATGGCACCTGCCACTCACGACCAGGAACCAAACAGGAAAGAATCCAAATTCTGTGTTTACAGGGCTTTCATGCTCAGTAAAATGCATAAGCACTTTTATTAGGGTTCTTAAAATTAGAAATCTATACT");
 		assertEquals(QSVConstants.NOT_FOUND, splitReadContig.getNonTemplateSequence());
 		assertEquals("TGA", splitReadContig.getMicrohomology());
 	}
-	
+
 	@Test
 	public void testTranslocationOrientation1() throws Exception {
-		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon-chr10_13231026_chr17_12656098_1_true\t204\t0\t100\tchr10\t135534747\t13230926\t13231026\t1\t100,\t0,\t13230926,\t").build());
-		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon-chr10_13231026_chr17_12656098_1_true\t204\t104\t204\tchr17\t81195210\t12656099\t12656199\t1\t100,\t104,\t12656099,\t").build());
+		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon_xxx_chr10_xxx_13231026_xxx_chr17_xxx_12656098_xxx_1_xxx_true\t204\t0\t100\tchr10\t135534747\t13230926\t13231026\t1\t100,\t0,\t13230926,\t").build());
+		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon_xxx_chr10_xxx_13231026_xxx_chr17_xxx_12656098_xxx_1_xxx_true\t204\t104\t204\tchr17\t81195210\t12656099\t12656199\t1\t100,\t104,\t12656099,\t").build());
 		createStandardObject(2);
-		testOrientationCategory("chr10", "chr17", 13231026, 12656098, QSVConstants.ORIENTATION_1, 
-			"AGCTCAGCGCAAAGCGTGCGGATCTGCAGTCCACCTTCTCTGGAGGACGAATTCCAAAGAAGTTTGCCCGCAGAGGCACCAGCCTCAAAGAACGGCTGTGTTTTAGCAGCCTGAATGGGGGCTCTGTTCCTTCTGAGCTGGATGGGCTGGACTCCGAGAAGGACAAGATGCTGGTGGAGAAGCAGAAGGTGATCAATGAACTCA");		
+		testOrientationCategory("chr10", "chr17", 13231026, 12656098, QSVConstants.ORIENTATION_1,
+			"AGCTCAGCGCAAAGCGTGCGGATCTGCAGTCCACCTTCTCTGGAGGACGAATTCCAAAGAAGTTTGCCCGCAGAGGCACCAGCCTCAAAGAACGGCTGTGTTTTAGCAGCCTGAATGGGGGCTCTGTTCCTTCTGAGCTGGATGGGCTGGACTCCGAGAAGGACAAGATGCTGGTGGAGAAGCAGAAGGTGATCAATGAACTCA");
 	}
-	
+
 	@Test
 	public void testTranslocationOrientation2() throws Exception {
 		createStandardObject(2);
-		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr17_12656199_chr10_13230926_2_true\t204\t0\t100\tchr10\t135534747\t13230926\t13231026\t1\t100,\t104,\t13230926,\t").build());
-		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr17_12656199_chr10_13230926_2_true\t204\t104\t204\tchr17\t81195210\t12656099\t12656199\t1\t100,\t0,\t12656099,\t").build());
-		
-		testOrientationCategory("chr10", "chr17", 13230926, 12656199, QSVConstants.ORIENTATION_2, 
-			"CACAGCCGTTCTTTGAGGCTGGTGCCTCTGCGGGCAAACTTCTTTGGAATTCGTCCTCCAGAGAAGGTGGACTGCAGATCCGCACGCTTTGCGCTGAGCTAAAATGAGTTCATTGATCACCTTCTGCTTCTCCACCAGCATCTTGTCCTTCTCGGAGTCCAGCCCATCCAGCTCAGAAGGAACAGAGCCCCCATTCAGGCTGCT");		
-	
+		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr17_xxx_12656199_xxx_chr10_xxx_13230926_xxx_2_xxx_true\t204\t0\t100\tchr10\t135534747\t13230926\t13231026\t1\t100,\t104,\t13230926,\t").build());
+		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr17_xxx_12656199_xxx_chr10_xxx_13230926_xxx_2_xxx_true\t204\t104\t204\tchr17\t81195210\t12656099\t12656199\t1\t100,\t0,\t12656099,\t").build());
+
+		testOrientationCategory("chr10", "chr17", 13230926, 12656199, QSVConstants.ORIENTATION_2,
+			"CACAGCCGTTCTTTGAGGCTGGTGCCTCTGCGGGCAAACTTCTTTGGAATTCGTCCTCCAGAGAAGGTGGACTGCAGATCCGCACGCTTTGCGCTGAGCTAAAATGAGTTCATTGATCACCTTCTGCTTCTCCACCAGCATCTTGTCCTTCTCGGAGTCCAGCCCATCCAGCTCAGAAGGAACAGAGCCCCCATTCAGGCTGCT");
+
 	}
-	
+
 	@Test
 	public void testTranslocationOrientation3() throws Exception {
 		createStandardObject(2);
-		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon-chr10_13231026_chr17_12656200_3_true\t204\t0\t100\tchr17\t81195210\t12656099\t12656199\t1\t100,\t0,\t12656099,\t").build());
-		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr10_13231026_chr17_12656200_3_true\t204\t104\t204\tchr10\t135534747\t13230926\t13231026\t1\t100,\t0,\t13230926,\t").build());
-	
-		testOrientationCategory("chr10", "chr17", 13231026, 12656200, QSVConstants.ORIENTATION_3, 
-			"AGCAGCCTGAATGGGGGCTCTGTTCCTTCTGAGCTGGATGGGCTGGACTCCGAGAAGGACAAGATGCTGGTGGAGAAGCAGAAGGTGATCAATGAACTCAAAAACACAGCCGTTCTTTGAGGCTGGTGCCTCTGCGGGCAAACTTCTTTGGAATTCGTCCTCCAGAGAAGGTGGACTGCAGATCCGCACGCTTTGCGCTGAGCT");		
+		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon_xxx_chr10_xxx_13231026_xxx_chr17_xxx_12656200_xxx_3_xxx_true\t204\t0\t100\tchr17\t81195210\t12656099\t12656199\t1\t100,\t0,\t12656099,\t").build());
+		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr10_xxx_13231026_xxx_chr17_xxx_12656200_xxx_3_xxx_true\t204\t104\t204\tchr10\t135534747\t13230926\t13231026\t1\t100,\t0,\t13230926,\t").build());
+
+		testOrientationCategory("chr10", "chr17", 13231026, 12656200, QSVConstants.ORIENTATION_3,
+			"AGCAGCCTGAATGGGGGCTCTGTTCCTTCTGAGCTGGATGGGCTGGACTCCGAGAAGGACAAGATGCTGGTGGAGAAGCAGAAGGTGATCAATGAACTCAAAAACACAGCCGTTCTTTGAGGCTGGTGCCTCTGCGGGCAAACTTCTTTGGAATTCGTCCTCCAGAGAAGGTGGACTGCAGATCCGCACGCTTTGCGCTGAGCT");
 	}
-	
+
 	@Test
 	public void testTranslocationOrientation4() throws Exception {
 		createStandardObject(2);
-		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon-chr10_13230927_chr17_12656100_4_false\t204\t0\t100\tchr17\t81195210\t12656099\t12656199\t1\t100,\t104,\t12656099,\t").build());
-		records.add(new BLATRecord.Builder("101\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon-chr10_13230927_chr17_12656100_4_false\t204\t103\t204\tchr10\t135534747\t13230925\t13231026\t1\t101,\t103,\t13230925,\t").build());
-		testOrientationCategory("chr10", "chr17", 13230927, 12656100, QSVConstants.ORIENTATION_4, 
-			"TGAGTTCATTGATCACCTTCTGCTTCTCCACCAGCATCTTGTCCTTCTCGGAGTCCAGCCCATCCAGCTCAGAAGGAACAGAGCCCCCATTCAGGCTGCTAAAAAGCTCAGCGCAAAGCGTGCGGATCTGCAGTCCACCTTCTCTGGAGGACGAATTCCAAAGAAGTTTGCCCGCAGAGGCACCAGCCTCAAAGAACGGCTGTG");		
+		records.add(new BLATRecord.Builder("100\t0\t0\t0\t0\t0\t0\t0\t-\tsplitcon_xxx_chr10_xxx_13230927_xxx_chr17_xxx_12656100_xxx_4_xxx_false\t204\t0\t100\tchr17\t81195210\t12656099\t12656199\t1\t100,\t104,\t12656099,\t").build());
+		records.add(new BLATRecord.Builder("101\t0\t0\t0\t0\t0\t0\t0\t+\tsplitcon_xxx_chr10_xxx_13230927_xxx_chr17_xxx_12656100_xxx_4_xxx_false\t204\t103\t204\tchr10\t135534747\t13230925\t13231026\t1\t101,\t103,\t13230925,\t").build());
+		testOrientationCategory("chr10", "chr17", 13230927, 12656100, QSVConstants.ORIENTATION_4,
+			"TGAGTTCATTGATCACCTTCTGCTTCTCCACCAGCATCTTGTCCTTCTCGGAGTCCAGCCCATCCAGCTCAGAAGGAACAGAGCCCCCATTCAGGCTGCTAAAAAGCTCAGCGCAAAGCGTGCGGATCTGCAGTCCACCTTCTCTGGAGGACGAATTCCAAAGAAGTTTGCCCGCAGAGGCACCAGCCTCAAAGAACGGCTGTG");
 	}
-	private void testOrientationCategory(String leftReference, String rightReference, 
+	private void testOrientationCategory(String leftReference, String rightReference,
 			int leftBreakpoint, int rightBreakpoint, String orientation, String consensus) throws Exception {
-		splitReadContig = new SplitReadContig(new TIntObjectHashMap<int[]>(), p, leftReference, rightReference, leftBreakpoint, 
+		splitReadContig = new SplitReadContig(new TIntObjectHashMap<int[]>(), p, leftReference, rightReference, leftBreakpoint,
 				rightBreakpoint, orientation);
 		splitReadContig.setConsensus(consensus);
 		splitReadContig.setConfidenceLevel(QSVConstants.LEVEL_HIGH);
@@ -605,6 +634,6 @@ public class SplitReadContigTest {
 		assertTrue(splitReadContig.getIsPotentialSplitRead());
 		assertEquals(splitReadContig.getOrientationCategory(), orientation);
 	}
-	
+
 
 }


### PR DESCRIPTION
Fix to deal with underscore in chromosome names in GRCh38 and to improve breakpoint merging

# Description

Temporary files were created with underscore as seperator in file name but GRCh38 has chromosome names with underscore in them, resulting in exceptions when running qsv. Fixed to use a different separator in file names. Also identified some issues with merging of clip breakpoints and fixed these. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added or updated new unit tests

# Are WDL Updates Required?

Will need to do new adamajava release create wdlwf/wdl tags. Update sv.wdl and somaticDnaFastqToMaf.wdl

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
