### PR TITLE
fix(nanno): deal with contig names that include numbers and letters

### DIFF
--- a/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
+++ b/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
@@ -64,10 +64,13 @@ public class ChrPositionUtils {
         if (null == contigName || contigName.isEmpty()) {
             throw new IllegalArgumentException("null or empty contig name supplied to convertContigNameToInt");
         }
-        int i = Character.isDigit(contigName.charAt(0)) ? Integer.parseInt(contigName) : -1;
-        if (i > -1) {
-            return i;
+        // check if the contig name is a number
+        // if so, return it as an int
+        // otherwise, convert it to a hash code
+        if (isDigits(contigName)) {
+            return Integer.parseInt(contigName);
         }
+
 
         if (contigName.length() > 3 && contigName.startsWith("chr")) {
             return convertContigNameToInt(contigName.substring(3));
@@ -79,6 +82,15 @@ public class ChrPositionUtils {
             case "M", "MT" -> 25;
             default -> contigName.hashCode();
         };
+    }
+
+    public static boolean isDigits(String str) {
+        if (str == null || str.isEmpty()) return false;
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (c < '0' || c > '9') return false;
+        }
+        return true;
     }
 
     /**

--- a/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
+++ b/qcommon/src/org/qcmg/common/util/ChrPositionUtils.java
@@ -86,7 +86,7 @@ public class ChrPositionUtils {
 
     public static boolean isDigits(String str) {
         if (str == null || str.isEmpty()) return false;
-        for (int i = 0; i < str.length(); i++) {
+        for (int i = 0, len = str.length(); i < len; i++) {
             char c = str.charAt(i);
             if (c < '0' || c > '9') return false;
         }

--- a/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
+++ b/qcommon/test/org/qcmg/common/util/ChrPositionUtilsTest.java
@@ -36,6 +36,61 @@ public class ChrPositionUtilsTest {
 	}
 
 	@Test
+	public void testConvertContigNameToInt_NumericContig() {
+		assertEquals(1, ChrPositionUtils.convertContigNameToInt("1"));
+		assertEquals(22, ChrPositionUtils.convertContigNameToInt("22"));
+	}
+
+	@Test
+	public void testConvertContigNameToInt_ChromosomeWithChrPrefix() {
+		assertEquals(1, ChrPositionUtils.convertContigNameToInt("chr1"));
+		assertEquals(22, ChrPositionUtils.convertContigNameToInt("chr22"));
+	}
+
+	@Test
+	public void testConvertContigNameToInt_SexChromosomes() {
+		assertEquals(23, ChrPositionUtils.convertContigNameToInt("X"));
+		assertEquals(24, ChrPositionUtils.convertContigNameToInt("Y"));
+	}
+
+	@Test
+	public void testConvertContigNameToInt_Mitochondrial() {
+		assertEquals(25, ChrPositionUtils.convertContigNameToInt("M"));
+		assertEquals(25, ChrPositionUtils.convertContigNameToInt("MT"));
+	}
+
+	@Test
+	public void testConvertContigNameToInt_ChromosomeWithChrPrefixSpecialCases() {
+		assertEquals(23, ChrPositionUtils.convertContigNameToInt("chrX"));
+		assertEquals(24, ChrPositionUtils.convertContigNameToInt("chrY"));
+		assertEquals(25, ChrPositionUtils.convertContigNameToInt("chrM"));
+	}
+
+	@Test
+	public void testConvertContigNameToInt_AltChromosome() {
+		assertEquals("22_KI270739v1_random".hashCode(), ChrPositionUtils.convertContigNameToInt("chr22_KI270739v1_random"));
+		assertEquals("Y_KI270740v1_random".hashCode(), ChrPositionUtils.convertContigNameToInt("chrY_KI270740v1_random"));
+		assertEquals("Un_KI270302v1".hashCode(), ChrPositionUtils.convertContigNameToInt("chrUn_KI270302v1"));
+	}
+
+	@Test
+	public void testConvertContigNameToInt_OtherValues() {
+		// For other values, it should return hashCode
+		String contig = "other";
+		assertEquals(contig.hashCode(), ChrPositionUtils.convertContigNameToInt(contig));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConvertContigNameToInt_NullInput() {
+		ChrPositionUtils.convertContigNameToInt(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConvertContigNameToInt_EmptyInput() {
+		ChrPositionUtils.convertContigNameToInt("");
+	}
+
+	@Test
 	public void testConvertChrPositionToLong() {
 		long expected = ((long) 4 << 32) + 9;
 		long actual = ChrPositionUtils.convertContigAndPositionToLong("4", 9);


### PR DESCRIPTION
# Description

Skip VCF records that are not in the standard list of contigs. Reason for this is that the annotation sources only supply data for the standard contigs.

Bug in nanno where contig name with numbers and letters (eg `chr22_KI270739v1_random`) would cause a `NumberFormatException` has been fixed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Additional unit tests have been added, existing tests pass, code has been run on vcf that highlighted these issues and now completes succesfully.

# Are WDL Updates Required?

n/a

