### PR TITLE
fix(qsnp): OOM caused by large number of failed filter reads at same location

### DIFF
--- a/qsnp/test/org/qcmg/snp/PipelineTest.java
+++ b/qsnp/test/org/qcmg/snp/PipelineTest.java
@@ -1,12 +1,13 @@
 package org.qcmg.snp;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -21,21 +22,22 @@ import org.qcmg.picard.util.SAMUtils;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 
+import static org.junit.Assert.*;
+
 public class PipelineTest {
 	
 	@Rule
 	public final TemporaryFolder testFolder = new TemporaryFolder();
-	
+
 	@Test
 	public void getHeader() {
 		VcfHeader h = Pipeline.getHeaderForQSnp("abc", "123", "456", "qsnp", null, null, "xyz");
-		assertEquals(true, null != h.getFormatRecord(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND));
-		assertEquals(true, h.getFormatRecord(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND).toString().contains(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND_DESC));
+        assertNotNull(h.getFormatRecord(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND));
+        assertTrue(h.getFormatRecord(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND).toString().contains(VcfHeaderUtils.FORMAT_OBSERVED_ALLELES_BY_STRAND_DESC));
 	}
-	
-	
+
 	@Test
-	public void getAccumulatorsFromReads() throws IOException {
+	public void getAccumulatorsFromReads() {
 		final Pipeline pipeline = new TestPipeline();
 		
 		CountDownLatch consumerLatch = new CountDownLatch(1);

--- a/qsnp/test/org/qcmg/snp/StandardPipelineTest.java
+++ b/qsnp/test/org/qcmg/snp/StandardPipelineTest.java
@@ -12,19 +12,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.qcmg.common.commandline.Executor;
-import org.qcmg.common.model.Accumulator;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
@@ -96,9 +91,9 @@ public class StandardPipelineTest {
 		final String command = "-log " + logFile.getAbsolutePath() + " -i " + ini.getAbsolutePath();
 		final Executor exec = new Executor(command, "org.qcmg.snp.Main");
 		assertEquals(0, exec.getErrCode());
-		List<String> vcfs = Files.lines(Paths.get(vcf.getPath())).filter(s -> ! s.startsWith("#")).collect(Collectors.toList());
+		List<String> vcfs = Files.lines(Paths.get(vcf.getPath())).filter(s -> ! s.startsWith("#")).toList();
 		
-		vcfs.stream().forEach(System.out::println);
+		vcfs.forEach(System.out::println);
 		
 		assertEquals(60, vcfs.size());
 		AtomicInteger ai = new AtomicInteger(0);
@@ -147,40 +142,16 @@ public class StandardPipelineTest {
 		final String command = "-log " + logFile.getAbsolutePath() + " -i " + ini.getAbsolutePath();
 		final Executor exec = new Executor(command, "org.qcmg.snp.Main");
 		assertEquals(0, exec.getErrCode());
-		List<String> vcfs = Files.lines(Paths.get(vcf.getPath())).filter(s -> ! s.startsWith("#")).collect(Collectors.toList());
+		List<String> vcfs = Files.lines(Paths.get(vcf.getPath())).filter(s -> ! s.startsWith("#")).toList();
 		
-		vcfs.stream().forEach(System.out::println);
+		vcfs.forEach(System.out::println);
 		
 		assertEquals(4, vcfs.size());
 //		assertEquals("GL000208.1	53	.	T	G	.	.	FLANK=AAGTGGTTCAA	GT:AD:DP:EOR:FF:FT:INF:NNS:OABS	0/1:90,6:96:T1[]5[]:C1;G51;T89:.:.:6:G1[41]5[40.2];T9[35.22]81[39.68]	0/1:90,6:96:T1[]5[]:C1;G51;T89:.:.:6:G1[41]5[40.2];T9[35.22]81[39.68]", vcfs.get(0));
-		assertEquals("GL000208.1	53	.	T	G	.	.	FLANK=AAGTGGTTCAA	GT:AD:DP:EOR:FF:FT:INF:NNS:OABS	0/1:115,10:125:T1[]7[]:C1;G51;T89:.:.:9:G2[41]8[40.5];T9[35.22]106[39.88]	0/1:115,10:125:T1[]7[]:C1;G51;T89:.:.:9:G2[41]8[40.5];T9[35.22]106[39.88]", vcfs.get(0));
+		assertEquals("GL000208.1	53	.	T	G	.	.	FLANK=AAGTGGTTCAA	GT:AD:DP:EOR:FF:FT:INF:NNS:OABS	0/1:115,10:125:T1[]7[]:C1;G51;T89:.:.:9:G2[41]8[40.5];T9[35.22]106[39.88]	0/1:115,10:125:T1[]7[]:C1;G51;T89:.:.:9:G2[41]8[40.5];T9[35.22]106[39.88]", vcfs.getFirst());
 //		assertEquals("GL000208.1	77	.	T	C	.	.	FLANK=AAAGACGTATT	GT:AD:DP:EOR:FF:FT:INF:NNS:OABS	1/1:4,94:98:C0[]3[];T0[]1[]:C171;T11:.:.:64:C9[35.78]85[39.94];T1[41]3[39.67]	1/1:4,94:98:C0[]3[];T0[]1[]:C171;T11:.:.:64:C9[35.78]85[39.94];T1[41]3[39.67]", vcfs.get(1));
 //		assertEquals("GL000208.1	84	.	C	A	.	.	FLANK=TATTCAACTCA	GT:AD:DP:EOR:FF:FT:INF:NNS:OABS	0/1:22,71:93:A2[]6[]:A178;C6:.:.:50:A8[38.62]63[38.92];C2[36.5]20[40.2]	0/1:22,71:93:A2[]6[]:A178;C6:.:.:50:A8[38.62]63[38.92];C2[36.5]20[40.2]", vcfs.get(2));
 //		assertEquals("GL000208.1	98	.	C	A	.	.	FLANK=ACTTTAATGCA	GT:AD:DP:EOR:FF:FT:INF:NNS:OABS	1/1:0,83:83:A0[]8[]:A188;G1:.:.:59:A8[37]75[38.63]	1/1:0,83:83:A0[]8[]:A188;G1:.:.:59:A8[37]75[38.63]", vcfs.get(3));
-	}
-	
-	@Ignore
-	public void testContainsAndRemove() {
-		final ConcurrentMap<Integer, Accumulator> map = new ConcurrentHashMap<Integer, Accumulator>();
-		final int noOfLoops = 100000;
-		long time = System.currentTimeMillis();
-		for (int i = 0 ; i < noOfLoops ; i++) {
-			map.remove(i);
-		}
-		System.out.println("EMPTY: remove time: " + (System.currentTimeMillis() - time));
-		
-		time = System.currentTimeMillis();
-		for (int i = 0 ; i < noOfLoops ; i++) {
-			if (map.containsKey(i))
-				map.remove(i);
-		}
-		System.out.println("EMPTY: contains and remove time: " + (System.currentTimeMillis() - time));
-		
-		time = System.currentTimeMillis();
-		for (int i = 0 ; i < noOfLoops ; i++) {
-			map.remove(i);
-		}
-		System.out.println("EMPTY: remove time: " + (System.currentTimeMillis() - time));
 	}
 	
 	public void checkBam(File f) {


### PR DESCRIPTION

# Description


This pull request introduces several improvements and bug fixes to the `qsnp` pipeline, primarily focused on memory management during BAM processing, code modernization, and test cleanup. The most significant update is the addition of a safeguard to limit memory usage when encountering large numbers of poor-quality reads at the same genomic position. Additionally, the codebase is modernized with Java 8+ idioms, and tests are updated for clarity and conciseness.

**Pipeline memory and performance improvements:**

* Added logic in the `Producer` class to limit the number of failed filter records per start position to 1000, preventing memory issues when many poor-quality reads map to the same location (`Pipeline.java`). [[1]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4R738-R740) [[2]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4L877-R896)

**Code modernization and cleanup:**

* Replaced explicit type arguments with the diamond operator (`<>`) and updated collection usage to use Java 8+ idioms, such as `List::toList` instead of `stream().collect(Collectors.toList())` (`Pipeline.java`, `StandardPipelineTest.java`). [[1]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4L453-R452) [[2]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4L1380-R1399) [[3]](diffhunk://#diff-4ca0b72605259fc5142d38dfdb76f031d92d9c4fc6612d8c63c3244d3c42a8d2L99-R96) [[4]](diffhunk://#diff-4ca0b72605259fc5142d38dfdb76f031d92d9c4fc6612d8c63c3244d3c42a8d2L150-L185)
* Updated deprecated or verbose code, such as using `getFirst()` instead of `get(0)` for lists and simplifying exception messages (`Pipeline.java`). [[1]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4L488-R487) [[2]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4L1278-R1300)

**Test improvements and cleanup:**

* Updated assertions in tests to use more descriptive and modern JUnit methods (`PipelineTest.java`). [[1]](diffhunk://#diff-49e9c2a04ec9fdc7aeaaef08a625b10eb95ffaa96c12e1a4854143e870bf5d13R25-R26) [[2]](diffhunk://#diff-49e9c2a04ec9fdc7aeaaef08a625b10eb95ffaa96c12e1a4854143e870bf5d13L32-R40)
* Removed unused imports and deprecated or ignored test methods, streamlining the test codebase (`PipelineTest.java`, `StandardPipelineTest.java`). [[1]](diffhunk://#diff-49e9c2a04ec9fdc7aeaaef08a625b10eb95ffaa96c12e1a4854143e870bf5d13L3-R10) [[2]](diffhunk://#diff-4ca0b72605259fc5142d38dfdb76f031d92d9c4fc6612d8c63c3244d3c42a8d2L15-L27) [[3]](diffhunk://#diff-4ca0b72605259fc5142d38dfdb76f031d92d9c4fc6612d8c63c3244d3c42a8d2L150-L185)

**Documentation and naming consistency:**

* Improved parameter naming and documentation for clarity in method signatures and comments (`Pipeline.java`). [[1]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4L636-R635) [[2]](diffhunk://#diff-145f20cd2a9b4e4597afb4c1f77314bc41eef7cc7c9a6e55845e49a44e46c6f4L989-R1008)

These changes collectively improve the pipeline's robustness, maintainability, and code clarity.) were we now keep the bases of the failed filter reads rather than just a count in the Accumulator object.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No new unit tests, but I ran this against the 47 failed SDFTM runs in cromwell prod and they all succeeded.


# Are WDL Updates Required?

Not specifically, but the adamajava version used in the various workflows will need to be updated once this change has been released

