### PR TITLE
Qcoverage fix

### DIFF
--- a/qcoverage/src/org/qcmg/coverage/Coverage.java
+++ b/qcoverage/src/org/qcmg/coverage/Coverage.java
@@ -205,10 +205,9 @@ public final class Coverage {
 
 			String outfile = options.getOutputFileNames()[0];
 			//rename .bed extension if present to add the mnin coverage value
-			if (outfile.endsWith(".bed")) {
-				outfile = outfile.substring(0, outfile.length() - 4);
+			if (!outfile.endsWith(".bed")) {
+				outfile = outfile + ".bed";
 			}
-			outfile = String.format("%s.low_read_depth.%s.bed", outfile, options.getLowReadDepthCutoff());
 
 			final HashMap<String, List<LowReadDepthRegion>> lowReadDepthResultsFinalMap = jobQueue.getLowReadDepthResultsFinalMap();
 			LinkedHashSet<String> refNamesOrdered = jobQueue.getRefNamesOrdered();

--- a/qcoverage/src/org/qcmg/coverage/Coverage.java
+++ b/qcoverage/src/org/qcmg/coverage/Coverage.java
@@ -204,7 +204,6 @@ public final class Coverage {
 		if (coverageType.equals(CoverageType.LOW_READDEPTH)) {
 
 			String outfile = options.getOutputFileNames()[0];
-			//rename .bed extension if present to add the mnin coverage value
 			if (!outfile.endsWith(".bed")) {
 				outfile = outfile + ".bed";
 			}

--- a/qcoverage/test/org/qcmg/coverage/CoverageTest.java
+++ b/qcoverage/test/org/qcmg/coverage/CoverageTest.java
@@ -34,7 +34,7 @@ public class CoverageTest {
 	 public TemporaryFolder testFolder = new TemporaryFolder();
 	
 	
-	@Before
+	 @Before
 	 public void setup() throws IOException {
 		 inputBam = testFolder.newFile("coverage.bam").getAbsolutePath();
 		 inputBai = inputBam.replace("bam", "bai");
@@ -59,8 +59,8 @@ public class CoverageTest {
 		fname = testFolder.getRoot().getAbsolutePath()+"/output.txt";
 		bedname = testFolder.getRoot().getAbsolutePath()+"/output.bed";
 
-	 } 
-	
+	 }
+
 	@Test
 	public final void defaultTest() throws Exception {
 		
@@ -105,17 +105,25 @@ public class CoverageTest {
 	    Executor exec = execute(cmd);
 	    assertEquals(0, exec.getErrCode());
 	    File fBedOutput = new File(bedname);
-	    assertFalse(fBedOutput.exists());
-
-	   //filename should have file endings .low_read_depth.[readdepth-cutoff value].bed
-		File outputBed = new File(bedname.replace(".bed",".low_read_depth.8.bed"));
-		assertTrue(outputBed.exists());
-
-		//filename should have file endings .low_read_depth.[readdepth-cutoff value].bed
-		outputBed = new File(bedname.replace(".bed",".low_read_depth.12.bed"));
-		assertFalse(outputBed.exists());
-
+	    assertTrue(fBedOutput.exists());
    }
+
+	@Test
+	public final void testLowReadDepthOptionNoBedExtension() throws Exception {
+		String bed = bedname.replace(".bed","");
+		String cmd = "--log " + log + " --type low_readdepth --input-gff3 " + inputGff3 + " --input-bam " + inputBam +
+				" --input-bai " + inputBai +  " --output " + bed + " --output-format bed --readdepth-cutoff 8";
+
+		//default value txt output only
+		Executor exec = execute(cmd);
+		assertEquals(0, exec.getErrCode());
+		File fBedOutput = new File(bed);
+		assertFalse(fBedOutput.exists());
+
+		fBedOutput = new File(bedname);
+		assertTrue(fBedOutput.exists());
+	}
+
 
 	@Test
 	public final void testLowReadDepthOptionMissingCutoffOption() throws Exception {

--- a/qcoverage/test/org/qcmg/coverage/LowReadDepthTest.java
+++ b/qcoverage/test/org/qcmg/coverage/LowReadDepthTest.java
@@ -66,8 +66,8 @@ public class LowReadDepthTest {
 
     @Test
     public void lowReadDepthMinEight() throws Exception {
-        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
-        File fOutput = new File(fname + ".low_read_depth.8.bed");
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output.bed";
+        File fOutput = new File(fname);
         String cmd = "--log ./logfile --type low_readdepth --input-gff3 " + gff1000To1065 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname + " --readdepth-cutoff 8";
 
         Executor exec = execute(cmd);
@@ -91,8 +91,8 @@ public class LowReadDepthTest {
 
     @Test
     public void lowReadDepthMinTwelve() throws Exception {
-        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
-        File fOutput = new File(fname + ".low_read_depth.12.bed");
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output.bed";
+        File fOutput = new File(fname);
         String cmd = "--log ./logfile --type low_readdepth --input-gff3 " + gff1000To1065 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname + " --readdepth-cutoff 12";
 
         Executor exec = execute(cmd);

--- a/qcoverage/test/org/qcmg/coverage/QueryLowReadDepthTest.java
+++ b/qcoverage/test/org/qcmg/coverage/QueryLowReadDepthTest.java
@@ -66,8 +66,8 @@ public class QueryLowReadDepthTest {
 
     @Test
     public void lowReadDepthMinTwelveQuery() throws Exception {
-        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
-        File fOutput = new File(fname + ".low_read_depth.12.bed");
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output.bed";
+        File fOutput = new File(fname);
         String cmd = "--log ./logfile --type low_readdepth --input-gff3 " + gff1000To1065 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname + " --readdepth-cutoff 12 --query and(flag_DuplicateRead==false,flag_NotprimaryAlignment==false,MAPQ>10)";
 
         Executor exec = execute(cmd);
@@ -89,8 +89,8 @@ public class QueryLowReadDepthTest {
 
     @Test
     public void lowReadDepthMinEightQuery() throws Exception {
-        String fname = testFolder.getRoot().getAbsolutePath() + "/output";
-        File fOutput = new File(fname + ".low_read_depth.8.bed");
+        String fname = testFolder.getRoot().getAbsolutePath() + "/output.bed";
+        File fOutput = new File(fname);
         String cmd = "--log ./logfile --type low_readdepth --input-gff3 " + gff1000To1065 + " --input-bam " + bam + " --input-bai " + bai + " --output " + fname + " --readdepth-cutoff 8 --query and(flag_DuplicateRead==false,flag_NotprimaryAlignment==false,MAPQ>10)";
 
         Executor exec = execute(cmd);


### PR DESCRIPTION
# Description

Low read depth output file was changed so that it matches the supplied name in in outputFileNames option. Updated junit tests

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran Junit tests and ran on a test BAM file. 

# Are WDL Updates Required?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes