### PR TITLE
feat(qsignature): add blocklist option that takes a BED file and ignores positions contained therein

### DIFF
--- a/qsignature/src/org/qcmg/sig/Options.java
+++ b/qsignature/src/org/qcmg/sig/Options.java
@@ -123,6 +123,8 @@ final class Options {
 				.describedAs("emailSubject");
 		parser.accepts("excludeVcfsFile", "file containing a list of vcf files to ignore in the comparison").withRequiredArg().ofType(String.class)
 				.describedAs("excludeVcfsFile");
+        parser.accepts("blocklist", "BED file containing a list of genomic position to ignore in the comparison").withRequiredArg().ofType(String.class)
+                .describedAs("BED file containing regions to ignore");
 		parser.accepts("validation", VALIDATION_STRINGENCY_OPTION_DESCRIPTION).withRequiredArg().ofType(String.class);
 		parser.accepts("stream", STREAM_OPTION_DESCRIPTION);
 		parser.acceptsAll(asList("p", "position"), "File containing a list of positions that will be examined. Must be a subset of the positions in the snpPositions file").withRequiredArg().ofType(String.class).describedAs("position");
@@ -296,6 +298,9 @@ final class Options {
 	public String getExcludeVcfsFile() {
 		return (String) options.valueOf("excludeVcfsFile");
 	}
+    public String getBlocklist() {
+        return (String) options.valueOf("blocklist");
+    }
 	public Optional<String> getGeneModelFile() {
 		return Optional.ofNullable((String) options.valueOf("geneModel"));
 	}

--- a/qsignature/test/org/qcmg/sig/CompareTest.java
+++ b/qsignature/test/org/qcmg/sig/CompareTest.java
@@ -60,9 +60,8 @@ public class CompareTest {
 		writeVcfFile(f1);
 		writeVcfFileHeader(f2);
 		writeVcfFile(f3);
-		
 		Executor exec = execute("--log " + logF.getAbsolutePath() + " -d " + f1.getParent() + " -o " + o.getAbsolutePath());
-		assertEquals(0, exec.getErrCode());		// all ok
+        assertEquals(0, exec.getErrCode());		// all ok
 		assertTrue(o.exists());
 		List<String> outputData = Files.readAllLines(Paths.get(o.getAbsolutePath()));
 		assertEquals(14, outputData.size());		// 13 lines means 3 comparison


### PR DESCRIPTION
This pull request introduces support for specifying a blocklist (in BED format) to exclude certain genomic regions from signature comparisons in the `qsignature` tool. The changes add a new command-line option for the blocklist, ensure the blocklist is loaded and parsed efficiently, and integrate blocked region filtering into the signature genotype loading logic.

**Blocklist Support and Integration:**

* Added a new `--blocklist` command-line option to the `Options` class, allowing users to specify a BED file containing regions to ignore during comparison.
* Implemented logic in `Compare.java` to load the blocklist file, parse its contents into a map of blocked positions, and log the total number of blocked regions. [[1]](diffhunk://#diff-555a559c11c45a6f2cde90292d37f250e97f3380bdeeb2e549915a9641a8044fR86-R100) [[2]](diffhunk://#diff-555a559c11c45a6f2cde90292d37f250e97f3380bdeeb2e549915a9641a8044fR442-L429)
* Extended the signature genotype loading pipeline (`SignatureUtil.java`) to accept blocked positions and filter out positions from blocked regions during data extraction. This includes changes to method signatures and the addition of efficient blocklist parsing and position filtering. [[1]](diffhunk://#diff-0d5b8b5975574efbfcd6d942325a1daac1fe144425f33fba5432aab7c7d4c44dL340-R348) [[2]](diffhunk://#diff-0d5b8b5975574efbfcd6d942325a1daac1fe144425f33fba5432aab7c7d4c44dL364-R417) [[3]](diffhunk://#diff-0d5b8b5975574efbfcd6d942325a1daac1fe144425f33fba5432aab7c7d4c44dR434-R450)
* Updated the method for extracting data from bespoke layout files to skip any positions found in the blocklist, improving accuracy for comparisons with excluded regions.
* Provided new getter methods in `Options.java` to retrieve the blocklist file path for use in the comparison logic.


**Are WDL Updates Required?**

No, unless the new functionality is required in which case the `blocklist` option will need to be added along with the appropriate `BED` file

