### PR TITLE
fix(qsv): fixing issue where references didn't match

### DIFF
--- a/qsv/test/org/qcmg/qsv/splitread/SplitReadContigTest.java
+++ b/qsv/test/org/qcmg/qsv/splitread/SplitReadContigTest.java
@@ -234,6 +234,41 @@ public class SplitReadContigTest {
 	}
 
 	@Test
+	public void testknownAndPotentialReferencesMatch() {
+		StructuralVariant knownSV = new StructuralVariant("chr10", "chr10", 89700299, 89712341, "1");
+		SplitReadAlignment left = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		SplitReadAlignment right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		assertTrue(SplitReadContig.knownAndPotentialReferencesMatch(knownSV, left, right));
+
+		knownSV = new StructuralVariant("chr10", "chr10", 89700299, 89712341, "1");
+		left = new SplitReadAlignment("chr12", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		assertFalse(SplitReadContig.knownAndPotentialReferencesMatch(knownSV, left, right));
+
+		knownSV = new StructuralVariant("chr10", "chr10", 89700299, 89712341, "1");
+		left = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		right = new SplitReadAlignment("chr12", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		assertFalse(SplitReadContig.knownAndPotentialReferencesMatch(knownSV, left, right));
+
+		knownSV = new StructuralVariant("chr10", "chr12", 89700299, 89712341, "1");
+		left = new SplitReadAlignment("chr12", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		assertTrue(SplitReadContig.knownAndPotentialReferencesMatch(knownSV, left, right));
+
+		knownSV = new StructuralVariant("chr10", "chr12", 89700299, 89712341, "1");
+		left = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		right = new SplitReadAlignment("chr12", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		assertTrue(SplitReadContig.knownAndPotentialReferencesMatch(knownSV, left, right));
+
+		knownSV = new StructuralVariant("chr10", "chr12", 89700299, 89712341, "1");
+		left = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		right = new SplitReadAlignment("chr10", QSVUtil.MINUS, 89700210, 89700299, 109, 282);
+		assertFalse(SplitReadContig.knownAndPotentialReferencesMatch(knownSV, left, right));
+
+
+	}
+
+	@Test
 	public void setSplitReadAlignments2() {
 		/*
 		 * consensus: CGTGGGGGTGGGATCCACTGAGCTAGAACACTTGGCTCCCTGGCTTTGGCCCCCTTTCCAGGGGAGTGAACAGTTCTGTCTTGCTGGTGTTCCAGGCGCCACTGGGGTATGAAAAATATTCCTGCAGCTAGCTCAGTGTCTTCTTGGCAATGTGGGCACTTTTTTGGTTCCATATGAATTTTAAAGTAGTTTTTTCCAATTCTGTGAAGAAA


### PR DESCRIPTION
For a SplitReadContig, there was a case where the SV was a translocation but a reference check was not performed resulting in the incorrect breakpoint associated with the incorrect reference. Added a reference check

# Description

In SplitReadContig, a reference (chromosome) check of the knownSV reference compared with the the proposed split read SV references was added. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit test. Tested qSV with the sample that was failing and also another sample that has been used for testing in the past to make sure the new code didn't have any unintended changes. 

# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
