### PR TITLE
perf(qmule:fastqtosamwithheaders): minor performance inmprovements

### DIFF
--- a/qmule/test/org/qcmg/qmule/FastqToSamWithHeadersTest.java
+++ b/qmule/test/org/qcmg/qmule/FastqToSamWithHeadersTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static htsjdk.samtools.SAMUtils.MAX_PHRED_SCORE;
+import static htsjdk.samtools.util.SequenceUtil.getSamReadNameFromFastqHeader;
 import static org.junit.Assert.*;
 
 public class FastqToSamWithHeadersTest {
@@ -116,6 +117,19 @@ public class FastqToSamWithHeadersTest {
         assertEquals("/aa", fastqToSam.getBaseName("/aa", "/aa" , freader1, freader2));
         assertEquals("aa/", fastqToSam.getBaseName("aa/", "aa/" , freader1, freader2));
         assertEquals("ab/c", fastqToSam.getBaseName("ab/c", "ab/c", freader1, freader2));
+        assertEquals("@ST-E00104:647:HFNMWALXX:4:1101:12357:1063", fastqToSam.getBaseName(getSamReadNameFromFastqHeader("@ST-E00104:647:HFNMWALXX:4:1101:12357:1063 1:N:0:NGGCTATG TB:n+#"), getSamReadNameFromFastqHeader("@ST-E00104:647:HFNMWALXX:4:1101:12357:1063 2:N:0:NGGCTATG TB:nAGA+#--A"), freader1, freader2));
+        assertEquals("@H3CK2CCXY:2:2222:2121145:0", fastqToSam.getBaseName("@H3CK2CCXY:2:2222:2121145:0", "@H3CK2CCXY:2:2222:2121145:0", freader1, freader2));
+    }
+
+    @Test
+    public void getSamReadFromFastqHeader() {
+        assertEquals("@ST-E00104:647:HFNMWALXX:4:1101:12357:1063", getSamReadNameFromFastqHeader("@ST-E00104:647:HFNMWALXX:4:1101:12357:1063 1:N:0:NGGCTATG TB:n+#"));
+        assertEquals("@H3CK2CCXY:2:2222:2121145:0", getSamReadNameFromFastqHeader("@H3CK2CCXY:2:2222:2121145:0"));
+        assertEquals("@V350038332L1C001R00400000275", getSamReadNameFromFastqHeader("@V350038332L1C001R00400000275/1"));
+        assertEquals("@V350038332L1C001R00400000275", getSamReadNameFromFastqHeader("@V350038332L1C001R00400000275/2"));
+        assertEquals("@V350038332L1C001R00400000275/3", getSamReadNameFromFastqHeader("@V350038332L1C001R00400000275/3"));
+        assertEquals("@V350038332L1C001R00400000275/3", getSamReadNameFromFastqHeader("@V350038332L1C001R00400000275/3/2/1"));
+        assertEquals("@V350038332L1C001R00400000275", getSamReadNameFromFastqHeader("@V350038332L1C001R00400000275/2/1"));
     }
 
     @Test
@@ -141,11 +155,11 @@ public class FastqToSamWithHeadersTest {
             Assert.fail("Should have thrown an exception");
         } catch (PicardException ignored) {}
         try {
-            fastqToSam.getBaseName("aa/1", "aa/1" , freader1, freader2);
+            fastqToSam.getBaseName("aa/4", "aa/5" , freader1, freader2);
             Assert.fail("Should have thrown an exception");
         } catch (PicardException ignored) {}
         try {
-            fastqToSam.getBaseName("aa/2", "aa/2" , freader1, freader2);
+            fastqToSam.getBaseName("aa/2", "aa/1" , freader1, freader2);
             Assert.fail("Should have thrown an exception");
         } catch (PicardException ignored) {}
     }


### PR DESCRIPTION
# Description

Remove unnecessary check on quality (if in standard mode), adjust getBaseName method as the inputs that are passed to it have had the pertinent parts (/1, /2) removed

Fixes # (issue)

## Type of change

Performance

# How Has This Been Tested?

Additional unit tests, and has been run against real life fastqs

# Are WDL Updates Required?

No, although this change will most benefit the FTUB_WGGSS workflow.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
